### PR TITLE
add success message and rebase information on create_tags command

### DIFF
--- a/cmd/k3s_release/create_tags.go
+++ b/cmd/k3s_release/create_tags.go
@@ -49,15 +49,16 @@ func createTags(c *cli.Context) error {
 		return nil
 	}
 
-	tags, err := release.RebaseAndTag(ctx, client)
+	rebaseOut, tags, err := release.RebaseAndTag(ctx, client)
 	if err != nil {
 		logrus.Fatalf("failed to rebase and create tags: %v", err)
 	}
+  logrus.Info("successfully rebased and tagged")
+  logrus.Info(rebaseOut)
 
 	tagFile := filepath.Join(release.Workspace, "tags-"+release.NewK8SVersion)
 	if err := os.WriteFile(tagFile, []byte(strings.Join(tags, "\n")), 0644); err != nil {
 		logrus.Fatalf("failed to write tags file: %v", err)
 	}
-
 	return nil
 }

--- a/cmd/k3s_release/create_tags.go
+++ b/cmd/k3s_release/create_tags.go
@@ -53,8 +53,8 @@ func createTags(c *cli.Context) error {
 	if err != nil {
 		logrus.Fatalf("failed to rebase and create tags: %v", err)
 	}
-  logrus.Info("successfully rebased and tagged")
-  logrus.Info(rebaseOut)
+	logrus.Info("successfully rebased and tagged")
+	logrus.Info(rebaseOut)
 
 	tagFile := filepath.Join(release.Workspace, "tags-"+release.NewK8SVersion)
 	if err := os.WriteFile(tagFile, []byte(strings.Join(tags, "\n")), 0644); err != nil {

--- a/cmd/k3s_release/create_tags.go
+++ b/cmd/k3s_release/create_tags.go
@@ -49,7 +49,7 @@ func createTags(c *cli.Context) error {
 		return nil
 	}
 
-	rebaseOut, tags, err := release.RebaseAndTag(ctx, client)
+	tags, rebaseOut, err := release.RebaseAndTag(ctx, client)
 	if err != nil {
 		logrus.Fatalf("failed to rebase and create tags: %v", err)
 	}


### PR DESCRIPTION
For some reason, the `git rebase` command always writes to STDERR and when logging in Go, the rebase command output deletes everything that comes before in the line.

```diff
- INFO[0232] Successfully rebased and updated detached HEAD. # expected
+ Successfully rebased and updated detached HEAD. # result
```

Closes: #175 