### PR TITLE
Fix containerd version in Gen Release notes

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -592,7 +592,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 | Kine | [{{.KineVersion}}](https://github.com/k3s-io/kine/releases/tag/{{.KineVersion}}) |
 | SQLite | [{{.SQLiteVersion}}](https://sqlite.org/releaselog/{{.SQLiteVersionReplaced}}.html) |
 | Etcd | [{{.EtcdVersionK3S}}](https://github.com/k3s-io/etcd/releases/tag/{{.EtcdVersionK3S}}) |
-{{- if and (ge .fullVersion "1.23.17") (lt .fullVersion "1.26.5")}}
+{{- if and (ge .fullVersion "1.24.0") (lt .fullVersion "1.26.5")}}
 | Containerd | [{{.ContainerdVersionK3S}}](https://github.com/k3s-io/containerd/releases/tag/{{.ContainerdVersionK3S}}) |
 {{- else }}
 | Containerd | [{{.ContainerdVersionGoMod}}](https://github.com/k3s-io/containerd/releases/tag/{{.ContainerdVersionGoMod}}) |


### PR DESCRIPTION
#### Proposed Changes ####

- Created a validation to get the Containerd version from the version.sh file, if the K3s version is between 1.24 and 1.26.5 Otherwise from go.mod

#### Types of Changes ####

- Template

#### Verification ####

#### Testing ####

We need to maintain getting from the version.sh for versions 1.24 to 1.26.5 to get the right information.

Example: Release https://github.com/k3s-io/k3s/releases/tag/v1.25.3%2Bk3s1

I used both sources and from the version.sh is the right one.

![ecm](https://github.com/rancher/ecm-distro-tools/assets/20056331/97b75490-a85a-4435-962b-53245c4345e6)

#### Linked Issues ####

https://github.com/rancher/ecm-distro-tools/issues/202

#### User-Facing Change ####

#### Further Comments ####
