### PR TITLE
Add script to verify release artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ docker run --rm -it rancher/ecm-distro-tools bootstrap_hash -p k3s
 ```sh
 # RKE2
 docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets v1.23.4
-release: v1.23.4+rke2r1 expected: 30 got: 30 status: OK
-release: v1.23.4-rc2+rke2r1 expected: 30 got: 30 status: OK
-release: v1.23.4-rc1+rke2r1 expected: 30 got: 0 status: MISMATCH
+release: v1.23.4+rke2r1 status: OK
+release: v1.23.4-rc2+rke2r1 status: OK
+release: v1.23.4-rc1+rke2r1status: MISMATCH
 
 #K3s
 docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets -r k3s-io/k3s v1.23.4
-release: v1.23.4+k3s1 expected: 18 got: 18 status: OK
-release: v1.23.4-rc1+k3s1 expected: 18 got: 18 status: OK
+release: v1.23.4+k3s1 status: OK
+release: v1.23.4-rc1+k3s1 status: OK
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ docker run --rm -it rancher/ecm-distro-tools standup -f
 docker run --rm -it rancher/ecm-distro-tools bootstrap_hash -p k3s
 ```
 
+### Verify K3s and RKE2 release assets
+
+```sh
+# RKE2
+docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets v1.23.4
+release: v1.23.4+rke2r1 expected: 30 got: 30 status: OK
+release: v1.23.4-rc2+rke2r1 expected: 30 got: 30 status: OK
+release: v1.23.4-rc1+rke2r1 expected: 30 got: 0 status: MISMATCH
+
+#K3s
+docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets -r k3s-io/k3s v1.23.4
+release: v1.23.4+k3s1 expected: 18 got: 18 status: OK
+release: v1.23.4-rc1+k3s1 expected: 18 got: 18 status: OK
+```
+
 ## Contributing
 
 We welcome additions to this repo and are excited to keep expanding its functionality.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ docker run --rm -it rancher/ecm-distro-tools bootstrap_hash -p k3s
 docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets v1.23.4
 release: v1.23.4+rke2r1 status: OK
 release: v1.23.4-rc2+rke2r1 status: OK
-release: v1.23.4-rc1+rke2r1status: MISMATCH
+release: v1.23.4-rc1+rke2r1 status: MISMATCH
 
 #K3s
 docker run --rm -it --env GITHUB_TOKEN=<TOKEN> rancher/ecm-distro-tools verify_release_assets -r k3s-io/k3s v1.23.4

--- a/bin/libstd-ecm.sh
+++ b/bin/libstd-ecm.sh
@@ -89,9 +89,7 @@ setup_verify_arch() {
 # setup_tmp create temporary directory 
 # and cleanup when done.
 setup_tmp() {
-    TMP_DIR=$(mktemp -d -t k3s-install.XXXXXXXXXX)
-    TMP_HASH=${TMP_DIR}/k3s.hash
-    TMP_BIN=${TMP_DIR}/k3s.bin
+    TMP_DIR=$(mktemp -d -t ecm.XXXXXXXXXX)
     cleanup() {
         code=$?
         set +e
@@ -100,6 +98,8 @@ setup_tmp() {
         exit $code
     }
     trap cleanup INT EXIT
+
+    export TMP_DIR
 }
 
 # date functions
@@ -127,11 +127,11 @@ __YELLOW='\033[1;33m'
 __NC='\033[0m'
 
 print_red() {
-    printf "${__RED}%s${__NC}" "$1"
+    printf "${__RED}%b${__NC}" "$1"
 }
 
 print_green() {
-    printf "${__GREEN}%s${__NC}" "$1"
+    printf "${__GREEN}%b${__NC}" "$1"
 }
 
 print_yellow() {

--- a/bin/libstd-ecm.sh
+++ b/bin/libstd-ecm.sh
@@ -135,5 +135,5 @@ print_green() {
 }
 
 print_yellow() {
-    printf "${__YELLOW}%s${__NC}" "$1"
+    printf "${__YELLOW}%b${__NC}" "$1"
 }

--- a/bin/verify_release_assets
+++ b/bin/verify_release_assets
@@ -124,3 +124,5 @@ if [ "${LIST_ASSETS}" = 'true' ]; then
     find "${TMP_DIR}" -type f -name '*-assets' -exec \
         sh -c '_file="$1"; echo "=== $(basename -s -assets $_file)"; cat $_file' shell {} \;
 fi
+
+exit 0

--- a/bin/verify_release_assets
+++ b/bin/verify_release_assets
@@ -50,7 +50,7 @@ print_status() {
         expected="${ASSERT_AMOUNT}"
     fi
 
-    printf "release: %s expected: %s got: %s status: " "${release}" "${expected}" "${current_count}"
+    printf "release: %s status: " "${release}"
 
     if [ "${current_count}" = "${expected}" ]; then
         print_green 'OK\n'

--- a/bin/verify_release_assets
+++ b/bin/verify_release_assets
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+set -e
+
+. libstd-ecm.sh
+
+REPOSITORY='rancher/rke2'
+STRICT_MATCH='false'
+LIST_ASSETS='false'
+ASSERT_AMOUNT=''
+
+usage() {
+    echo "usage: $0 [adhlr] <repository>
+    -l    list assets file names
+    -r    set target repository. default: $REPOSITORY
+    -s    use strict release tag name match
+    -a    override expected assets amount
+    -h    show help
+
+examples:
+    $0 -s v1.23.4
+    $0 -s v1.23.4-rc2+rke2r1
+    $0 -l -r rancher/rke2 v1.23.4"
+}
+
+print_status() {
+    release="${1}"
+    current_count="${2}"
+    expected=''
+
+    case "${REPOSITORY}" in
+    *rke2)
+        expected='30'
+        ;;
+    *rke2-packaging)
+        expected='23'
+        ;;
+    *k3s)
+        expected='18'
+        ;;
+    *)
+        if [ -z "${ASSERT_AMOUNT}" ]; then
+            echo 'Unable to assert expected assets amount, please provide it through -a flag'
+            return 1
+        fi
+        ;;
+    esac
+
+    if [ -n "${ASSERT_AMOUNT}" ]; then
+        expected="${ASSERT_AMOUNT}"
+    fi
+
+    printf "release: %s expected: %s got: %s status: " "${release}" "${expected}" "${current_count}"
+
+    if [ "${current_count}" = "${expected}" ]; then
+        print_green 'OK\n'
+    else
+        print_red 'MISMATCH\n'
+    fi
+}
+
+while getopts 'a:dhlr:s' c; do
+    case "${c}" in
+    d)
+        set_debug
+        ;;
+    r)
+        REPOSITORY=$OPTARG
+        ;;
+    a)
+        ASSERT_AMOUNT=$OPTARG
+        ;;
+    s)
+        STRICT_MATCH='true'
+        ;;
+    l)
+        LIST_ASSETS='true'
+        ;;
+    h)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+if [ -z "${1}" ]; then
+    echo "error: release tag required"
+    exit 1
+fi
+
+has_gh
+
+# gh environment variable overrides
+export GH_REPO="${REPOSITORY}"
+export PAGER='cat'
+
+setup_tmp
+
+RELEASE_TAG="${1}"
+PATTERN=".tag_name | startswith(\"${RELEASE_TAG}\")"
+if [ "${STRICT_MATCH}" = 'true' ]; then
+    PATTERN=".tag_name==\"${RELEASE_TAG}\""
+fi
+
+gh api 'repos/{owner}/{repo}/releases' -q ".[] | select(${PATTERN}) | \"\(.id) \(.tag_name)\" " >"${TMP_DIR}/${RELEASE_TAG}-list"
+
+while IFS= read -r line; do
+    echo "${line}" | (
+        IFS=' ' read -r id name
+        gh api "repos/{owner}/{repo}/releases/${id}/assets" -q '.[] | .name' >"${TMP_DIR}/${name}-assets"
+
+        assets_count=$(wc -l <"${TMP_DIR}/${name}-assets")
+
+        print_status "${name}" "${assets_count}"
+    )
+done <"${TMP_DIR}/${RELEASE_TAG}-list"
+
+if [ "${LIST_ASSETS}" = 'true' ]; then
+    find "${TMP_DIR}" -type f -name '*-assets' -exec \
+        sh -c '_file="$1"; echo "=== $(basename -s -assets $_file)"; cat $_file' shell {} \;
+fi


### PR DESCRIPTION
Problem: RKE2/K3s team needs a simple way to verify which assets could
be missing from a given release.

Solution: This script lists all the artifacts associated to a release
tag. The result can be piped into a grep that verifies the expected
artifacts.

Sample run:

```sh
./verify_release_assets -r rancher/rke2-packaging v1.23.4
release: v1.23.4-rc2+rke2r1.testing.1 status: OK
release: v1.23.4+rke2r1.testing.0 status: OK
release: v1.23.4+rke2r1.stable.0 status: OK
release: v1.23.4+rke2r1.latest.0 status: OK
release: v1.23.4-rc2+rke2r1.testing.0 status: MISMATCH
```

OK and MISMATCH words are printed green and red accordingly.