### PR TITLE
WIP: Add slack notifications

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,6 +45,22 @@ steps:
       instance:
         - drone-publish.rancher.io
 
+  - name: failed-build-notification
+    image: plugins/slack
+    settings:
+      template: "Build {{build.link}} failed.\n"
+      channel: "TODO" # PR: Either create or choose the channel for these messages
+      webhook:
+        from_secret: slack_webhook # PR: This webhook is created upon request
+    when:
+      event:
+        exclude:
+          - pull_request
+      instance:
+        - drone-publish.rancher.io
+      status:
+        - failure
+
 volumes:
   - name: docker
     host:


### PR DESCRIPTION
Added the lines that we would need for notifying CI failures, as requested in #77 . Unfortunately I got block by the following aspects (also I commented them in the .drone.yml just in case):

- We need to either create or pick which channel that will receive the CI messages.
- A new slack webhook needs to be created. I already discussed this matter with EIO, and they suggested to create a helpdesk ticket stating our needs, upon approval and creation we can proceed with this change.