### PR TITLE
Stop duplicate PRs from being added to release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ data/*
 *.srl
 
 .DS_Store
+
+.vscode

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -98,8 +98,6 @@ func main() {
 	}
 
 	// account for processing against an rc
-	milestone = strings.Replace(milestone, "-rc", "", -1)
-
 	idx := strings.Index(milestone, "-rc")
 	if idx != -1 {
 		tmpMilestone := []rune(milestone)


### PR DESCRIPTION
1) If a PR is not squashed, multiple commits in a release branch will point back to the same PR. This prevents duplicate PR lines being added to the notes.
2) Empty but still existing "release notes" sections of PR would cause the title of a PR to be blank

CMD:
`./bin/gen-release-notes -r k3s -p v1.21.8+k3s2 -m v1.21.9-rc1+k3s1`
Problem:
```
<!-- v1.21.91+k3s1 -->
This release updates Kubernetes to v1.21.91, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1218).

## Changes since v1.21.8+k3s2:

*  [(#4932)](https://github.com/k3s-io/k3s/pull/4932)
* K3s servers no longer attempt to manage cgroup membership when the (unsupported, hidden) `--disable-agent` flag is used. [(#4926)](https://github.com/k3s-io/k3s/pull/4926)
* Update etcd to v3.4.18-k3s1 [(#4945)](https://github.com/k3s-io/k3s/pull/4945)
* [Release 1.21] Add IPv6 NAT [(#4982)](https://github.com/k3s-io/k3s/pull/4982)
* [Release 1.21] Remove ip6table rules when cleaning up k3s [(#4978)](https://github.com/k3s-io/k3s/pull/4978)
* [Release 1.21] Add IPv6 NAT [(#4982)](https://github.com/k3s-io/k3s/pull/4982)
* [Release 1.21] Add IPv6 NAT [(#4982)](https://github.com/k3s-io/k3s/pull/4982)
* [Release 1.21] Add IPv6 NAT [(#4982)](https://github.com/k3s-io/k3s/pull/4982)
*  [(#4959)](https://github.com/k3s-io/k3s/pull/4959)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
```

Fix:
```
# Changes since v1.21.8+k3s2:

*  [Release-1.21] Enable debug logging on all k3s subcommands with debug flag [(#4932)](https://github.com/k3s-io/k3s/pull/4932)
* K3s servers no longer attempt to manage cgroup membership when the (unsupported, hidden) `--disable-agent` flag is used. [(#4926)](https://github.com/k3s-io/k3s/pull/4926)
* Update etcd to v3.4.18-k3s1 [(#4945)](https://github.com/k3s-io/k3s/pull/4945)
* [Release 1.21] Add IPv6 NAT [(#4982)](https://github.com/k3s-io/k3s/pull/4982)
* [Release 1.21] Remove ip6table rules when cleaning up k3s [(#4978)](https://github.com/k3s-io/k3s/pull/4978)
* [Release-1.21] Adds the ability to compress etcd snapshots (#4866) [(#4959)](https://github.com/k3s-io/k3s/pull/4959)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
* Update to v1.21.9 [(#4994)](https://github.com/k3s-io/k3s/pull/4994)
```
Signed-off-by: Derek Nola <derek.nola@suse.com>