### PR TITLE
#254: Add list images rc sub-comand for rancher release

### DIFF
--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -11,7 +11,7 @@ import (
 func listImagesRCCommand() cli.Command {
 	return cli.Command{
 		Name:   "list-images-rc",
-		Usage:  "list all images which are in rc form given a tag",
+		Usage:  "list all non-mirrored images which are in rc form given a tag in a MD format",
 		Flags:  []cli.Flag{
       cli.StringFlag{
         Name:   "tag",

--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rancher/ecm-distro-tools/release/rancher"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func listImagesRCCommand() cli.Command {
+	return cli.Command{
+		Name:   "list-images-rc",
+		Usage:  "list all images which are in rc form given a tag",
+		Flags:  []cli.Flag{
+      cli.StringFlag{
+        Name:   "tag",
+        Usage:  "release tag to validate images",
+				Required: true,
+      },
+    },
+		Action: listImagesRC,
+	}
+}
+
+func listImagesRC(c *cli.Context) error {
+	tag := c.String("tag")
+	logrus.Debug("tag: " + tag)
+	imagesRC, err := rancher.ListRancherImagesRC(tag)
+	if err != nil { 
+		return err
+	}
+	fmt.Println(imagesRC)
+  return nil
+}

--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -26,6 +26,7 @@ func listImagesRCCommand() cli.Command {
 func listImagesRC(c *cli.Context) error {
 	tag := c.String("tag")
 	logrus.Debug("tag: " + tag)
+
 	imagesRC, err := rancher.ListRancherImagesRC(tag)
 	if err != nil {
 		return err

--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -13,11 +13,11 @@ func listImagesRCCommand() cli.Command {
 		Name:   "list-images-rc",
 		Usage:  "list all non-mirrored images which are in rc form given a tag in a MD format",
 		Flags:  []cli.Flag{
-      cli.StringFlag{
-        Name:   "tag",
-        Usage:  "release tag to validate images",
+			cli.StringFlag{
+				Name:   "tag",
+				Usage:  "release tag to validate images",
 				Required: true,
-      },
+			},
     },
 		Action: listImagesRC,
 	}

--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -10,7 +10,7 @@ import (
 
 func listImagesRCCommand() cli.Command {
 	return cli.Command{
-		Name:  "list-images-rc",
+		Name:  "list-nonmirrored-rc-images",
 		Usage: "list all non-mirrored images which are in rc form given a tag in a MD format",
 		Flags: []cli.Flag{
 			cli.StringFlag{

--- a/cmd/rancher_release/list_images_rc.go
+++ b/cmd/rancher_release/list_images_rc.go
@@ -10,15 +10,15 @@ import (
 
 func listImagesRCCommand() cli.Command {
 	return cli.Command{
-		Name:   "list-images-rc",
-		Usage:  "list all non-mirrored images which are in rc form given a tag in a MD format",
-		Flags:  []cli.Flag{
+		Name:  "list-images-rc",
+		Usage: "list all non-mirrored images which are in rc form given a tag in a MD format",
+		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:   "tag",
-				Usage:  "release tag to validate images",
+				Name:     "tag",
+				Usage:    "release tag to validate images",
 				Required: true,
 			},
-    },
+		},
 		Action: listImagesRC,
 	}
 }
@@ -27,9 +27,9 @@ func listImagesRC(c *cli.Context) error {
 	tag := c.String("tag")
 	logrus.Debug("tag: " + tag)
 	imagesRC, err := rancher.ListRancherImagesRC(tag)
-	if err != nil { 
+	if err != nil {
 		return err
 	}
 	fmt.Println(imagesRC)
-  return nil
+	return nil
 }

--- a/cmd/rancher_release/main.go
+++ b/cmd/rancher_release/main.go
@@ -23,7 +23,9 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "rancher-release"
 	app.Usage = "Perform a Rancher release"
-	app.Commands = []cli.Command{}
+	app.Commands = []cli.Command{
+		listImagesRCCommand(),
+	}
 	app.Flags = rootFlags
 
 	if err := app.Run(os.Args); err != nil {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -18,7 +18,8 @@ const (
 )
 
 func ListRancherImagesRC(tag string) (string, error) {
-	imagesFile, err := rancherImages(tag)
+	downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
+	imagesFile, err := rancherImages(downloadURL)
 	if err != nil {
 		return "", err
 	}
@@ -56,11 +57,10 @@ func findRCNonMirroredImages(images string) ([]string, error) {
 	return rcImages, nil
 }
 
-func rancherImages(tag string) (string, error) {
+func rancherImages(imagesURL string) (string, error) {
 	httpClient := http.Client{Timeout: time.Second * 15}
-	downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
-	logrus.Debug("downloading: " + downloadURL)
-	resp, err := httpClient.Get(downloadURL)
+	logrus.Debug("downloading: " + imagesURL)
+	resp, err := httpClient.Get(imagesURL)
 	if err != nil {
 		return "", err
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -1,0 +1,70 @@
+package rancher
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+  rancherImagesBaseURL = "https://github.com/rancher/rancher/releases/download/"
+  rancherImagesFileName = "/rancher-images.txt"
+)
+
+func ListRancherImagesRC(tag string) (string, error) {
+	imagesFile, err := getRancherImagesFile(tag)
+	if err != nil {
+		return "", err
+	}
+	rcImages, err := findRCNonMirroredImages(imagesFile)
+	if err != nil {
+		return "", err
+	}
+
+  if len(rcImages) == 0 {
+    return "There are none non-mirrored images still in rc form for tag " + tag, nil
+  }
+
+  output := "The following non-mirrored images for tag *"+tag+"* are still in RC form\n```\n"
+  for _, image := range(rcImages) {
+    output += image + "\n"
+  }
+  output += "```"
+
+  return output, nil
+}
+
+func findRCNonMirroredImages(imagesFile io.ReadCloser) ([]string, error) {
+  var rcImages []string
+  
+  scanner := bufio.NewScanner(imagesFile) 
+  for scanner.Scan() {
+    image := scanner.Text()
+    if strings.Contains(image, "mirrored") {
+      continue
+    }
+    if strings.Contains(image, "-rc") {
+      rcImages = append(rcImages, image)
+    }
+  }
+  return rcImages, imagesFile.Close()
+}
+
+func getRancherImagesFile(tag string) (io.ReadCloser, error) {
+  downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
+  logrus.Debug("downloading: " + downloadURL)
+  resp, err := http.Get(downloadURL) 
+  if err != nil {
+    return nil, err
+  }
+  if resp.StatusCode != http.StatusOK {
+    return nil, errors.New("failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode))
+  }
+
+  return resp.Body, nil
+}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -18,7 +18,7 @@ const (
 )
 
 func ListRancherImagesRC(tag string) (string, error) {
-	imagesFile, err := getRancherImagesFile(tag)
+	imagesFile, err := rancherImages(tag)
 	if err != nil {
 		return "", err
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -65,11 +65,9 @@ func rancherImages(imagesURL string) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", errors.New("failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode))
 	}
-
 	images, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
-
 	return string(images), nil
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -23,10 +23,7 @@ func ListRancherImagesRC(tag string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rcImages, err := findRCNonMirroredImages(imagesFile)
-	if err != nil {
-		return "", err
-	}
+	rcImages := nonMirroredRCImages(imagesFile)
 
 	if len(rcImages) == 0 {
 		return "There are none non-mirrored images still in rc form for tag " + tag, nil
@@ -41,7 +38,7 @@ func ListRancherImagesRC(tag string) (string, error) {
 	return output, nil
 }
 
-func findRCNonMirroredImages(images string) ([]string, error) {
+func nonMirroredRCImages(images string) []string {
 	var rcImages []string
 
 	scanner := bufio.NewScanner(strings.NewReader(images))
@@ -54,7 +51,7 @@ func findRCNonMirroredImages(images string) ([]string, error) {
 			rcImages = append(rcImages, image)
 		}
 	}
-	return rcImages, nil
+	return rcImages
 }
 
 func rancherImages(imagesURL string) (string, error) {
@@ -66,9 +63,7 @@ func rancherImages(imagesURL string) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.New(
-			"failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode),
-		)
+		return "", errors.New("failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode))
 	}
 
 	images, err := io.ReadAll(resp.Body)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -56,9 +57,10 @@ func findRCNonMirroredImages(imagesFile io.ReadCloser) ([]string, error) {
 }
 
 func getRancherImagesFile(tag string) (io.ReadCloser, error) {
+	httpClient := http.Client{Timeout: time.Second * 15}
 	downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
 	logrus.Debug("downloading: " + downloadURL)
-	resp, err := http.Get(downloadURL)
+	resp, err := httpClient.Get(downloadURL)
 	if err != nil {
 		return nil, err
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-  rancherImagesBaseURL = "https://github.com/rancher/rancher/releases/download/"
-  rancherImagesFileName = "/rancher-images.txt"
+	rancherImagesBaseURL  = "https://github.com/rancher/rancher/releases/download/"
+	rancherImagesFileName = "/rancher-images.txt"
 )
 
 func ListRancherImagesRC(tag string) (string, error) {
@@ -26,45 +26,47 @@ func ListRancherImagesRC(tag string) (string, error) {
 		return "", err
 	}
 
-  if len(rcImages) == 0 {
-    return "There are none non-mirrored images still in rc form for tag " + tag, nil
-  }
+	if len(rcImages) == 0 {
+		return "There are none non-mirrored images still in rc form for tag " + tag, nil
+	}
 
-  output := "The following non-mirrored images for tag *"+tag+"* are still in RC form\n```\n"
-  for _, image := range(rcImages) {
-    output += image + "\n"
-  }
-  output += "```"
+	output := "The following non-mirrored images for tag *" + tag + "* are still in RC form\n```\n"
+	for _, image := range rcImages {
+		output += image + "\n"
+	}
+	output += "```"
 
-  return output, nil
+	return output, nil
 }
 
 func findRCNonMirroredImages(imagesFile io.ReadCloser) ([]string, error) {
-  var rcImages []string
-  
-  scanner := bufio.NewScanner(imagesFile) 
-  for scanner.Scan() {
-    image := scanner.Text()
-    if strings.Contains(image, "mirrored") {
-      continue
-    }
-    if strings.Contains(image, "-rc") {
-      rcImages = append(rcImages, image)
-    }
-  }
-  return rcImages, imagesFile.Close()
+	var rcImages []string
+
+	scanner := bufio.NewScanner(imagesFile)
+	for scanner.Scan() {
+		image := scanner.Text()
+		if strings.Contains(image, "mirrored") {
+			continue
+		}
+		if strings.Contains(image, "-rc") {
+			rcImages = append(rcImages, image)
+		}
+	}
+	return rcImages, imagesFile.Close()
 }
 
 func getRancherImagesFile(tag string) (io.ReadCloser, error) {
-  downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
-  logrus.Debug("downloading: " + downloadURL)
-  resp, err := http.Get(downloadURL) 
-  if err != nil {
-    return nil, err
-  }
-  if resp.StatusCode != http.StatusOK {
-    return nil, errors.New("failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode))
-  }
+	downloadURL := rancherImagesBaseURL + tag + rancherImagesFileName
+	logrus.Debug("downloading: " + downloadURL)
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(
+			"failed to download rancher-images.txt file, expected status code 200, got: " + strconv.Itoa(resp.StatusCode),
+		)
+	}
 
-  return resp.Body, nil
+	return resp.Body, nil
 }

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -11,10 +11,7 @@ func TestFindRCNonMirroredImages(t *testing.T) {
 	images := "rancher/pushprox-proxy:v0.1.0-rancher2-proxy\nrancher/rancher-agent:v2.7.6-rc5\nrancher/rancher-csp-adapter:v2.0.2\nrancher/rancher-webhook:v0.3.5\nrancher/rancher:v2.7.6-rc5\nrancher/mirrored-rke-tools:v0.1.88-rc3"
 	exptectedRCImages := []string{"rancher/rancher-agent:v2.7.6-rc5", "rancher/rancher:v2.7.6-rc5"}
 
-	result, err := findRCNonMirroredImages(images)
-	if err != nil {
-		t.Error(err)
-	}
+	result := nonMirroredRCImages(images)
 	if reflect.DeepEqual(exptectedRCImages, result) != true {
 		t.Errorf("failed: result images does not equal expected images, expected %+v, got %+v", exptectedRCImages, result)
 	}

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -1,0 +1,44 @@
+package rancher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestFindRCNonMirroredImages(t *testing.T) {
+	images := "rancher/pushprox-proxy:v0.1.0-rancher2-proxy\nrancher/rancher-agent:v2.7.6-rc5\nrancher/rancher-csp-adapter:v2.0.2\nrancher/rancher-webhook:v0.3.5\nrancher/rancher:v2.7.6-rc5\nrancher/mirrored-rke-tools:v0.1.88-rc3"
+	exptectedRCImages := []string{"rancher/rancher-agent:v2.7.6-rc5", "rancher/rancher:v2.7.6-rc5"}
+
+	result, err := findRCNonMirroredImages(images)
+	if err != nil {
+		t.Error(err)
+	}
+	if reflect.DeepEqual(exptectedRCImages, result) != true {
+		t.Errorf("failed: result images does not equal expected images, expected %+v, got %+v", exptectedRCImages, result)
+	}
+}
+
+func TestRancherImages(t *testing.T) {
+	path := "/rancher/rancher/releases/download/v2.7.7-rc4/rancher-images.txt"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			t.Errorf(
+				"Expected to request '/rancher/rancher/releases/download/v2.7.7-rc4/rancher-images.txt', got: %s",
+				r.URL.Path,
+			)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("images"))
+	}))
+	defer server.Close()
+
+	result, err := rancherImages(server.URL + path)
+	if err != nil {
+		t.Error(err)
+	}
+	if result != "images" {
+		t.Errorf("Expected 'images', got %s", result)
+	}
+}

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -10,7 +10,6 @@ import (
 func TestFindRCNonMirroredImages(t *testing.T) {
 	images := "rancher/pushprox-proxy:v0.1.0-rancher2-proxy\nrancher/rancher-agent:v2.7.6-rc5\nrancher/rancher-csp-adapter:v2.0.2\nrancher/rancher-webhook:v0.3.5\nrancher/rancher:v2.7.6-rc5\nrancher/mirrored-rke-tools:v0.1.88-rc3"
 	exptectedRCImages := []string{"rancher/rancher-agent:v2.7.6-rc5", "rancher/rancher:v2.7.6-rc5"}
-
 	result := nonMirroredRCImages(images)
 	if reflect.DeepEqual(exptectedRCImages, result) != true {
 		t.Errorf("failed: result images does not equal expected images, expected %+v, got %+v", exptectedRCImages, result)

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestFindRCNonMirroredImages(t *testing.T) {
+func TestNonMirroredRCImages(t *testing.T) {
 	images := "rancher/pushprox-proxy:v0.1.0-rancher2-proxy\nrancher/rancher-agent:v2.7.6-rc5\nrancher/rancher-csp-adapter:v2.0.2\nrancher/rancher-webhook:v0.3.5\nrancher/rancher:v2.7.6-rc5\nrancher/mirrored-rke-tools:v0.1.88-rc3"
 	exptectedRCImages := []string{"rancher/rancher-agent:v2.7.6-rc5", "rancher/rancher:v2.7.6-rc5"}
 	result := nonMirroredRCImages(images)


### PR DESCRIPTION
Closes: #254 

This PR adds a sub-command to the rancher release CLI that lists all non-mirrored images which are in an RC format.

There's a limitation with Slack, where it won't apply MD styling automatically, it shows a pop-up asking if you want to apply it, or you can set it to always apply on advanced settings, but you lose the styling bar.

## How to test
* ```
    git clone https://github.com/Tashima42/ecm-distro-tools.git
   ```
* ```
    git switch 254-list-images-rc
   ```
* ```
    make rancher_release
    ```
* ```
    cmd/rancher_release/bin/rancher_release list-images-rc --tag v2.7.7-rc3
    ```