### PR TITLE
Fixes to using release notes with RCs

### DIFF
--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -25,9 +25,9 @@ Options:
     -i issue id          original issue id
     -c commit            commit id that is being backported
     -b branch(es)        branches issue is being backported to
-    -d					 enable debug logs
+    -d                   enable debug logs
 Examples: 
-	# generate release notes for RKE2 for milestone v1.21.5
+    # generate release notes for RKE2 for milestone v1.21.5
     %[2]s -t <TOKEN> -r k3s -b "release-1.21,release-1.22" -i 1234 -c 1
 `
 

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/rancher/ecm-distro-tools/repository"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -25,7 +24,7 @@ Options:
     -i issue id          original issue id
     -c commit            commit id that is being backported
     -b branch(es)        branches issue is being backported to
-    -d                   enable debug logs
+
 Examples: 
     # generate release notes for RKE2 for milestone v1.21.5
     %[2]s -t <TOKEN> -r k3s -b "release-1.21,release-1.22" -i 1234 -c 1
@@ -62,15 +61,11 @@ func main() {
 	flag.StringVar(&commitID, "c", "", "")
 	flag.UintVar(&issueID, "i", 0, "")
 	flag.StringVar(&branches, "b", "", "")
-	flag.BoolVar(&debug, "d", false, "")
 	flag.Parse()
 
 	if vers {
 		fmt.Fprintf(os.Stdout, "version: %s - git sha: %s\n", version, gitSHA)
 		return
-	}
-	if debug {
-		logrus.SetLevel(logrus.DebugLevel)
 	}
 
 	ghToken := os.Getenv("GITHUB_TOKEN")

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/rancher/ecm-distro-tools/repository"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -24,6 +25,7 @@ Options:
     -i issue id          original issue id
     -c commit            commit id that is being backported
     -b branch(es)        branches issue is being backported to
+	-d					 enable debug logs
 Examples: 
 	# generate release notes for RKE2 for milestone v1.21.5
     %[2]s -t <TOKEN> -r k3s -b "release-1.21,release-1.22" -i 1234 -c 1
@@ -36,6 +38,7 @@ const (
 
 var (
 	vers     bool
+	debug    bool
 	repo     string
 	commitID string
 	issueID  uint
@@ -59,16 +62,20 @@ func main() {
 	flag.StringVar(&commitID, "c", "", "")
 	flag.UintVar(&issueID, "i", 0, "")
 	flag.StringVar(&branches, "b", "", "")
+	flag.BoolVar(&debug, "d", false, "")
 	flag.Parse()
 
 	if vers {
 		fmt.Fprintf(os.Stdout, "version: %s - git sha: %s\n", version, gitSHA)
 		return
 	}
+	if debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 
 	ghToken := os.Getenv("GITHUB_TOKEN")
 	if ghToken == "" {
-		fmt.Println("error: please provide a token")
+		fmt.Println("error: please provide a GITHUB_TOKEN")
 		os.Exit(1)
 	}
 

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -25,7 +25,7 @@ Options:
     -i issue id          original issue id
     -c commit            commit id that is being backported
     -b branch(es)        branches issue is being backported to
-	-d					 enable debug logs
+    -d					 enable debug logs
 Examples: 
 	# generate release notes for RKE2 for milestone v1.21.5
     %[2]s -t <TOKEN> -r k3s -b "release-1.21,release-1.22" -i 1234 -c 1

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -24,9 +24,10 @@ Options:
     -v                   show version and exit
     -r repo              repository that should be used
     -m milestone         milestone to be used
-	-p prev milestone    previous milestone
+    -p prev milestone    previous milestone
+    -d                   enable debug logs
 Examples:
-	# generate release notes for RKE2 for milestone v1.21.5
+    # generate release notes for RKE2 for milestone v1.21.5
     %[2]s -r rke2 -m v1.21.5+rke2r1 -p v1.21.4+rke2r1
 `
 

--- a/release/release.go
+++ b/release/release.go
@@ -35,28 +35,32 @@ func GenReleaseNotes(ctx context.Context, repo, milestone, prevMilestone, ghToke
 	}
 
 	// account for processing against an rc
+	milestoneNoRC := milestone
 	idx := strings.Index(milestone, "-rc")
 	if idx != -1 {
 		tmpMilestone := []rune(milestone)
 		tmpMilestone = append(tmpMilestone[0:idx], tmpMilestone[idx+4:]...)
-		milestone = string(tmpMilestone)
+		milestoneNoRC = string(tmpMilestone)
 	}
 
-	k8sVersion := strings.Split(milestone, "+")[0]
+	k8sVersion := strings.Split(milestoneNoRC, "+")[0]
 	markdownVersion := strings.Replace(k8sVersion, ".", "", -1)
 	tmp := strings.Split(strings.Replace(k8sVersion, "v", "", -1), ".")
 	majorMinor := tmp[0] + "." + tmp[1]
 	changeLogSince := strings.Replace(strings.Split(prevMilestone, "+")[0], ".", "", -1)
 	calicoVersion := imageTagVersion("calico-node", repo, milestone)
 	calicoVersionTrimmed := strings.Replace(calicoVersion, ".", "", -1)
-	calicoVersionMajMin := calicoVersion[:strings.LastIndex(calicoVersion, ".")]
+	calicoVersionMajMin := ""
+	if calicoVersion != "" {
+		calicoVersionMajMin = calicoVersion[:strings.LastIndex(calicoVersion, ".")]
+	}
 	sqliteVersionK3S := goModLibVersion("go-sqlite3", repo, milestone)
 	sqliteVersionBinding := sqliteVersionBinding(sqliteVersionK3S)
 
 	buf := bytes.NewBuffer(nil)
 
 	if err := tmpl.Execute(buf, map[string]interface{}{
-		"milestone":                   milestone,
+		"milestone":                   milestoneNoRC,
 		"prevMilestone":               prevMilestone,
 		"changeLogSince":              changeLogSince,
 		"content":                     content,


### PR DESCRIPTION
- Component versions will now be found correctly when generating release notes from RCs.
- Fixed a index out of bound error when generating K3s notes.
- Added option to expose debug logs
Signed-off-by: Derek Nola <derek.nola@suse.com>