### PR TITLE
Add tool for loading up Azure container registry

### DIFF
--- a/bin/azr_import_images
+++ b/bin/azr_import_images
@@ -40,7 +40,7 @@ az_login() {
     if [ ! -z "${password}" ]; then 
         az login --service-principal -u "${username}" -p="${password}" -t "${tenant}" >/dev/null
     else
-        read -p "Azure password: " AZ_PASS && echo && az login --service-principal -u "${username}" -t "${tenant}" -p=$AZ_PASS
+        read -rsp "Azure password: " AZ_PASS && echo && az login --service-principal -u "${username}" -t "${tenant}" -p="$AZ_PASS"
     fi
     az account set --subscription "${subscription}"
     az acr login -n "${registry}"

--- a/bin/azr_import_images
+++ b/bin/azr_import_images
@@ -1,0 +1,118 @@
+#!/bin/sh
+# Azure Container Registry import tool for Rancher image lists
+
+set -e
+
+. libstd-ecm.sh
+
+REPOSITORY='rancher/rancher'
+REGISTRY_NAME=''
+AZURE_USERNAME=''
+AZURE_SUBSCRIPTION=''
+AZURE_TENANT=''
+AZURE_PASSWORD=''
+
+usage() {
+    echo "usage: $0 [arusxhtp] <tag>
+    -no-rc-list     do not import image lists for tags matching *-rc[0-9]{2}
+    -no-rc-images   do not import images appended with *-rc[0-9]{2} 
+    -a              set target Azure Container Registry. 
+    -r              set target GitHub repository. default: $REPOSITORY
+    -u              set Azure username or service principal ID for login [required]
+    -p              use stdin for Azure password instead of a prompt
+    -s              override default Azure subscription [optional]
+    -t              set target Azure Service Principal name for login [required]
+    -x              print debug messages
+    -h              show help
+
+examples:
+    $0 -a myregistry -u me@microsoft.com -s mysubscription -p stdinpasswordsarebad -t mytenantid v2.6.4
+    $0 -a myregistry -u me@microsoft.com -s mysubscription -p stdinpasswordsarebad -t mytenantid v2.6.4 v2.6.5-rc6 v2.5.13"
+}
+
+az_login() {
+    registry="${1}"
+    username="${2}"
+    tenant="${3}"
+    subscription="${4}"
+    password="${5}"
+
+    if [ ! -z "${password}" ]; then 
+        az login --service-principal -u "${username}" -p="${password}" -t "${tenant}" >/dev/null
+    else
+        read -p "Azure password: " AZ_PASS && echo && az login --service-principal -u "${username}" -t "${tenant}" -p=$AZ_PASS
+    fi
+    az account set --subscription "${subscription}"
+    az acr login -n "${registry}"
+}
+
+while getopts 'a:u:s:p:t:r:xh' c; do
+    case "${c}" in
+    x)
+        set_debug
+        ;;
+    r)
+        REPOSITORY=$OPTARG
+        ;;
+    u)
+        AZURE_USERNAME=$OPTARG
+        ;;
+    p)
+        AZURE_PASSWORD=$OPTARG
+        ;;
+    s)
+        AZURE_SUBSCRIPTION=$OPTARG
+        ;;
+    a)
+        REGISTRY_NAME=$OPTARG
+        ;;
+    t)
+        AZURE_TENANT=$OPTARG
+        ;;
+    h)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+shift "$((OPTIND-1))"
+if [ -z "${1}" ]; then
+    echo "error: release tag required"
+    usage
+    exit 1
+fi
+
+has_curl
+has_docker
+has_az
+
+setup_tmp
+
+for tag in "$@"; do
+    echo "https://github.com/rancher/rancher/releases/download/${tag}/rancher-windows-images.txt" >> "${TMP_DIR}/image-lists"
+    echo "https://github.com/rancher/rancher/releases/download/${tag}/rancher-images.txt" >> "${TMP_DIR}/image-lists"
+done
+
+az_login "${REGISTRY_NAME}" "${AZURE_USERNAME}" "${AZURE_TENANT}" "${AZURE_SUBSCRIPTION}" "${AZURE_PASSWORD}"
+
+while IFS= read -r url; do
+        print_green "starting import of images from $url\n"
+        curl -sSL "$url" | while IFS="" read -r i
+        do
+            if echo "$i" | grep -q 'docker.io'; then
+                i="${i#docker.io/*}" # strip docker.io from the beginning of the line
+            fi
+            if az acr import --name "${REGISTRY_NAME}" --source docker.io/"$i" --image "$i" --only-show-errors 2>/dev/null --no-wait; then
+                print_green "imported $i\n" 
+            else
+                print_yellow "skipped $i\n"
+            fi
+        done
+done <"${TMP_DIR}/image-lists"
+
+exit 0

--- a/bin/libstd-ecm.sh
+++ b/bin/libstd-ecm.sh
@@ -64,6 +64,11 @@ has_trivy() {
     __cmd_check "${TRIVY}"
 }
 
+has_az() {
+    AZ="$(command -v az)"
+    __cmd_check "${AZ}"
+}
+
 # setup_verify_arch set arch and suffix,
 # fatal if architecture not supported.
 setup_verify_arch() {

--- a/bin/verify_release_assets
+++ b/bin/verify_release_assets
@@ -38,6 +38,9 @@ print_status() {
     *k3s)
         expected='18'
         ;;
+    *rancher)
+        expected='23'
+        ;;
     *)
         if [ -z "${ASSERT_AMOUNT}" ]; then
             echo 'Unable to assert expected assets amount, please provide it through -a flag'


### PR DESCRIPTION
This PR comes from an investigation by Clippy's Revenge into how we can reduce the total time required to test and validate airgap setups due to the length of time consumed by the current Jenkins job for pulling/pushing images.

This script will automagically import all images from rancher-images.txt and rancher-windows-images.txt for the specified Rancher versions into an Azure container registry, which supports multi-arch images including Windows and s390x.


`./bin/azr_import_images -a myregistry -u myserviceprincipalid -s mysubscription -p stdinpasswordsarebad -t mytenantid v2.6.4 v2.6.5-rc6`

https://docs.microsoft.com/en-us/azure/container-registry/push-multi-architecture-images