### PR TITLE
remove unused fi in rancher-release set-kdm-branch

### DIFF
--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -18,7 +18,7 @@ Results are printed in MD, and can be pasted into Slack, but formatting is trick
 **Examples**
 
 ```
-rancher_release list-nonmirrored-rc-images --tag v2.6
+rancher_release list-nonmirrored-rc-images --tag v2.8.0-rc1
 ```
 
 ### check-rancher-image
@@ -32,7 +32,7 @@ Checks if there’s an available Helm Chart and Docker images for amd64, arm and
 **Examples**
 
 ```
-rancher_release check-rancher-image --tag v2.6
+rancher_release check-rancher-image --tag v2.8.0-rc1
 ```
 
 ### set-kdm-branch-refs

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -56,7 +56,6 @@ Linux)
 	exit 1
 	;;
 esac
-fi
 git add pkg/settings/setting.go
 git add package/Dockerfile
 git add Dockerfile.dapper


### PR DESCRIPTION
* Removes an unused `fi` in rancher-release set-kdm-branch
* Updates docs