### PR TITLE
Fix multi-line changelog markup

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/google/go-github/v39/github"
 	"github.com/rancher/ecm-distro-tools/repository"
@@ -30,6 +31,20 @@ func trimPeriods(v string) string {
 	return strings.Replace(v, ".", "", -1)
 }
 
+// capitalize returns a new string whose first letter is capitalized.
+func capitalize(s string) string {
+	if runes := []rune(s); len(runes) > 0 {
+		for i, r := range runes {
+			if unicode.IsLetter(r) {
+				runes[i] = unicode.ToUpper(r)
+				s = string(runes)
+				break
+			}
+		}
+	}
+	return s
+}
+
 // GenReleaseNotes genereates release notes based on the given milestone,
 // previous milestone, and repository.
 func GenReleaseNotes(ctx context.Context, repo, milestone, prevMilestone string, client *github.Client) (*bytes.Buffer, error) {
@@ -39,6 +54,7 @@ func GenReleaseNotes(ctx context.Context, repo, milestone, prevMilestone string,
 		"majMin":      majMin,
 		"trimPeriods": trimPeriods,
 		"split":       strings.Split,
+		"capitalize":  capitalize,
 	}
 
 	tmpl := template.New(templateName).Funcs(funcMap)
@@ -437,11 +453,11 @@ var changelogTemplate = `
 {{- define "changelog" -}}
 ## Changes since {{.prevMilestone}}:
 {{range .content}}
-* {{.Title}} [(#{{.Number}})]({{.URL}})
+* {{ capitalize .Title }} [(#{{.Number}})]({{.URL}})
 {{- $lines := split .Note "\n"}}
 {{- range $i, $line := $lines}}
 {{- if ne $line "" }}
-  * {{$line}}
+  * {{ capitalize $line }}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -51,3 +51,34 @@ func TestTrimPeriods(t *testing.T) {
 		})
 	}
 }
+
+func TestCapitalize(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{
+			version: "HELLO WORLD",
+			want:    "HELLO WORLD",
+		},
+		{
+			version: "hello world",
+			want:    "Hello world",
+		},
+		{
+			version: " hello world",
+			want:    " Hello world",
+		},
+		{
+			version: " [hello] world",
+			want:    " [Hello] world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := capitalize(tt.version); got != tt.want {
+				t.Errorf("capitalize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -162,6 +162,7 @@ type Issue struct {
 // to populate the template.
 type ChangeLog struct {
 	Title  string
+	Note   string
 	Number int
 	URL    string
 }
@@ -271,6 +272,7 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 				continue
 			}
 
+			title := strings.TrimSpace(prs[0].GetTitle())
 			body := prs[0].GetBody()
 
 			var releaseNote string
@@ -290,17 +292,12 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 					}
 				}
 				releaseNote = strings.TrimSpace(releaseNote)
-
-				if strings.Contains(releaseNote, "\r") {
-					releaseNote = prs[0].GetTitle() + "\n * " + releaseNote
-					releaseNote = strings.ReplaceAll(releaseNote, "\r", "\n * ")
-				}
-			} else {
-				releaseNote = prs[0].GetTitle()
+				releaseNote = strings.ReplaceAll(releaseNote, "\r", "\n")
 			}
 
 			found = append(found, ChangeLog{
-				Title:  releaseNote,
+				Title:  title,
+				Note:   releaseNote,
 				Number: prs[0].GetNumber(),
 				URL:    prs[0].GetHTMLURL(),
 			})


### PR DESCRIPTION
- Fixes #150
- Moves PR URL to the parent list line when a nested list is also present.
- Fixes incorrect nested markdown list indentation.
- Adds a reusable changelog template.
- Consolidate markdown formatting into release package by moving list markup out of repository package.
