### PR TITLE
[gen-release-notes] Convert multiline changelog into sublist

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -156,14 +156,15 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 			body := prs[0].GetBody()
 
 			var releaseNote string
-			inNote := false
+			var inNote bool
 			if strings.Contains(body, releaseNoteSection) && !strings.Contains(body, emptyReleaseNote) {
 				lines := strings.Split(body, "\n")
 				for _, line := range lines {
 					if strings.Contains(line, releaseNoteSection) {
 						inNote = true
 						continue
-					} else if strings.Contains(line, "```") {
+					}
+					if strings.Contains(line, "```") {
 						inNote = false
 					}
 					if inNote && line != "" {


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

PR of concern: https://github.com/k3s-io/k3s/pull/4966

Problem: Only the first line would be printed:
```
## Changes since v1.21.8+k3s2:

* [Release-1.21] Adds the ability to compress etcd snapshots (#4866) [(#4959)](https://github.com/k3s-io/k3s/pull/4959)
* Update local-path-provisioner to v0.0.21 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
```

Solution: If multine comment is detected use the PR title, with all changelog lines as a sublist
```
## Changes since v1.21.8+k3s2:
* [Release-1.21] Adds the ability to compress etcd snapshots (#4866) [(#4959)](https://github.com/k3s-io/k3s/pull/4959)
* [release-1.21] Update packaged components
 * Update local-path-provisioner to v0.0.21
 * Update local-path-provisioner busybox helper to 1.34.1
 * Update metrics-server to 0.5.2
 * Update coredns to 1.8.6
 * Update traefik to 2.5.6
 * Update pause to 3.6 [(#4966)](https://github.com/k3s-io/k3s/pull/4966)
```

Yes the PR link should probably go at the top line, but that can be manually fixed for now.