### PR TITLE
Add semver package and semv cmd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
             ${{ github.workspace }}/cmd/k3s_release/bin/k3s_release
             ${{ github.workspace }}/cmd/standup/bin/standup
             ${{ github.workspace }}/cmd/test_coverage/bin/test_coverage
+            ${{ github.workspace }}/cmd/semv/bin/semv
       - name: Docker Hub Login
         uses: docker/login-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ cmd/k3s_release/bin
 cmd/test_coverage/bin
 cmd/upstream_go_version/bin
 cmd/rancher_release/bin
+cmd/semv/bin
 
 data/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN cd ./cmd/backport && make LDFLAGS="-linkmode=external"
 RUN cd ./cmd/gen_release_notes && make LDFLAGS="-linkmode=external"
 RUN cd ./cmd/gen_release_report && make LDFLAGS="-linkmode=external"
 RUN cd ./cmd/k3s_release && make LDFLAGS="-linkmode=external"
+RUN cd ./cmd/semv && make LDFLAGS="-linkmode=external"
 RUN cd ./cmd/standup && make
 ARG ETCD_VERSION=v3.5.7
 ARG GH_VERSION=2.23.0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: gen_release_notes gen_release_report backport standup k3s_release rancher_release test_coverage upstream_go_version
+all: gen_release_notes gen_release_report backport standup k3s_release rancher_release test_coverage upstream_go_version semv
 
 .PHONY: gen_release_notes
 gen_release_notes:
@@ -31,6 +31,10 @@ test_coverage:
 
 .PHONY: upstream_go_version
 upstream_go_version:
+	cd cmd/$@ && $(MAKE)
+
+.PHONY: semv
+semv:
 	cd cmd/$@ && $(MAKE)
 
 .PHONY: test

--- a/cmd/semv/Makefile
+++ b/cmd/semv/Makefile
@@ -1,0 +1,17 @@
+GO = go
+
+BINDIR := bin
+BINARY := semv
+
+VERSION           = v0.1.0
+GIT_SHA           = $(shell git rev-parse HEAD)
+override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
+TAGS              = "netgo osusergo no_stage static_build"
+
+$(BINDIR)/$(BINARY): clean
+	CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v  -ldflags "$(LDFLAGS)" -o $@
+
+.PHONY: clean
+clean:
+	$(GO) clean
+	rm -f $(BINDIR)/$(BINARY)

--- a/cmd/semv/README.md
+++ b/cmd/semv/README.md
@@ -1,0 +1,22 @@
+# semv
+
+Parse, test and compare semantic versions
+
+### Examples
+
+```sh
+semv -test v1.1.x v1.1.1-rc1
+```
+
+```sh
+semv -is-prerelease v1.1.1-rc1
+```
+
+```sh
+semv -parse v1.1.1-rc1 -o 
+```
+
+## Contributions
+
+* File Issue with details of the problem, feature request, etc.
+* Submit a pull request and include details of what problem or feature the code is solving or implementing.

--- a/cmd/semv/main.go
+++ b/cmd/semv/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"html/template"
+	"os"
+	"strings"
+
+	"github.com/rancher/ecm-distro-tools/release/semver"
+	"gopkg.in/yaml.v3"
+)
+
+func Format(v *semver.Version, format string) (string, error) {
+	switch {
+	case format == "":
+		str := fmt.Sprintf(
+			"Version: %s\nMajor: %d\nMinor: %d\nPatch: %d\nPrerelease: %s\nBuild: %s\n",
+			v.Version,
+			v.Major,
+			v.Minor,
+			v.Patch,
+			v.Prerelease,
+			v.Build,
+		)
+		return str, nil
+	case format == "json":
+		jsonData, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(jsonData), nil
+	case format == "yaml":
+		yml, err := yaml.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(yml), nil
+	case strings.HasPrefix(format, "go-template="):
+		goTemplate := strings.TrimPrefix(format, "go-template=")
+		tmpl, err := template.New("output").Parse(goTemplate)
+		if err != nil {
+			return "", err
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, v); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	}
+	return "", errors.New("invalid output format")
+}
+
+var (
+	name    string
+	version string
+	gitSHA  string
+)
+
+const usage = `version: %s
+Usage: %[2]s [-test] [-parse]
+Options:
+    -h            help
+    -v            show version and exit
+    -test         test a complete version against a semantic version pattern
+    -parse        parse a semantic version
+
+Examples: 
+    # parse
+    %[2]s -parse v1.2.3-rc1 -o go-template="{{.Major}}.{{.Minor}}.{{.Patch}}{{.Prerelease}}"
+    #test
+    %[2]s -pattern v1.x -test v1.2.3
+`
+
+func main() {
+	flag.Usage = func() {
+		w := os.Stderr
+		for _, arg := range os.Args {
+			if arg == "-h" {
+				w = os.Stdout
+				break
+			}
+		}
+		fmt.Fprintf(w, usage, version, name)
+	}
+
+	var vers bool
+	var parseArg, patternArg, testArg, formatArg string
+
+	flag.BoolVar(&vers, "v", false, "")
+	flag.StringVar(&parseArg, "parse", "", "Perform parse")
+	flag.StringVar(&patternArg, "pattern", "", "Perform test")
+	flag.StringVar(&testArg, "test", "", "Perform test")
+	flag.StringVar(&formatArg, "o", "", "Output format")
+
+	flag.Parse()
+
+	if vers {
+		fmt.Fprintf(os.Stdout, "version: %s - git sha: %s\n", version, gitSHA)
+		return
+	}
+
+	if testArg != "" {
+		if patternArg == "" || parseArg != "" {
+			fmt.Println("Invalid arguments. Usage:" + name + " -pattern <pattern> -test <version>")
+			os.Exit(1)
+		}
+
+		pattern, err := semver.ParsePattern(patternArg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		version, err := semver.ParseVersion(testArg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		pattern.Test(version)
+	}
+
+	if parseArg != "" {
+		version, err := semver.ParseVersion(parseArg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		result, err := Format(version, formatArg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Print(result)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/MetalBlueberry/go-plotly v0.4.0
 	github.com/urfave/cli v1.22.9
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -50,5 +51,4 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/release/semver/semver.go
+++ b/release/semver/semver.go
@@ -1,0 +1,195 @@
+package semver
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/ecm-distro-tools/types"
+
+	"golang.org/x/mod/semver"
+)
+
+type Pattern struct {
+	Pattern    string
+	Major      *int
+	Minor      *int
+	Patch      *int
+	Prerelease string
+	Build      string
+}
+
+type Version struct {
+	Version    string
+	Major      int
+	Minor      int
+	Patch      int
+	Prerelease string
+	Build      string
+}
+
+func majorMinorPatch(version string) (string, string, string, error) {
+	if !strings.HasPrefix(version, "v") {
+		return "", "", "", errors.New("version must start with 'v'")
+	}
+
+	// Remove the "v" prefix
+	version = strings.TrimPrefix(version, "v")
+
+	// Remove anything following a "-" or a "+"
+	version = strings.FieldsFunc(version, func(c rune) bool {
+		return c == '-' || c == '+'
+	})[0]
+
+	parts := strings.Split(version, ".")
+	if len(parts) == 0 {
+		return "", "", "", errors.New("invalid version")
+	}
+	major := parts[0]
+	var minor, patch string
+
+	if len(parts) > 1 {
+		minor = parts[1]
+	}
+
+	if len(parts) > 2 {
+		patch = parts[2]
+	}
+
+	return major, minor, patch, nil
+}
+func ParsePattern(pattern string) (*Pattern, error) {
+	prerelease := semver.Prerelease(pattern)
+	build := semver.Build(pattern)
+	major, minor, patch, err := majorMinorPatch(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	p := Pattern{Pattern: pattern}
+
+	if major == "" || major == "x" {
+		p.Major = nil
+	} else {
+		majorInt, err := strconv.Atoi(major)
+		if err != nil {
+			return nil, err
+		}
+		p.Major = types.IntPtr(majorInt)
+	}
+
+	if minor == "" || minor == "x" {
+		p.Minor = nil
+	} else {
+		minorInt, err := strconv.Atoi(minor)
+		if err != nil {
+			return nil, err
+		}
+		p.Minor = types.IntPtr(minorInt)
+	}
+
+	if patch == "" || patch == "x" {
+		p.Patch = nil
+	} else {
+		patchInt, err := strconv.Atoi(patch)
+		if err != nil {
+			return nil, err
+		}
+		p.Patch = types.IntPtr(patchInt)
+	}
+
+	if prerelease == "" || prerelease == "-x" {
+		p.Prerelease = ""
+	} else {
+		p.Prerelease = prerelease
+	}
+
+	if build == "" || build == "-x" {
+		p.Build = ""
+	} else {
+		p.Build = build
+	}
+
+	return &p, nil
+}
+
+func ParseVersion(version string) (*Version, error) {
+	if !semver.IsValid(version) {
+		return nil, errors.New("invalid version")
+	}
+
+	major := semver.Major(version)
+	majorMinor := semver.MajorMinor(version)
+	canonical := semver.Canonical(version)
+	prerelease := semver.Prerelease(version)
+
+	v := Version{Version: version}
+
+	majorInt, err := strconv.Atoi(strings.TrimPrefix(major, "v"))
+	if err != nil {
+		return nil, err
+	}
+	v.Major = majorInt
+
+	minor := strings.TrimPrefix(majorMinor, major+".")
+	minorInt, err := strconv.Atoi(minor)
+	if err != nil {
+		return nil, err
+	}
+	v.Minor = minorInt
+
+	patchAndPrerelease := strings.TrimPrefix(canonical, majorMinor+".")
+	patch := strings.SplitN(patchAndPrerelease, "-", 2)[0]
+	patchInt, err := strconv.Atoi(patch)
+	if err != nil {
+		return nil, err
+	}
+	v.Patch = patchInt
+
+	v.Prerelease = prerelease
+	v.Build = semver.Build(version)
+
+	return &v, nil
+}
+
+// returns true if the semver pattern p is matched by version v
+func (p *Pattern) Test(v *Version) (bool, error) {
+	if p == nil {
+		return false, errors.New("invalid pattern")
+	}
+	if v == nil {
+		return false, errors.New("invalid version")
+	}
+
+	if p.Major != nil {
+		if *p.Major != v.Major {
+			return false, nil
+		}
+	}
+
+	if p.Minor != nil {
+		if *p.Minor != v.Minor {
+			return false, nil
+		}
+	}
+
+	if p.Patch != nil {
+		if *p.Patch != v.Patch {
+			return false, nil
+		}
+	}
+
+	if p.Prerelease != "" && p.Prerelease != "x" {
+		if p.Prerelease != v.Prerelease {
+			return false, nil
+		}
+	}
+
+	if p.Build != "" && p.Build != "x" {
+		if p.Build != v.Build {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/release/semver/semver_test.go
+++ b/release/semver/semver_test.go
@@ -1,0 +1,169 @@
+package semver
+
+import (
+	"testing"
+
+	"github.com/rancher/ecm-distro-tools/types"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		version    string
+		major      int
+		minor      int
+		patch      int
+		prerelease string
+		build      string
+	}{
+		{"v1.2.3", 1, 2, 3, "", ""},
+		{"v2.0.0", 2, 0, 0, "", ""},
+		{"v2.8", 2, 8, 0, "", ""},
+		{"v1.28.2-rc1+rke2r1", 1, 28, 2, "-rc1", "rke2r1"},
+		{"v0.1.0", 0, 1, 0, "", ""},
+		{"v0.1.0", 0, 1, 0, "", ""},
+	}
+
+	for _, tt := range tests {
+		v, err := ParseVersion(tt.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tt.major != v.Major {
+			t.Fatalf("expected %d, got %d", tt.major, v.Major)
+		}
+		if tt.minor != v.Minor {
+			t.Fatalf("expected %d, got %d", tt.minor, v.Minor)
+		}
+		// assert.NoError(t, err)
+		// assert.Equal(t, tt.major, v.Major)
+		// assert.Equal(t, tt.minor, v.Minor)
+	}
+}
+
+func TestParsePattern(t *testing.T) {
+	tests := []struct {
+		pattern    string
+		major      *int
+		minor      *int
+		patch      *int
+		prerelease string
+		build      string
+	}{
+		{"v1.0.1", types.IntPtr(1), types.IntPtr(0), types.IntPtr(1), "", ""},
+		{"v2.1.3", types.IntPtr(2), types.IntPtr(1), types.IntPtr(3), "", ""},
+		{"v0.0.0", types.IntPtr(0), types.IntPtr(0), types.IntPtr(0), "", ""},
+		{"v0.0.0-rc1+abc", types.IntPtr(0), types.IntPtr(0), types.IntPtr(0), "-rc1", "+abc"},
+		{"v1", types.IntPtr(1), nil, nil, "", ""},
+		{"v0.x", types.IntPtr(0), nil, nil, "", ""},
+		{"v2.8.x", types.IntPtr(2), types.IntPtr(8), nil, "", ""},
+	}
+
+	for _, tt := range tests {
+		p, err := ParsePattern(tt.pattern)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p == nil {
+			t.Fatal("pattern is nil")
+		}
+
+		if tt.major == nil {
+			if p.Major != nil {
+				t.Fatalf("expected nil, got %d", *p.Major)
+			}
+		} else {
+			if p.Major == nil {
+				t.Fatalf("expected %d, got nil", tt.major)
+			}
+			if *tt.major != *p.Major {
+				t.Fatalf("expected %d, got %d", tt.major, p.Major)
+			}
+		}
+
+		if tt.minor == nil {
+			if p.Minor != nil {
+				t.Fatalf("expected nil, got %d", *p.Minor)
+			}
+		} else {
+			if p.Minor == nil {
+				t.Fatalf("expected %d, got nil", tt.minor)
+			}
+			if *tt.minor != *p.Minor {
+				t.Fatalf("expected %d, got %d", tt.minor, p.Minor)
+			}
+		}
+
+		if tt.patch == nil {
+			if p.Patch != nil {
+				t.Fatalf("expected nil, got %d", *p.Patch)
+			}
+		} else {
+			if p.Patch == nil {
+				t.Fatalf("expected %d, got nil", tt.patch)
+			}
+			if *tt.patch != *p.Patch {
+				t.Fatalf("expected %d, got %d", tt.patch, p.Patch)
+			}
+		}
+
+		if tt.prerelease != p.Prerelease {
+			t.Fatalf("expected %s, got %s", tt.prerelease, p.Prerelease)
+		}
+		if tt.build != p.Build {
+			t.Fatalf("expected %s, got %s", tt.build, p.Build)
+		}
+	}
+}
+
+func TestPatternTest(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		version  string
+		result   bool
+		hasError bool
+	}{
+		{"v1.0.0", "v1.0.0", true, false},
+		{"v1.0.0", "v1.0.1", false, false},
+		{"v1.0.1", "v1.0.1", true, false},
+		{"v1.0.1", "v1.0.2", false, false},
+		{"v1.0.1", "v1.0.0", false, false},
+		{"v1.0.1", "v1.0.1-rc1", true, false},
+		{"v1.0.1-rc1", "v1.0.1-rc1", true, false},
+		{"v1.0.1-rc1", "v1.0.1-rc2", false, false},
+		{"v1.0.1+abc", "v1.0.1+abc", true, false},
+		{"v1.0+abc", "v1.0.1+abc", true, false},
+		{"v1.0.x+abc", "v1.0.1+abc", true, false},
+		{"v1.0.1+abc", "v1.0.1+abc", true, false},
+		{"v1.0.1-rc1+abc", "v1.0.1+abc", false, false},
+		{"v1.0.1", "v1.0.1+abc", true, false},
+		{"v2.8.x", "v2.8.1", true, false},
+		{"v2.8.x", "v2.8.10-rc1", true, false},
+	}
+
+	for _, tt := range tests {
+		pattern, err := ParsePattern(tt.pattern)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pattern == nil {
+			t.Fatal("pattern is nil")
+		}
+
+		version, err := ParseVersion(tt.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if version == nil {
+			t.Fatal("version is nil")
+		}
+
+		result, err := pattern.Test(version)
+		if !tt.hasError && err != nil {
+			t.Fatal(err)
+
+		}
+		if tt.result != result {
+			t.Fatalf("expected %t, got %t", tt.result, result)
+		}
+	}
+}


### PR DESCRIPTION
- Adds a package for parsing semantic versions, and for testing a semantic version range.
- Adds a command `semv`

Using `semv`

```sh
semv -parse v1.2.3-rc1 -o go-template="{{.Major}}.{{.Minor}}.{{.Patch}}"
# 1.2.3-rc1
semv -parse v1.2.3-rc1 -o go-template="{{.Major}}.{{.Minor}}.{{.Patch}}"
# -rc1
```

```sh
semv -pattern v1.x -test v1.2.3
# exit 0
semv -pattern v1.1 -test v1.2.3
# exit 1
```