### PR TITLE
Add generic version for alpine for the go wrapper

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -302,7 +302,7 @@ func (r *Release) buildGoWrapper() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	goImageVersion := fmt.Sprintf("golang:%s-alpine3.15", goVersion)
+	goImageVersion := fmt.Sprintf("golang:%s-alpine", goVersion)
 	devDockerfile := strings.ReplaceAll(dockerDevImage, "%goimage%", goImageVersion)
 	if err := os.WriteFile(filepath.Join(r.Workspace, "dockerfile"), []byte(devDockerfile), 0644); err != nil {
 		return "", err


### PR DESCRIPTION
well, kinda of an obvious solution to the issue, is to use a generic tag that doesnt use the alpine version, which should get the latest alpine image for this go version.

https://github.com/rancher/ecm-distro-tools/issues/165