### PR TITLE
K3s release no GPG sign

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -213,7 +213,7 @@ func (r *Release) RebaseAndTag(_ context.Context, ghClient *github.Client) ([]st
 	}
 
 	// setup gitconfig
-	gitconfigFile, err := r.setupGitArtifacts(true)
+	gitconfigFile, err := r.setupGitArtifacts()
 	if err != nil {
 		return nil, "", err
 	}
@@ -349,7 +349,7 @@ func (r *Release) buildGoWrapper() (string, error) {
 	return wrapperImageTag, nil
 }
 
-func (r *Release) setupGitArtifacts(disableGpg bool) (string, error) {
+func (r *Release) setupGitArtifacts() (string, error) {
 	gitconfigFile := filepath.Join(r.Workspace, ".gitconfig")
 
 	// setting up username and email for tagging purposes
@@ -357,12 +357,10 @@ func (r *Release) setupGitArtifacts(disableGpg bool) (string, error) {
 	gitconfigFileContent = strings.ReplaceAll(gitconfigFileContent, "%user%", r.Handler)
 
 	// disable gpg signing direct in .gitconfig
-	if disableGpg {
-		if strings.Contains(gitconfigFileContent, "[commit]") {
-			gitconfigFileContent = strings.Replace(gitconfigFileContent, "gpgsign = true", "gpgsign = false", 1)
-		} else {
-			gitconfigFileContent += "[commit]\n\tgpgsign = false\n"
-		}
+	if strings.Contains(gitconfigFileContent, "[commit]") {
+		gitconfigFileContent = strings.Replace(gitconfigFileContent, "gpgsign = true", "gpgsign = false", 1)
+	} else {
+		gitconfigFileContent += "[commit]\n\tgpgsign = false\n"
 	}
 
 	if err := os.WriteFile(gitconfigFile, []byte(gitconfigFileContent), 0644); err != nil {
@@ -449,7 +447,7 @@ func (r *Release) TagsFromFile(_ context.Context) ([]string, error) {
 func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *github.Client, remote string) error {
 	// here we can use go-git library or runCommand function
 	// I am using go-git library to enhance code quality
-	gitConfigFile, err := r.setupGitArtifacts(true)
+	gitConfigFile, err := r.setupGitArtifacts()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Proposed Changes ####

- Created a validation to allow edit .gitconfig file generated at create-tags and push-tags commands, disabling gpgsing direct in the file 

search resource: [stackoverflow](https://stackoverflow.com/questions/39274739/how-to-disable-git-gpg-signing#:~:text=the%20%5Buser%5D%20configuration%3A-,%5Bcommit%5D%0A%20%20%20%20gpgsign%20%3D%20false,-Share) saving :)

#### Types of Changes ####

- backend code 

#### Verification ####

#### Testing ####

1 - Empty .gitconfig file 

![gpg1](https://github.com/rancher/ecm-distro-tools/assets/20056331/d1680bb6-7435-467c-bb85-a98a48ac05b1)

2 - Executed create-tags and cat .gitconfig file generated 

![gpg2](https://github.com/rancher/ecm-distro-tools/assets/20056331/474e8faa-a2a3-4479-a44b-330a1f25514f)

3 - If exists .gitconfig file with gpgsign as true, must set as false:

![gpg3](https://github.com/rancher/ecm-distro-tools/assets/20056331/df0074b2-c402-4aa9-997c-f331cce40d3a)

![gpg4](https://github.com/rancher/ecm-distro-tools/assets/20056331/156b5d4a-04d7-43d0-b472-66dc15e0d50b)

#### Linked Issues ####

https://github.com/rancher/ecm-distro-tools/issues/178

#### User-Facing Change ####

#### Further Comments ####
