### PR TITLE
Backport: Allow user assignment override

### DIFF
--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -27,7 +27,7 @@ Options:
     -i issue id          original issue id
     -c commits           commits to be backported (comma seperated)
     -b branch(es)        branches issue is being backported to
-	-u user			     user to assign new issues to (default: user assigned to orig. issue)
+    -u user			     user to assign new issues to (default: user assigned to orig. issue)
 
 Examples: 
     # generate 2 backport issues for k3s issue 1234

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -27,10 +27,11 @@ Options:
     -i issue id          original issue id
     -c commits           commits to be backported (comma seperated)
     -b branch(es)        branches issue is being backported to
+	-u user			     user to assign new issues to (default: user assigned to orig. issue)
 
 Examples: 
     # generate 2 backport issues for k3s issue 1234
-    %[2]s -r k3s -b "release-1.21,release-1.22" -i 1234 -c 1
+    %[2]s -r k3s -b "release-1.25,release-1.26" -i 1234 -c 1
 	%[2]s -r k3s -b "release-1.26" -i 1234 -c 1,2,3
 `
 
@@ -40,6 +41,7 @@ var (
 	commitIDs string
 	issueID   uint
 	branches  string
+	user      string
 )
 
 func main() {
@@ -59,6 +61,7 @@ func main() {
 	flag.StringVar(&commitIDs, "c", "", "")
 	flag.UintVar(&issueID, "i", 0, "")
 	flag.StringVar(&branches, "b", "", "")
+	flag.StringVar(&user, "u", "", "")
 	flag.Parse()
 
 	if vers {
@@ -91,6 +94,7 @@ func main() {
 		Commits:  commits,
 		IssueID:  issueID,
 		Branches: branches,
+		User:     user,
 	}
 	issues, err := repository.PerformBackport(ctx, client, &pbo)
 	if err != nil {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -202,7 +202,7 @@ type ChangeLog struct {
 }
 
 // CreateBackportIssues
-func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue *github.Issue, repo, branch string, i *Issue) (*github.Issue, error) {
+func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue *github.Issue, repo, branch, user string, i *Issue) (*github.Issue, error) {
 	org, err := OrgFromRepo(repo)
 	if err != nil {
 		return nil, err
@@ -212,7 +212,9 @@ func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue 
 	body := fmt.Sprintf(i.Body, origIssue.GetTitle(), *origIssue.Number)
 
 	var assignee *string
-	if origIssue.GetAssignee() != nil {
+	if user != "" {
+		assignee = types.StringPtr(user)
+	} else if origIssue.GetAssignee() != nil {
 		assignee = origIssue.GetAssignee().Login
 	} else {
 		assignee = types.StringPtr("")
@@ -235,6 +237,7 @@ type PerformBackportOpts struct {
 	Commits  []string `json:"commits"`
 	IssueID  uint     `json:"issue_id"`
 	Branches string   `json:"branches"`
+	User     string   `json:"user"`
 }
 
 // PerformBackport creates backport issues, performs a cherry-pick of the
@@ -266,7 +269,7 @@ func PerformBackport(ctx context.Context, client *github.Client, pbo *PerformBac
 
 	issues := make([]*github.Issue, len(backportBranches))
 	for _, branch := range backportBranches {
-		newIssue, err := CreateBackportIssues(ctx, client, origIssue, pbo.Repo, branch, &issue)
+		newIssue, err := CreateBackportIssues(ctx, client, origIssue, pbo.Repo, branch, pbo.User, &issue)
 		if err != nil {
 			return nil, err
 		}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -274,7 +274,6 @@ func PerformBackport(ctx context.Context, client *github.Client, pbo *PerformBac
 			return nil, err
 		}
 		issues = append(issues, newIssue)
-		fmt.Println("Backport issue created: " + newIssue.GetHTMLURL())
 	}
 
 	// stop here if there are no commits given


### PR DESCRIPTION
Problem:
If the current user assigned to an issue is not in the k3s-io org, the backport tool will `error 422` when attempting to make a new issue. 

Changes:
- Allow a `-u user` to override an original assignee for backports
Signed-off-by: Derek Nola <derek.nola@suse.com>