### PR TITLE
#219: remove asterisks on changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ cmd/backport/bin
 cmd/standup/bin
 cmd/k3s_release/bin
 cmd/test_coverage/bin
+cmd/upstream_go_version/bin
 
 data/*
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -393,6 +393,7 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 						releaseNote += line
 					}
 				}
+				releaseNote = strings.Replace(releaseNote, "*", "", 0)
 				releaseNote = strings.TrimSpace(releaseNote)
 				releaseNote = strings.ReplaceAll(releaseNote, "\r", "\n")
 			}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -390,10 +390,10 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 						inNote = false
 					}
 					if inNote && line != "" {
+						line = strings.Replace(line, "* ", "", 1)
 						releaseNote += line
 					}
 				}
-				releaseNote = strings.Replace(releaseNote, "*", "", 0)
 				releaseNote = strings.TrimSpace(releaseNote)
 				releaseNote = strings.ReplaceAll(releaseNote, "\r", "\n")
 			}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -390,7 +390,7 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, repo,
 						inNote = false
 					}
 					if inNote && line != "" {
-						line = strings.Replace(line, "* ", "", 1)
+						line = strings.TrimPrefix(line, "* ")
 						releaseNote += line
 					}
 				}


### PR DESCRIPTION
Closes: #219 

This PR solves the double asterisk problem for `gen_release_notes` and removes a bin folder from git

Before: 
```
## Changes since v1.24.14+k3s1:

* E2E Backports - June [(#7726)](https://github.com/k3s-io/k3s/pull/7726)
  * * Shortcircuit commands with version or help flags #7683
  * * Add Rotation certification Check, remove func to restart agents #7097
  * * E2E: Sudo for RunCmdOnNode #7686
* VPN integration [(#7729)](https://github.com/k3s-io/k3s/pull/7729)
* Revert "VPN integration" [(#7742)](https://github.com/k3s-io/k3s/pull/7742)
* Fix spelling check [(#7753)](https://github.com/k3s-io/k3s/pull/7753)
* Backport version bumps and bugfixes [(#7719)](https://github.com/k3s-io/k3s/pull/7719)
* Remove unused libvirt config [(#7759)](https://github.com/k3s-io/k3s/pull/7759)
* Add format command on Makefile [(#7764)](https://github.com/k3s-io/k3s/pull/7764)
* Update Kubernetes to v1.24.15 [(#7785)](https://github.com/k3s-io/k3s/pull/7785)
```
After:
```
## Changes since v1.24.14+k3s1:

* E2E Backports - June [(#7726)](https://github.com/k3s-io/k3s/pull/7726)
  * Shortcircuit commands with version or help flags #7683
  * Add Rotation certification Check, remove func to restart agents #7097
  * E2E: Sudo for RunCmdOnNode #7686
* VPN integration [(#7729)](https://github.com/k3s-io/k3s/pull/7729)
* Revert "VPN integration" [(#7742)](https://github.com/k3s-io/k3s/pull/7742)
* Fix spelling check [(#7753)](https://github.com/k3s-io/k3s/pull/7753)
* Backport version bumps and bugfixes [(#7719)](https://github.com/k3s-io/k3s/pull/7719)
* Remove unused libvirt config [(#7759)](https://github.com/k3s-io/k3s/pull/7759)
* Add format command on Makefile [(#7764)](https://github.com/k3s-io/k3s/pull/7764)
* Update Kubernetes to v1.24.15 [(#7785)](https://github.com/k3s-io/k3s/pull/7785)
```

## How to test
1. `make`
2. `export GITHUB_TOKEN=<your_token>`
3.  `cmd/gen_release_notes/bin/gen_release_notes -p v1.24.14+k3s1 -m v1.24.15-rc1+k3s1 -r k3s`
4. Verify that the output doesn't have the double asterisk problem

Try other milestones.