### PR TITLE
make modify-k3s script output in debug, addt updates

### DIFF
--- a/cmd/k3s_release/Makefile
+++ b/cmd/k3s_release/Makefile
@@ -7,6 +7,7 @@ VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
+
 $(BINDIR)/$(BINARY): clean
 	CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v  -ldflags "$(LDFLAGS)" -o $@
 

--- a/cmd/k3s_release/main.go
+++ b/cmd/k3s_release/main.go
@@ -7,32 +7,30 @@ import (
 	"github.com/urfave/cli"
 )
 
-var (
-	rootFlags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "config",
-			Usage:  "Specify release config file",
-			EnvVar: "RELEASE_CONFIG",
-		},
-		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "Debug mode",
-		},
-	}
-)
+var rootFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   "config",
+		Usage:  "Specify release config file",
+		EnvVar: "RELEASE_CONFIG",
+	},
+	cli.BoolFlag{
+		Name:  "debug",
+		Usage: "Debug mode",
+	},
+}
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "k3s-release"
-	app.Usage = "Start a k3s release"
+	app.Usage = "Perform a k3s release"
 	app.Commands = []cli.Command{
 		createTagsCommand(),
 		pushTagsCommand(),
 		modifyK3SCommand(),
 	}
 	app.Flags = rootFlags
-	err := app.Run(os.Args)
-	if err != nil {
+
+	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/cmd/k3s_release/modify_k3s.go
+++ b/cmd/k3s_release/modify_k3s.go
@@ -19,20 +19,25 @@ func modifyK3SCommand() cli.Command {
 
 func modifyK3S(c *cli.Context) error {
 	ctx := context.Background()
+
 	configPath := c.String("config")
-	release, err := k3s.NewReleaseFromConfig(configPath)
+
+	release, err := k3s.NewRelease(configPath)
 	if err != nil {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
+
 	client, err := k3s.NewGithubClient(ctx, release.Token)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}
 
+	logrus.Info("Performing modify and push")
 	if err := release.ModifyAndPush(ctx); err != nil {
 		logrus.Fatalf("failed to modify k3s go.mod: %v", err)
 	}
 
+	logrus.Info("Creating pull request")
 	if err := release.CreatePRFromK3S(ctx, client); err != nil {
 		logrus.Fatalf("failed to create a new PR: %v", err)
 	}

--- a/cmd/k3s_release/push_tags.go
+++ b/cmd/k3s_release/push_tags.go
@@ -23,24 +23,30 @@ func pushTagsCommand() cli.Command {
 
 func pushTags(c *cli.Context) error {
 	ctx := context.Background()
+
 	// pushing tags to k3s-io kubernetes fork
 	configPath := c.String("config")
-	release, err := k3s.NewReleaseFromConfig(configPath)
+
+	release, err := k3s.NewRelease(configPath)
 	if err != nil {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
+
 	client, err := k3s.NewGithubClient(ctx, release.Token)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}
+
 	// this subcommand depends on tag file being created in workspace
 	tags, err := release.TagsFromFile(ctx)
 	if err != nil {
 		logrus.Fatalf("failed to extract tags from file: %v", err)
 	}
+
 	logrus.Infof("pushing tags to github")
 	if err := release.PushTags(ctx, tags, client, k3sRemote); err != nil {
 		logrus.Fatalf("failed to push tags: %v", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
The majority of this is just minor tweaks but the primary changes is the modify-k3s template (script) having `set -x` added to it for debug level output while executing.

https://github.com/rancher/ecm-distro-tools/pull/169/files#diff-9e4900fdb68c9c954cd9d4413f9ff22b8708544a866e80b77e7448b0ae9d6babR47