### PR TITLE
Test-pad Improvements

### DIFF
--- a/docs/test_pad.md
+++ b/docs/test_pad.md
@@ -81,10 +81,10 @@ You have a local code change/PR you want to test. The code change only affects H
 ### QA
 You have an K3s issue than is `To Test`, but validation requires a split role cluster.  
 - Download the latest commit and test files:  
-  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split -o`
+  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split --download`
 - Modify the contents of `Vagrantfile` and add any additional configuration to the YAML section of the nodes as required.  
 - Spin up the cluster:  
-  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split -s`
+  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split --skip`
 - SSH into the individual nodes and verify the issue as required:  
   `vagrant ssh server-cp-0`
 - Destroy the cluster:  
@@ -95,4 +95,4 @@ If you need to modify the configuration again with different values:
   `test-pad -k`
 - Modify the contents of the `Vagrantfile` again.
 - Spin up the cluster:  
-  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split -s`
+  `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split --skip`

--- a/docs/test_pad.md
+++ b/docs/test_pad.md
@@ -5,10 +5,10 @@ This tool is built upon:
 - libvirt (and the vagrant-libvirt plugin)
 - RKE2/K3s E2E tests
 
-**Note:** A similar tool, [Corral](https://github.com/rancherlabs/corral) enables consistent RKE2 and K3s deployments to Digital Ocean or AWS. If you want to deploy K3s or RKE2 on cloud resources, Corral may prove more useful. Currently only single node, and 3 node HA deployments are supported.
+**Note:** A similar tool, [Corral](https://github.com/rancherlabs/corral) enables consistent RKE2 and K3s deployments to Digital Ocean or AWS. If you want to deploy K3s or RKE2 on cloud resources, Corral may prove more useful. Currently, only single node, and 3 node HA deployments are supported.
 
 ## Setup 
-1) Download the latest version (currently 2.2.19) of Vagrant *from the website*. Do not use built-in packages, they often old or do not include the required ruby library extensions necessary to get certain plugins working.
+1) Download the latest version (currently 2.2.19) of Vagrant [*from the website*](https://www.vagrantup.com/downloads). Do not use built-in packages, they often old or do not include the required ruby library extensions necessary to get certain plugins working.
 2) Install libvirt/qemu on your host:  
     - [openSUSE](https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-vt-installation.html)
     - [ubuntu](https://ubuntu.com/server/docs/virtualization-libvirt)
@@ -16,10 +16,10 @@ This tool is built upon:
     - [fedora](https://developer.fedoraproject.org/tools/virtualization/installing-libvirt-and-virt-install-on-fedora-linux.html)
 
 The first time you use the tool, it will check and attempt to install the proper vagrant plugins.  
-**Note:** The `vagrant-libvirt` plugin should be > v0.9.0. This solves several issues around networking and preventing VMs from being destroy if provisioning fails.
+**Note:** The `vagrant-libvirt` plugin should be > v0.9.0. This solves several issues around networking and preventing VMs from being destroyed if provisioning fails.
 
 ## Cluster Configuration
-The followuing cluster configurations are supported:
+The following cluster configurations are supported:
 - basic:        2 VMs, 1 server, 1 agent
 - basic-lite:   1 VM,  1 server
 - ha:           5 VMs, 3 servers, 2 agents
@@ -35,16 +35,16 @@ There are 3 types of K3s or RKE2 that a user can deploy:
 - A COMMIT ID install, such as `763a8bc8fe376e3376faceed48c8c889d396b88c`.
 - A local executable path, which enabled local dev/PR testing.
 
-**Note:** For RKE2, regardless of Executable version, an airgap installation of RKE2 is conducted. Thus this 
-tool can and should be used to test airgap specific issues. 
+**Note:** For RKE2, regardless of executable version, an air-gap installation of RKE2 is conducted. This 
+tool can and should be used to test air-gap specific issues. 
 
 ## VM Resources 
-For K3s, each VM consumes 2 vcpus and 1GB of memory. For RKE2, each VM consumes 2 vcpus and 2GB of memory.  
-Thus for a `split` cluster of RKE2, it is recommened to have a 8 core / 16 thread cpu and 16GB+ of memory.
+For K3s, each VM consumes 2 vCPUs and 1GB of memory. For RKE2, each VM consumes 2 vCPUs and 3GB of memory.  
+Thus, for a `split` cluster of RKE2, it is recommended to have an 8 core / 16 thread CPU and 16GB+ of memory.
 
-By default, K3s VMs use Alpine, while RKE2 VMs use Ubuntu. Apline is a much smaller VM (500MB vs 1.5GB) and 
-has a faster startup time. RKE2 must use Ubuntu because it only supports systemd. The default OS can be overriden
-with the `-p [alpine|ubuntu]` flag.
+By default, K3s VMs use Alpine, while RKE2 VMs use Ubuntu. Alpine is a much smaller VM (500MB vs 1.5GB) and 
+has a faster startup time. RKE2 must use Ubuntu because it only supports systemd. The default OS can be overridden
+with the `--os [alpine|ubuntu]` flag.
 
 ## Examples:
 - Deploy a 1 server, 1 agent cluster of K3s v1.22.9+k3s1.  
@@ -57,7 +57,7 @@ with the `-p [alpine|ubuntu]` flag.
   `test-pad -r k3s -b ../../k3s/dist/artifacts/k3s -c ha-lite ` 
 - Deploy a 3 server, 2 agent cluster of rke2 v1.23.5+rke2r1  
   `test-pad -r rke2 -v v1.23.5+rke2r1 -c ha`
-- Deploy a 1 server and 1 agent cluser of a local build of rke2  
+- Deploy a 1 server and 1 agent cluster of a local build of rke2  
   `test-pad -r rke2 -b ../../rke2/dist/artifacts/rke2.linux-amd64.tar.gz -i ../../rke2/build/images -c basic`
 
 
@@ -79,7 +79,7 @@ You have a local code change/PR you want to test. The code change only affects H
 
 
 ### QA
-You have an K3s issue than is `To Test`, but validation requires a split role cluster.  
+You have a K3s issue than is `To Test`, but validation requires a split-role cluster.  
 - Download the latest commit and test files:  
   `test-pad -r k3s -v <LATEST_COMMIT_FROM_MASTER> -c split --download`
 - Modify the contents of `Vagrantfile` and add any additional configuration to the YAML section of the nodes as required.  

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -16,9 +16,10 @@ usage() {
     -d              kill cluster and delete files
     --download      only download artifacts, don't create cluster
     --skip          skip Vagrantfile download
-    --os            override OS [alpine|ubuntu]
+    --os            override default OS [alpine|ubuntu]
     -h, --help      show help
 
+docs: https://github.com/rancher/ecm-distro-tools/blob/master/docs/test_pad.md
 cluster types:
     - basic:        2 VMs, 1 server, 1 agent
     - basic-lite:   1 VM,  1 server
@@ -34,7 +35,7 @@ examples:
     $0 -r k3s -v 1d4f995edd33186e178bfa9cf3d442dd244d2022 -c basic-lite
     $0 -r k3s -b ../../k3s/dist/artifacts/k3s -c ha-lite 
     $0 -r rke2 -b ../../rke2/dist/artifacts/rke2.linux-amd64.tar.gz -i ../../rke2/build/images -c basic
-    "
+"
 }
 
 # TODO - dual-stack:   3 VMs, 3 servers with IPv4 and IPv6
@@ -86,7 +87,7 @@ download_artifacts() {
                 echo "${STORAGE_URL}/${BINARY}-${VERSION}"
                 wget -q --show-progress "${STORAGE_URL}/${BINARY}-${VERSION}" -O ./artifacts/"${BINARY}"
             fi
-            if [ $? -ne 0 ]; then 
+            if [ "$?" -ne 0 ]; then 
                 echo "error: unable to find ${BINARY} version ${VERSION}"
                 exit 1
             fi 

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -218,6 +218,11 @@ has_curl
 has_wget
 has_awk
 
+if [ "$#" -eq 0 ]; then
+    usage
+    exit 1
+fi
+
 if [ -z "${CLUSTER}" ]; then
     if [ -f "artifacts/cluster" ]; then
         CLUSTER=$(cat artifacts/cluster)

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -29,8 +29,8 @@ cluster types:
     - split-lite:   3 VMs, 1 etcd-only server, 1 cp-only servers, 1 agent. Taints on etcd and control-plane
     - rancher:      4 VMs, 1 single server with rancher, 3 blank VMs ready for provisioning
 examples:
-    $0 -r k3s -v v1.22.9+k3s1 -c basic 
-    $0 -r k3s -v v1.23.5+k3s1 -c ha
+    $0 -r k3s -v v1.22.12+k3s1 -c basic 
+    $0 -r k3s -v v1.23.9+k3s1 -c ha
     $0 -r k3s -v 1d4f995edd33186e178bfa9cf3d442dd244d2022 -c basic-lite
     $0 -r k3s -b ../../k3s/dist/artifacts/k3s -c ha-lite 
     $0 -r rke2 -b ../../rke2/dist/artifacts/rke2.linux-amd64.tar.gz -i ../../rke2/build/images -c basic
@@ -162,11 +162,13 @@ get_possible_node_roles() {
     esac
 }
 
-# RKE2 needs a delay between node startup
-# else the service crashes from too many learners
-rke2_delay() {
+# Both K3s and RKE2 need a needs a delay between node startup
+# else the service crashes from too many etcd learners
+node_delay() {
     if [ "${REPO}" = "rke2" ] && [ "$1" != "$2" ]; then
         sleep 30
+    elif [ "${REPO}" = "k3s" ] && [ "$1" != "$2" ]; then
+        sleep 10
     fi
 }
 
@@ -373,7 +375,7 @@ ha | ha-lite |  split | split-heavy | split-lite)
     for node in ${NODE_ROLES}; do
         if [ "${node}" = "${FIRST_NODE}" ]; then continue; fi
         E2E_RELEASE_VERSION=skip E2E_NODE_ROLES="${NODE_ROLES}" E2E_NODE_BOXES="${OS_REPEAT}" vagrant provision "${node}" &
-        rke2_delay "${node}" "${LAST_NODE}"
+        node_delay "${node}" "${LAST_NODE}"
     done
     wait   
 ;;

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -205,7 +205,7 @@ while true; do
         KILL=true; shift 1;;
     -d)
         DESTROY=true; shift 1;;
-    --skip)
+    -s|--skip)
         SKIP_DOWNLOAD=true; shift 1;;
     --download)
         ONLY_DOWNLOAD=true; shift 1;;

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -16,7 +16,7 @@ usage() {
     -d              kill cluster and delete files
     --download      only download artifacts, don't create cluster
     --skip          skip Vagrantfile download
-    --os            override default OS [alpine|ubuntu]
+    --os            override default OS [alpine|ubuntu|debian]
     -h, --help      show help
 
 docs: https://github.com/rancher/ecm-distro-tools/blob/master/docs/test_pad.md
@@ -210,7 +210,7 @@ while true; do
     --download)
         ONLY_DOWNLOAD=true; shift 1;;
     --os)
-        OS=$2; shift 2;;
+        OSFLAG=$2; shift 2;;
     -h|--help)
         usage; exit 0;;
     --) shift; break ;;
@@ -261,25 +261,28 @@ elif  [ "${REPO}" = "k3s" ]; then
     STORAGE_URL="https://storage.googleapis.com/k3s-ci-builds"
     BINARY="k3s"
     # If not assigned, use alpine-3.16 for fast download and startup time
-    OS=${OS:-generic/alpine316}
+    OS=generic/alpine316
 elif [ "${REPO}" = "rke2" ]; then
     ORG="rancher"
     BINARY="rke2.linux-amd64"
     STORAGE_URL="https://storage.googleapis.com/rke2-ci-builds"
     # RKE2 requires systemd, so we use ubuntu,
     # note that it is much larger (~1.5GB) and takes longer to startup.
-    OS=${OS:-generic/ubuntu2004}
+    OS=generic/ubuntu2004
 else 
    echo "error: unknown repo (-r) $REPO"
    exit 1
 fi
 
-if [ "${OS}" = "alpine" ]; then 
-    OS=generic/alpine316; 
-elif [ "${OS}" = "ubuntu" ]; then 
+if [ "${OSFLAG}" = "alpine" ]; then 
+    OS=generic/alpine317; 
+elif [ "${OSFLAG}" = "ubuntu" ]; then 
     OS=generic/ubuntu2004; 
-elif [ "${OS}" != "generic/alpine316" ] && [ "${OS}" != "generic/ubuntu2004" ]; then
-    echo "error: unsupported OS (-p) $OS"
+elif [ "${OSFLAG}" = "debian" ]; then 
+    OS=generic/debian11; 
+elif [ -n "${OSFLAG}" ]; then
+    echo "error: unsupported OS (--os) $OSFLAG"
+    exit 1
 fi
 
 

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -185,6 +185,12 @@ if [ "$#" -eq 0 ]; then
     exit 0
 fi
 
+has_vagrant
+has_curl
+has_wget
+has_awk
+has_getopt
+
 PARSED_ARGUMENTS=$(getopt -o r:v:c:b:i:kdh --long os:,version:,skip,download,help -- "$@")
 
 eval set -- "$PARSED_ARGUMENTS"
@@ -218,12 +224,6 @@ while true; do
         usage; exit 1;;
     esac
 done
-
-has_vagrant
-has_curl
-has_wget
-has_awk
-has_getopt
 
 
 if [ -z "${CLUSTER}" ]; then

--- a/test-pad/test-pad
+++ b/test-pad/test-pad
@@ -3,21 +3,21 @@
 . "../bin/libstd-ecm.sh"
 
 usage() {
-    echo "usage: $0 [rcvbikdsoh]
-    -r    repository (k3s/rke2)
-    -c    cluster type
+    echo "usage: $0 [rcvbikdh]
+    -r              repository (k3s/rke2)
+    -c              cluster type
     
-    -v    k3s/rke2 version or commit id to use
+    -v, --version   k3s/rke2 version or commit id to use
     OR
-    -b    location of local k3s/rke2 binary to use
-    -i    location of local rke2 images
+    -b              location of local k3s/rke2 binary to use
+    -i              location of local rke2 images
 
-    -k    kill cluster
-    -d    kill cluster and delete files
-    -s    skip Vagrantfile download
-    -o    only download Vagrantfile, don't create cluster
-    -p    override OS [alpine|ubuntu]
-    -h    show help
+    -k, --kill      kill cluster
+    -d              kill cluster and delete files
+    --download      only download artifacts, don't create cluster
+    --skip          skip Vagrantfile download
+    --os            override OS [alpine|ubuntu]
+    -h, --help      show help
 
 cluster types:
     - basic:        2 VMs, 1 server, 1 agent
@@ -172,46 +172,49 @@ node_delay() {
     fi
 }
 
-while getopts 'r:c:v:b:i:p:kdohs' c; do
-    case $c in
-    r) 
-        REPO=$OPTARG
-    ;;
-    c) 
-        CLUSTER=$OPTARG
-    ;;
-    v) 
-        VERSION=$OPTARG
-    ;;
-    b)
-        BINARY_LOCATION=$OPTARG
-    ;;
-    i)
-        IMAGE_LOCATION=$OPTARG
-    ;;
-    k)
-        KILL=true
-    ;;
-    d)
-        DESTROY=true
-    ;;
-    s)
-        SKIP_DOWNLOAD=true
-    ;;
-    o)
-        ONLY_DOWNLOAD=true
-    ;;
-    p)
-        OS=$OPTARG
-    ;;
-    h)
-        usage
-        exit 0
-    ;;
-    *)
-        usage
+has_getopt() {
+    if [ -z "$(command -v getopt)" ]; then
+        printf "error: getopt is not installed\nif on MacOS: brew install gnu-getopt\n"
         exit 1
-    ;;
+    fi
+}
+
+if [ "$#" -eq 0 ]; then
+    usage
+    exit 0
+fi
+
+PARSED_ARGUMENTS=$(getopt -o r:v:c:b:i:kdh --long os:,version:,skip,download,help -- "$@")
+
+eval set -- "$PARSED_ARGUMENTS"
+
+while true; do
+    case "$1" in
+    -r)
+        REPO=$2; shift 2;;
+    -c)
+        CLUSTER=$2; shift 2;;
+    -v|--version)
+        VERSION=$2; shift 2;;
+    -b)
+        BINARY_LOCATION=$2; shift 2;;
+    -i) 
+        IMAGE_LOCATION=$2; shift 2;;
+    -k|--kill)
+        KILL=true; shift 1;;
+    -d)
+        DESTROY=true; shift 1;;
+    --skip)
+        SKIP_DOWNLOAD=true; shift 1;;
+    --download)
+        ONLY_DOWNLOAD=true; shift 1;;
+    --os)
+        OS=$2; shift 2;;
+    -h|--help)
+        usage; exit 0;;
+    --) shift; break ;;
+    *) echo "Unexpected flag: $1"
+        usage; exit 1;;
     esac
 done
 
@@ -219,11 +222,8 @@ has_vagrant
 has_curl
 has_wget
 has_awk
+has_getopt
 
-if [ "$#" -eq 0 ]; then
-    usage
-    exit 1
-fi
 
 if [ -z "${CLUSTER}" ]; then
     if [ -f "artifacts/cluster" ]; then


### PR DESCRIPTION
Changes the follow around test-pad tool:
- Correct spelling errors and improve documentation around using test-pad
- Convert flag parsing to gnu `getopt`, allows long and short flags
- Add support for debian11 as an OS, nice to have a nft native iptables OS