### PR TITLE
Fix for modify_k3s script to alllow updates only for K3s version

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -54,12 +54,15 @@ const (
 		git branch delete {{ .NewK8SVersion }}-{{ .NewK3SVersion }}
 		git checkout -B {{ .NewK8SVersion }}-{{ .NewK3SVersion }} upstream/{{.ReleaseBranch}}
 		git clean -xfd
+
 		sed -Ei "\|github.com/k3s-io/kubernetes| s|{{ replaceAll .OldK8SVersion "." "\\." }}-{{ .OldK3SVersion }}|{{ replaceAll .NewK8SVersion "." "\\." }}-{{ .NewK3SVersion }}|; t; /github.com\/k3s-io\/kubernetes/ s|{{ .OldK3SVersion }}|{{ .NewK3SVersion }}|" go.mod
 		sed -Ei "s/k8s.io\/kubernetes v\S+/k8s.io\/kubernetes {{ replaceAll .NewK8SVersion "." "\\." }}/" go.mod
 		sed -Ei "s/{{ replaceAll .OldK8SClient "." "\\." }}/{{ replaceAll .NewK8SClient "." "\\." }}/g" go.mod # This should only change ~6 lines in go.mod
+
 		go mod tidy
 		# There is no need for running make since the changes will be only for go.mod
 		# mkdir -p build/data && DRONE_TAG={{ .NewK8SVersion }}-{{ .NewK3SVersion }} make download && make generate
+
 		git add go.mod go.sum
 		git commit --all --signoff -m "Update to {{ .NewK8SVersion }}"
 		git push --set-upstream origin {{ .NewK8SVersion }}-{{ .NewK3SVersion }} # run git remote -v for your origin


### PR DESCRIPTION
#### Proposed Changes ####

- Updated the sed command responsible to change the old versions for K8s and K3s to the new ones, allowing if necessary only the K3s version.

#### Types of Changes ####

- Internal script command

#### Verification ####

#### Testing ####

I used some debug sessions to understand what was wrong with the command  **k3s_release**  **modify-k3s** passing the config file. I used a example config file setting for my forked K3s repo:

**Config**

`{
    "old_k8s_version": "v1.27.2",
    "new_k8s_version": "v1.27.3",
    "old_k3s_version": "k3s2",
    "new_k3s_version": "k3s1",
    "old_k8s_client": "0.25.4",
    "new_k8s_client": "0.25.5",
    "release_branch": "",  
    "workspace": "/modify/workspace/",
    "handler": "johnatasr",
    "email": "johnatas.santos@suse.com",
    "token": "MY_TOKEN",
    "ssh_key_path": "SOME_SSH"
}`

**So I commented some steps from the command to isolate what I wanted and edited the go.mod from my forked K3s repo just with test purposes**

Set some packages hard code with the old versions

![gomodk3sbefore](https://github.com/rancher/ecm-distro-tools/assets/20056331/078a4588-2b0e-4932-9005-fc8eecf0ee4b)

Then I ran the command, getting the expected version updated for both cases:

![gomodk3safter](https://github.com/rancher/ecm-distro-tools/assets/20056331/0cffbe54-9bec-42ee-9790-c0fd11b23c66)

#### Linked Issues ####

https://github.com/rancher/ecm-distro-tools/issues/173

#### User-Facing Change ####

#### Further Comments ####
