### PR TITLE
Add function to get Go  version in Kubernetes upstream

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -157,19 +157,16 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 	file, _, _, err := client.Repositories.GetContents(ctx, "kubernetes", "kubernetes", ".go-version", &github.RepositoryContentGetOptions{
 		Ref: version,
 	})
-
 	if err != nil {
 		if errors.As(err, &githubError) {
 			if githubError.Response.StatusCode == http.StatusNotFound {
 				return "", errors.New("failed to find .go-version file in given Kubernetes version")
 			}
-			return "", errors.New("unexpected GitHub API error")
 		}
 		return "", err
 	}
 
 	goVersion, err := file.GetContent()
-
 	if err != nil {
 		return "", errors.New("failed to decode content from .go-version file")
 	}

--- a/release/release.go
+++ b/release/release.go
@@ -152,31 +152,18 @@ func CheckUpstreamRelease(ctx context.Context, client *github.Client, org, repo 
 }
 
 func KubernetesGoVersion(ctx context.Context, client *github.Client, version string) (string, error) {
-	const (
-		owner string = "kubernetes"
-		repo  string = "kubernetes"
-	)
 
-	file, _, _, err := client.Repositories.GetContents(ctx, owner, repo, ".go-version", &github.RepositoryContentGetOptions{
+	file, _, _, err := client.Repositories.GetContents(ctx, "kubernetes", "kubernetes", ".go-version", &github.RepositoryContentGetOptions{
 		Ref: version,
 	})
 
 	if err != nil {
-		switch err := err.(type) {
-		case *github.ErrorResponse:
-			if err.Response.StatusCode == http.StatusNotFound {
-				logrus.Debugf("Failed to get .go-version file from given Kubernetes version")
-			}
-			return "", err
-		default:
-			return "", err
-		}
+		return "", err
 	}
 
 	goVersion, err := file.GetContent()
 
 	if err != nil {
-		logrus.Debugf("Failed to decode content from file")
 		return "", err
 	}
 

--- a/release/release.go
+++ b/release/release.go
@@ -160,7 +160,7 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 	if err != nil {
 		if errors.As(err, &githubError) {
 			if githubError.Response.StatusCode == http.StatusNotFound {
-				return "", errors.New("failed to find .go-version file in given Kubernetes version")
+				return "", err
 			}
 		}
 		return "", err
@@ -168,10 +168,10 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 
 	goVersion, err := file.GetContent()
 	if err != nil {
-		return "", errors.New("failed to decode content from .go-version file")
+		return "", err
 	}
 
-	return goVersion, nil
+	return strings.Trim(goVersion, "\n"), nil
 }
 
 // VerifyAssets checks the number of assets for the

--- a/release/release.go
+++ b/release/release.go
@@ -193,7 +193,7 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 	goVersion, err := file.GetContent()
 
 	if err != nil {
-		logrus.Debugf("Failed to decode content from .go-version file")
+		logrus.Debugf("Failed to decode content from file")
 		return "", err
 	}
 

--- a/release/release.go
+++ b/release/release.go
@@ -165,7 +165,7 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 			}
 			return "", errors.New("unexpected GitHub API error")
 		} else {
-			return "", errors.New("failed to find .go-version file in given Kubernetes version")
+			return "", err
 		}
 	}
 

--- a/release/release.go
+++ b/release/release.go
@@ -164,9 +164,8 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 				return "", errors.New("failed to find .go-version file in given Kubernetes version")
 			}
 			return "", errors.New("unexpected GitHub API error")
-		} else {
-			return "", err
 		}
+		return "", err
 	}
 
 	goVersion, err := file.GetContent()


### PR DESCRIPTION
**Proposed Changes**
This pull request introduces a new function that checks a Kubernetes repository for a given version. It fetches the Go version from the .go-version file.

**Types of Changes**
**Verification**
**Linked Issues**
[#189 ](https://github.com/rancher/ecm-distro-tools/issues/189)
**Further Comments**