### PR TITLE
#53: Current Dockerfile is trying to copy the standup binary from the backport/bin dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN apk --no-cache add \
 
 COPY cmd/gen-release-notes/bin/gen-release-notes /usr/local/bin
 COPY cmd/backport/bin/backport /usr/local/bin
-COPY cmd/backport/bin/standup /usr/local/bin
+COPY cmd/standup/bin/standup /usr/local/bin
 COPY bin/. /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make all
 To compile the container image locally, perform:
 
 ```sh
-docker build . -t rancher/ecm-distro-tools:local
+docker build . -t rancher/ecm-distro-tools
 ```
 
 ## Utility Index


### PR DESCRIPTION
This PR fixes #53 

It also changes the image tag in the documentation section because the other example commands use the *latest* tag instead of *local*.
