### PR TITLE
prevent panic when no assignee on issue

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v39/github"
+	"github.com/rancher/ecm-distro-tools/types"
 	"golang.org/x/oauth2"
 )
 
@@ -111,10 +112,16 @@ func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue 
 	title := fmt.Sprintf(i.Title, strings.Title(branch), origIssue.GetTitle())
 	body := fmt.Sprintf(i.Body, origIssue.GetTitle(), *origIssue.Number)
 
+	var assignee *string
+	if origIssue.GetAssignee() != nil {
+		assignee = origIssue.GetAssignee().Login
+	} else {
+		assignee = types.StringPtr("")
+	}
 	issue, _, err := client.Issues.Create(ctx, org, repo, &github.IssueRequest{
 		Title:    github.String(title),
 		Body:     github.String(body),
-		Assignee: origIssue.GetAssignee().Login,
+		Assignee: assignee,
 	})
 	if err != nil {
 		return nil, err

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,106 @@
+package types
+
+// IntPtr creates an int pointer value and
+// returns it to the caller.
+func IntPtr(i int) *int {
+	v := int(i)
+	return &v
+}
+
+// Int8Ptr creates an int8 pointer value and
+// returns it to the caller.
+func Int8Ptr(i int8) *int8 {
+	v := int8(i)
+	return &v
+}
+
+// Int16Ptr creates an int16 pointer value and
+// returns it to the caller.
+func Int16Ptr(i int16) *int16 {
+	v := int16(i)
+	return &v
+}
+
+// Int32Ptr creates an int32 pointer value and
+// returns it to the caller.
+func Int32Ptr(i int32) *int32 {
+	v := int32(i)
+	return &v
+}
+
+// Int64Ptr creates an int64 pointer value and
+// returns it to the caller.
+func Int64Ptr(i int64) *int64 {
+	v := int64(i)
+	return &v
+}
+
+// UintPtr creates a uint pointer value and
+// returns it to the caller.
+func UintPtr(i uint) *uint {
+	v := uint(i)
+	return &v
+}
+
+// Uint8Ptr creates a uint8 pointer value and
+// returns it to the caller.
+func Uint8Ptr(i uint8) *uint8 {
+	v := uint8(i)
+	return &v
+}
+
+// Uint16Ptr creates a uint16 pointer value and
+// returns it to the caller.
+func Uint16Ptr(i uint16) *uint16 {
+	v := uint16(i)
+	return &v
+}
+
+// Uint32Ptr creates a uint32 pointer value and
+// returns it to the caller.
+func Uint32Ptr(i uint32) *uint32 {
+	v := uint32(i)
+	return &v
+}
+
+// Uint64Ptr creates a uint64 pointer value and
+// returns it to the caller.
+func Uint64Ptr(i uint64) *uint64 {
+	v := uint64(i)
+	return &v
+}
+
+// StringPtr creates a string pointer value and
+// returns it to the caller.
+func StringPtr(s string) *string {
+	v := string(s)
+	return &v
+}
+
+// BytePtr creates a byte pointer value and
+// returns it to the caller.
+func BytePtr(b byte) *byte {
+	v := byte(b)
+	return &v
+}
+
+// Float32Ptr creates a float32 pointer value and
+// returns it to the caller.
+func Float32Ptr(f float32) *float32 {
+	v := float32(f)
+	return &v
+}
+
+// Float64Ptr creates a float64 pointer value and
+// returns it to the caller.
+func Float64Ptr(f float64) *float64 {
+	v := float64(f)
+	return &v
+}
+
+// BoolPtr creates a bool pointer value and
+// returns it to the caller.
+func BoolPtr(b bool) *bool {
+	v := bool(b)
+	return &v
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,502 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIntPtr(t *testing.T) {
+	type args struct {
+		i int
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue int
+	}{
+		{
+			name: "int",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*int",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IntPtr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("IntPtr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("IntPtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestInt8Ptr(t *testing.T) {
+	type args struct {
+		i int8
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue int8
+	}{
+		{
+			name: "int8",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*int8",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Int8Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Int8Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Int8Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestInt16Ptr(t *testing.T) {
+	type args struct {
+		i int16
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue int16
+	}{
+		{
+			name: "int16",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*int16",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Int16Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Int16Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Int16Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func Test32IntPtr(t *testing.T) {
+	type args struct {
+		i int32
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue int32
+	}{
+		{
+			name: "int32",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*int32",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Int32Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Int32Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Int32Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestInt64Ptr(t *testing.T) {
+	type args struct {
+		i int64
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue int64
+	}{
+		{
+			name: "int64",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*int64",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Int64Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Int64Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("IntPtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestUIntPtr(t *testing.T) {
+	type args struct {
+		i uint
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue uint
+	}{
+		{
+			name: "uint",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*uint",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UintPtr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("UintPtr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("UintPtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestUint8Ptr(t *testing.T) {
+	type args struct {
+		i uint8
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue uint8
+	}{
+		{
+			name: "uint8",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*uint8",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint8Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Uint8Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Uint8Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestUint16Ptr(t *testing.T) {
+	type args struct {
+		i uint16
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue uint16
+	}{
+		{
+			name: "uint16",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*uint16",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint16Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Uint16Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Uint16Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestUint32Ptr(t *testing.T) {
+	type args struct {
+		i uint32
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue uint32
+	}{
+		{
+			name: "uint32",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*uint32",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint32Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Uint32Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Uint32Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestUint64Ptr(t *testing.T) {
+	type args struct {
+		i uint64
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue uint64
+	}{
+		{
+			name: "uint64",
+			args: args{
+				i: 9,
+			},
+			wantType:  "*uint64",
+			wantValue: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint64Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Uint64Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Uint64Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestStringPtr(t *testing.T) {
+	type args struct {
+		i string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue string
+	}{
+		{
+			name: "string",
+			args: args{
+				i: "Test",
+			},
+			wantType:  "*string",
+			wantValue: "Test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringPtr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("StringPtr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("StringPtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestBytePtr(t *testing.T) {
+	type args struct {
+		i byte
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue byte
+	}{
+		{
+			name: "byte",
+			args: args{
+				i: 1,
+			},
+			wantType:  "*uint8",
+			wantValue: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BytePtr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("BytePtr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("BytePtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestFloat32Ptr(t *testing.T) {
+	type args struct {
+		i float32
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue float32
+	}{
+		{
+			name: "float32",
+			args: args{
+				i: 1.2,
+			},
+			wantType:  "*float32",
+			wantValue: 1.2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Float32Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Float32Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Float32Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestFloat64Ptr(t *testing.T) {
+	type args struct {
+		i float64
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue float64
+	}{
+		{
+			name: "float64",
+			args: args{
+				i: 1.2,
+			},
+			wantType:  "*float64",
+			wantValue: 1.2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Float64Ptr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("Float64Ptr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("Float64Ptr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+func TestBoolPtr(t *testing.T) {
+	type args struct {
+		i bool
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantType  string
+		wantValue bool
+	}{
+		{
+			name: "bool",
+			args: args{
+				i: true,
+			},
+			wantType:  "*bool",
+			wantValue: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BoolPtr(tt.args.i)
+			gotType := reflect.TypeOf(got).String()
+			gotValue := *got
+			if gotType != tt.wantType {
+				t.Errorf("BoolPtr() = %v, want %v", gotType, tt.wantType)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("BoolPtr() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolve issue that causes panic if original issue being backported doesn't have an assignee. 

Adds a types package to get a pointer from a given value of a Go type.