### PR TITLE
Switch shellcheck log level to "info", minor fix update_go

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   - name: shellcheck
     image: koalaman/shellcheck-alpine:latest
     commands:
-      - shellcheck --shell sh --check-sourced --severity=warning --exclude SC1091 --exclude SC2034 bin/*
+      - shellcheck --shell sh --check-sourced --severity=info --exclude SC1091 --exclude SC2034 bin/*
     when:
       event:
         - pull_request

--- a/bin/update_go
+++ b/bin/update_go
@@ -37,7 +37,7 @@ get_version() {
 
     for i in "Dockerfile" "Dockerfile.amd64"; do
         if [ -e  "${repo_path}/${i}" ]; then
-             info ${repo_path}
+             info "${repo_path}"
             info "$(awk -F ':' '/hardened-build-base/ {print $2}' "${repo_path}/${i}")"
         fi 
     done
@@ -80,7 +80,7 @@ update_go() {
     clone_path=$4
 
 
-    if [ ! -z "${repo}" ]; then
+    if [ -n "${repo}" ]; then
         get_repo "${repo}" "${clone_path}"
         substitute_go_version "${old}" "${new}" "${repo}" "${clone_path}"
         return 0
@@ -136,7 +136,7 @@ if [ ! -d "${CLONE_PATH}" ]; then
 fi
 
 if [ ${SHOW} ]; then
-    if [ ! -z "${REPOSITORY}" ]; then
+    if [ -n "${REPOSITORY}" ]; then
         get_repo "${REPOSITORY}" "${CLONE_PATH}"
         get_version "${REPOSITORY}" "${CLONE_PATH}"
         exit 0


### PR DESCRIPTION
Shellcheck classifies errors into 4 levels  (error, warning, info and style) ranked by order of severity (most severe to least in the list prior), by setting --severity=warning we get warnings and errors.
By setting the severity flag we are specifying the minimum severity of errors to return.
```
ex)
In bin/update_go line 40:
             info ${repo_path}
                  ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
             info "${repo_path}"


In bin/update_go line 83:
    if [ ! -z "${repo}" ]; then
         ^-- SC2236 (style): Use -n instead of ! -z.
```
if we set --severity=info we get info and greater, ignoring style, the lowest class of errors.