### PR TITLE
Command to check Rancher dependencies for a RC 

### DIFF
--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -160,7 +160,7 @@ The pattern of files to be checked includes:
 | `commit`, `c`    | Commit used to get all files during the check, required for remote execution                           | FALSE         |
 | `org`, `o`       | Reference organization of the commit, as default `rancher`                                                                                                                            | FALSE        |
 | `repo`, `r`      | Reference repository of the commit, as default `rancher`                                                                     | FALSE        |
-| `files`, `f`     | List of files to be checked by the command, required for remote execution                                   | TRUE         |
+| `files`, `f`     | List of files to be checked by the command                                   | FALSE         |
 | `for-ci`, `p`    | With this flag, it's possible to return an error if any of the files contain 'rc' tags or 'dev' dependencies, ideal for use in integration pipelines | FALSE        |
 
 **Examples**

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -144,7 +144,7 @@ rancher_release label-issues -t v2.8.1-rc1 --dry-run
 
 ### check-rancher-rc-deps
 
-This command checks Rancher by the commit hash in the selected files, verifying if they contain 'rc' and 'dev' dependencies. It generates an MD-formatted file print that can be used as a release description. If necessary, the command can generate an error if these dependencies are found, ideal for use in CI pipelines. When executed in the root of the Rancher project, it checks the `rancher-images.txt` and `rancher-windows-images.txt` files.
+This command checks Rancher verifying if contains 'rc' and 'dev' dependencies for some files, this command could be used locally or remotely by commit hash. It generates an MD-formatted file print that can be used as a release description. If necessary, the command can generate an error if these dependencies are found, ideal for use in CI pipelines. 
 
 The pattern of files to be checked includes:
 - `pkg/settings/setting.go`
@@ -157,14 +157,18 @@ The pattern of files to be checked includes:
 
 | **Flag**         | **Description**                                                                                       | **Required** |
 | ---------------- | ----------------------------------------------------------------------------------------------------- | ------------ |
-| `commit`, `c`    | Required commit to find the Rancher project reference that will be executed                            | TRUE         |
-| `org`, `o`       | Reference organization of the commit                                                                   | FALSE        |
-| `repo`, `r`      | Reference repository of the commit                                                                     | FALSE        |
-| `files`, `f`     | List of files to be checked by the command, they are mandatory                                         | TRUE         |
+| `commit`, `c`    | Commit used to get all files during the check, required for remote execution                           | FALSE         |
+| `org`, `o`       | Reference organization of the commit, as default `rancher`                                                                                                                            | FALSE        |
+| `repo`, `r`      | Reference repository of the commit, as default `rancher`                                                                     | FALSE        |
+| `files`, `f`     | List of files to be checked by the command, required for remote execution                                   | TRUE         |
 | `for-ci`, `p`    | With this flag, it's possible to return an error if any of the files contain 'rc' tags or 'dev' dependencies, ideal for use in integration pipelines | FALSE        |
 
 **Examples**
-
+LOCAL
+```
+rancher_release check-rancher-rc-deps
+```
+REMOTE
 ```
 rancher_release check-rancher-rc-deps -c <HASH_COMMIT> -f Dockerfile.dapper,go.mod,/package/Dockerfile,/pkg/apis/go.mod,/pkg/settings/setting.go,/scripts/package-env
 ```

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -174,6 +174,15 @@ rancher_release check-rancher-rc-deps -c <HASH_COMMIT> -f Dockerfile.dapper,go.m
 ```
 
 ```
+# Images with -rc
+
+* rancher/backup-restore-operator v4.0.0-rc1 (/bin/rancher-images.txt, line 1)
+* rancher/fleet v0.9.0-rc.5 (/bin/rancher-images.txt, line 1)
+* rancher/fleet-agent v0.9.0-rc.5 (/bin/rancher-images.txt, line 1)
+* rancher/rancher v2.8.0-rc3 (/bin/rancher-windows-images.txt, line 1)
+* rancher/rancher-agent v2.8.0-rc3 (/bin/rancher-windows-images.txt, line 1)
+* rancher/system-agent v0.3.4-rc1-suc (/bin/rancher-windows-images.txt, line 1)
+
 # Components with -rc
 
 * github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.1.0-rc2 // needed for containers/image/v5 (go.mod, line 15)

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -170,40 +170,42 @@ rancher_release check-rancher-rc-deps -c <HASH_COMMIT> -f Dockerfile.dapper,go.m
 ```
 
 ```
-# Images with -rc
-
-* rancher/backup-restore-operator v4.0.0-rc1 (./bin/rancher-images.txt, line 1)
-* rancher/rancher v2.8.0-rc3 (./bin/rancher-windows-images.txt, line 1)
-* rancher/rancher-agent v2.8.0-rc3 (./bin/rancher-windows-images.txt, line 2)
-* rancher/system-agent v0.3.4-rc1-suc (./bin/rancher-windows-images.txt, line 3)
-
 # Components with -rc
 
-* ENV CATTLE_KDM_BRANCH=dev-v2.8 (Dockerfile.dapper, line 16)
-* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
-* ARG CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
-* ARG CATTLE_KDM_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
-* KDMBranch = NewSetting("kdm-branch", "dev-v2.8") (/pkg/settings/setting.go, line 84)
-* ChartDefaultBranch = NewSetting("chart-default-branch", "dev-v2.8") (/pkg/settings/setting.go, line 116)
-* SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 5)
-* CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 7)
+* github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.1.0-rc2 // needed for containers/image/v5 (go.mod, line 15)
+* github.com/rancher/aks-operator v1.2.0-rc4 (go.mod, line 111)
+* github.com/rancher/dynamiclistener v0.3.6-rc3-deadlock-fix-revert (go.mod, line 114)
+* github.com/rancher/eks-operator v1.3.0-rc3 (go.mod, line 115)
+* github.com/rancher/gke-operator v1.2.0-rc2 (go.mod, line 117)
+* github.com/rancher/rke v1.5.0-rc5 (go.mod, line 124)
+* github.com/opencontainers/image-spec v1.1.0-rc3 // indirect (go.mod, line 370)
+* ENV CATTLE_RANCHER_WEBHOOK_VERSION=103.0.0+up0.4.0-rc9 (/package/Dockerfile, line 26)
+* ENV CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0-rc1 (/package/Dockerfile, line 27)
+* ENV CATTLE_CLI_VERSION v2.8.0-rc1 (/package/Dockerfile, line 48)
+* github.com/rancher/aks-operator v1.2.0-rc4 (/pkg/apis/go.mod, line 11)
+* github.com/rancher/eks-operator v1.3.0-rc3 (/pkg/apis/go.mod, line 12)
+* github.com/rancher/gke-operator v1.2.0-rc2 (/pkg/apis/go.mod, line 14)
+* github.com/rancher/rke v1.5.0-rc5 (/pkg/apis/go.mod, line 16)
+* ShellImage = NewSetting("shell-image", "rancher/shell:v0.1.21-rc1") (/pkg/settings/setting.go, line 121)
 
 # Min version components with -rc
 
 * ENV CATTLE_FLEET_MIN_VERSION=103.1.0+up0.9.0-rc.3
 * ENV CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0-rc1
 
-# Components with dev-
+# KDM References with dev branch
 
 * ENV CATTLE_KDM_BRANCH=dev-v2.8 (Dockerfile.dapper, line 16)
-* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
-* ARG CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
 * ARG CATTLE_KDM_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
 * KDMBranch = NewSetting("kdm-branch", "dev-v2.8") (/pkg/settings/setting.go, line 84)
+
+# Chart References with dev branch
+
+* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* ARG CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
 * ChartDefaultBranch = NewSetting("chart-default-branch", "dev-v2.8") (/pkg/settings/setting.go, line 116)
 * SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 5)
 * CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 7)
-
 ```
 
 ## Contributions

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -142,6 +142,70 @@ rancher_release label-issues -t v2.8.1-rc1 --dry-run
 #   [Waiting for RC] -> [To Test]
 ```
 
+### check-rancher-rc-deps
+
+This command checks Rancher by the commit hash in the selected files, verifying if they contain 'rc' and 'dev' dependencies. It generates an MD-formatted file print that can be used as a release description. If necessary, the command can generate an error if these dependencies are found, ideal for use in CI pipelines. When executed in the root of the Rancher project, it checks the `rancher-images.txt` and `rancher-windows-images.txt` files.
+
+The pattern of files to be checked includes:
+- `pkg/settings/setting.go`
+- `package/Dockerfile`
+- `scripts/package-env`
+- `Dockerfile.dapper`
+- `go.mod`
+- `pkg/apis/go.mod`
+- `pkg/client/go.mod`
+
+| **Flag**         | **Description**                                                                                       | **Required** |
+| ---------------- | ----------------------------------------------------------------------------------------------------- | ------------ |
+| `commit`, `c`    | Required commit to find the Rancher project reference that will be executed                            | TRUE         |
+| `org`, `o`       | Reference organization of the commit                                                                   | FALSE        |
+| `repo`, `r`      | Reference repository of the commit                                                                     | FALSE        |
+| `files`, `f`     | List of files to be checked by the command, they are mandatory                                         | TRUE         |
+| `for-ci`, `p`    | With this flag, it's possible to return an error if any of the files contain 'rc' tags or 'dev' dependencies, ideal for use in integration pipelines | FALSE        |
+
+**Examples**
+
+```
+rancher_release check-rancher-rc-deps -c <HASH_COMMIT> -f Dockerfile.dapper,go.mod,/package/Dockerfile,/pkg/apis/go.mod,/pkg/settings/setting.go,/scripts/package-env
+```
+
+```
+# Images with -rc
+
+* rancher/backup-restore-operator v4.0.0-rc1 (./bin/rancher-images.txt, line 1)
+* rancher/rancher v2.8.0-rc3 (./bin/rancher-windows-images.txt, line 1)
+* rancher/rancher-agent v2.8.0-rc3 (./bin/rancher-windows-images.txt, line 2)
+* rancher/system-agent v0.3.4-rc1-suc (./bin/rancher-windows-images.txt, line 3)
+
+# Components with -rc
+
+* ENV CATTLE_KDM_BRANCH=dev-v2.8 (Dockerfile.dapper, line 16)
+* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* ARG CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* ARG CATTLE_KDM_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* KDMBranch = NewSetting("kdm-branch", "dev-v2.8") (/pkg/settings/setting.go, line 84)
+* ChartDefaultBranch = NewSetting("chart-default-branch", "dev-v2.8") (/pkg/settings/setting.go, line 116)
+* SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 5)
+* CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 7)
+
+# Min version components with -rc
+
+* ENV CATTLE_FLEET_MIN_VERSION=103.1.0+up0.9.0-rc.3
+* ENV CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0-rc1
+
+# Components with dev-
+
+* ENV CATTLE_KDM_BRANCH=dev-v2.8 (Dockerfile.dapper, line 16)
+* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* ARG CHART_DEFAULT_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* ARG CATTLE_KDM_BRANCH=dev-v2.8 (/package/Dockerfile, line 1)
+* KDMBranch = NewSetting("kdm-branch", "dev-v2.8") (/pkg/settings/setting.go, line 84)
+* ChartDefaultBranch = NewSetting("chart-default-branch", "dev-v2.8") (/pkg/settings/setting.go, line 116)
+* SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 5)
+* CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.8"} (/scripts/package-env, line 7)
+
+```
+
 ## Contributions
 
 - File Issue with details of the problem, feature request, etc.

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/rancher/ecm-distro-tools/release/rancher"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+func checkRancherRCDepsCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "check-rancher-rc-deps",
+		Usage: "check if rancher commit contains the necessary values for a final rc",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "commit",
+				Aliases:  []string{"c"},
+				Usage:    "last commit for a final rc",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "release-title",
+				Aliases:  []string{"rt"},
+				Usage:    "release title from a given release process",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "org",
+				Aliases:  []string{"o"},
+				Usage:    "organization name, e.g rancher,suse",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "repo",
+				Aliases:  []string{"r"},
+				Usage:    "repository from process",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "files",
+				Aliases:  []string{"f"},
+				Usage:    "files to be checked",
+				Required: false,
+			},
+		},
+		Action: checkRancherRCDeps,
+	}
+}
+
+func checkRancherRCDeps(c *cli.Context) error {
+	rcReleaseTitle := c.String("release-title")
+	rcCommit := c.String("commit")
+	rcOrg := c.String("org")
+	rcRepo := c.String("repo")
+	rcFiles := c.String("files")
+
+	if rcFiles == "" {
+		return errors.New("'files' is required, e.g  --files Dockerfile.dapper,go.mod ")
+	}
+	if rcCommit == "" && rcReleaseTitle == "" {
+		return errors.New("'commit' or 'release-title' are required")
+	}
+	if rcOrg == "" {
+		return errors.New("'org' is required")
+	}
+	logrus.Debug("commit: " + rcCommit)
+
+	return rancher.CheckRancherFinalRCDeps(rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+}

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/sirupsen/logrus"
@@ -64,5 +65,12 @@ func checkRancherRCDeps(c *cli.Context) error {
 	logrus.Debugf("organization: %s, repository: %s, commit: %s, release title: %s, files: %s",
 		rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
 
-	return rancher.CheckRancherFinalRCDeps(rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+	output, err := rancher.CheckRancherFinalRCDeps(rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(output)
+
+	return nil
 }

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -44,6 +44,12 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Usage:    "files to be checked",
 				Required: true,
 			},
+			&cli.BoolFlag{
+				Name:     "template",
+				Aliases:  []string{"m"},
+				Usage:    "export as MD template",
+				Required: false,
+			},
 		},
 		Action: checkRancherRCDeps,
 	}
@@ -55,6 +61,7 @@ func checkRancherRCDeps(c *cli.Context) error {
 	rcOrg := c.String("org")
 	rcRepo := c.String("repo")
 	rcFiles := c.String("files")
+	toTemplate := c.String("template")
 
 	if rcCommit == "" && rcReleaseTitle == "" {
 		return errors.New("'commit' or 'release-title' are required")

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/sirupsen/logrus"
@@ -18,12 +17,6 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "commit",
 				Aliases:  []string{"c"},
 				Usage:    "last commit for a final rc",
-				Required: false,
-			},
-			&cli.StringFlag{
-				Name:     "release-title",
-				Aliases:  []string{"t"},
-				Usage:    "release title from a given release process",
 				Required: false,
 			},
 			&cli.StringFlag{
@@ -56,28 +49,24 @@ func checkRancherRCDepsCommand() *cli.Command {
 }
 
 func checkRancherRCDeps(c *cli.Context) error {
-	rcReleaseTitle := c.String("release-title")
 	rcCommit := c.String("commit")
 	rcOrg := c.String("org")
 	rcRepo := c.String("repo")
 	rcFiles := c.String("files")
 	forCi := c.Bool("for-ci")
 
-	if rcCommit == "" && rcReleaseTitle == "" {
-		return errors.New("'commit' or 'release-title' are required")
+	if rcCommit == "" {
+		return errors.New("'commit hash' are required")
 	}
 	if rcFiles == "" {
 		return errors.New("'files' is required, e.g, --files Dockerfile.dapper,go.mod")
 	}
-	logrus.Debugf("organization: %s, repository: %s, commit: %s, release title: %s, files: %s",
-		rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+	logrus.Debugf("organization: %s, repository: %s, commit: %s, files: %s",
+		rcOrg, rcRepo, rcCommit, rcFiles)
 
-	output, err := rancher.CheckRancherRCDeps(forCi, rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+	err := rancher.CheckRancherRCDeps(forCi, rcOrg, rcRepo, rcCommit, rcFiles)
 	if err != nil {
 		return err
 	}
-
-	fmt.Println(output)
-
 	return nil
 }

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -17,7 +17,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "commit",
 				Aliases:  []string{"c"},
 				Usage:    "last commit for a final rc",
-				Required: true,
+				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "release-title",
@@ -29,7 +29,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "org",
 				Aliases:  []string{"o"},
 				Usage:    "organization name",
-				Required: false,
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "repo",
@@ -41,7 +41,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "files",
 				Aliases:  []string{"f"},
 				Usage:    "files to be checked",
-				Required: false,
+				Required: true,
 			},
 		},
 		Action: checkRancherRCDeps,

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -17,7 +17,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "commit",
 				Aliases:  []string{"c"},
 				Usage:    "last commit for a final rc",
-				Required: false,
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "org",
@@ -40,7 +40,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:     "for-ci",
 				Aliases:  []string{"p"},
-				Usage:    "export a md template also check raising a error if contains rc tags and dev deps",
+				Usage:    "export a md template also check raising an error if contains rc tags and dev deps",
 				Required: false,
 			},
 		},

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -11,7 +11,7 @@ import (
 func checkRancherRCDepsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "check-rancher-rc-deps",
-		Usage: "check if the Rancher version specified by the commit does not contain development dependencies and rc tags",
+		Usage: "check if the Rancher version specified by the commit or pre-release title does not contain development dependencies and rc tags",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "commit",
@@ -29,7 +29,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Name:     "org",
 				Aliases:  []string{"o"},
 				Usage:    "organization name",
-				Required: true,
+				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "repo",
@@ -60,9 +60,6 @@ func checkRancherRCDeps(c *cli.Context) error {
 	}
 	if rcFiles == "" {
 		return errors.New("'files' is required, e.g, --files Dockerfile.dapper,go.mod")
-	}
-	if rcOrg == "" {
-		return errors.New("'org' is required")
 	}
 	logrus.Debugf("organization: %s, repository: %s, commit: %s, release title: %s, files: %s",
 		rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/sirupsen/logrus"
@@ -62,13 +61,10 @@ func checkRancherRCDeps(c *cli.Context) error {
 	rcFiles := c.String("files")
 	forCi := c.Bool("for-ci")
 
-	if rcCommit == "" {
-		if rcFiles != "" {
-			return errors.New("'commit hash' are required for remote operation")
-		}
-	}
 	if rcFiles == "" {
 		rcFiles = files
+	}
+	if rcCommit == "" {
 		local = true
 	}
 

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -11,7 +11,7 @@ import (
 func checkRancherRCDepsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "check-rancher-rc-deps",
-		Usage: "check if rancher commit contains the necessary values for a final rc",
+		Usage: "check if the Rancher version specified by the commit does not contain development dependencies and rc tags",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "commit",
@@ -28,13 +28,13 @@ func checkRancherRCDepsCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:     "org",
 				Aliases:  []string{"o"},
-				Usage:    "organization name, e.g rancher,suse",
+				Usage:    "organization name",
 				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "repo",
 				Aliases:  []string{"r"},
-				Usage:    "repository from process",
+				Usage:    "rancher repository from process",
 				Required: false,
 			},
 			&cli.StringFlag{
@@ -55,16 +55,17 @@ func checkRancherRCDeps(c *cli.Context) error {
 	rcRepo := c.String("repo")
 	rcFiles := c.String("files")
 
-	if rcFiles == "" {
-		return errors.New("'files' is required, e.g  --files Dockerfile.dapper,go.mod ")
-	}
 	if rcCommit == "" && rcReleaseTitle == "" {
 		return errors.New("'commit' or 'release-title' are required")
+	}
+	if rcFiles == "" {
+		return errors.New("'files' is required, e.g, --files Dockerfile.dapper,go.mod")
 	}
 	if rcOrg == "" {
 		return errors.New("'org' is required")
 	}
-	logrus.Debug("commit: " + rcCommit)
+	logrus.Debugf("organization: %s, repository: %s, commit: %s, release title: %s, files: %s",
+		rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
 
 	return rancher.CheckRancherFinalRCDeps(rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
 }

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -47,7 +47,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:     "for-ci",
 				Aliases:  []string{"p"},
-				Usage:    "instead export a md template run a check raising a error if contains rc tags and dev deps",
+				Usage:    "export a md template also check raising a error if contains rc tags and dev deps",
 				Required: false,
 			},
 		},

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -45,9 +45,9 @@ func checkRancherRCDepsCommand() *cli.Command {
 				Required: true,
 			},
 			&cli.BoolFlag{
-				Name:     "template",
-				Aliases:  []string{"m"},
-				Usage:    "export as MD template",
+				Name:     "for-ci",
+				Aliases:  []string{"p"},
+				Usage:    "instead export a md template run a check raising a error if contains rc tags and dev deps",
 				Required: false,
 			},
 		},
@@ -61,7 +61,7 @@ func checkRancherRCDeps(c *cli.Context) error {
 	rcOrg := c.String("org")
 	rcRepo := c.String("repo")
 	rcFiles := c.String("files")
-	toTemplate := c.String("template")
+	forCi := c.Bool("for-ci")
 
 	if rcCommit == "" && rcReleaseTitle == "" {
 		return errors.New("'commit' or 'release-title' are required")
@@ -72,7 +72,7 @@ func checkRancherRCDeps(c *cli.Context) error {
 	logrus.Debugf("organization: %s, repository: %s, commit: %s, release title: %s, files: %s",
 		rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
 
-	output, err := rancher.CheckRancherFinalRCDeps(rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
+	output, err := rancher.CheckRancherRCDeps(forCi, rcOrg, rcRepo, rcCommit, rcReleaseTitle, rcFiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/rancher_release/check_rancher_rc_deps.go
+++ b/cmd/rancher_release/check_rancher_rc_deps.go
@@ -21,7 +21,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:     "release-title",
-				Aliases:  []string{"rt"},
+				Aliases:  []string{"t"},
 				Usage:    "release title from a given release process",
 				Required: false,
 			},
@@ -34,7 +34,7 @@ func checkRancherRCDepsCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:     "repo",
 				Aliases:  []string{"r"},
-				Usage:    "rancher repository from process",
+				Usage:    "rancher repository",
 				Required: false,
 			},
 			&cli.StringFlag{

--- a/cmd/rancher_release/main.go
+++ b/cmd/rancher_release/main.go
@@ -31,6 +31,7 @@ func main() {
 		checkRancherImageCommand(),
 		setKDMBranchReferencesCommand(),
 		setChartsBranchReferencesCommand(),
+		checkRancherRCDepsCommand(),
 	}
 	app.Flags = rootFlags
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -320,14 +320,12 @@ func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, 
 }
 
 func createPRFromRancher(ctx context.Context, rancherBaseBranch, title, branchName, forkOwner string, ghClient *github.Client) error {
-
 	pull := &github.NewPullRequest{
 		Title:               github.String(title),
 		Base:                github.String(rancherBaseBranch),
 		Head:                github.String(forkOwner + ":" + branchName),
 		MaintainerCanModify: github.Bool(true),
 	}
-
 	_, _, err := ghClient.PullRequests.Create(ctx, "rancher", "rancher", pull)
 
 	return err

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -345,7 +345,6 @@ type Content struct {
 }
 
 func CheckRancherRCDeps(forCi bool, org, repo, commitHash, files string) error {
-	const partialFinalRCCommitMessage = "commit for final rc"
 	var (
 		matchCommitMessage bool
 		badFiles           bool
@@ -362,13 +361,6 @@ func CheckRancherRCDeps(forCi bool, org, repo, commitHash, files string) error {
 	}
 	if org == "" {
 		org = rancherOrg
-	}
-	if commitHash != "" {
-		commitData, err := repository.CommitInfo(org, repo, commitHash, &httpClient)
-		if err != nil {
-			return err
-		}
-		matchCommitMessage = strings.Contains(commitData.Message, partialFinalRCCommitMessage)
 	}
 
 	//should return data if executed in rancher project root path

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -360,7 +360,7 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 			return "", errors.New("check failed, some files don't match the expected dependencies for a final release candidate")
 		}
 
-		output += "check completed successfully \n"
+		output += "check completed successfully"
 		return output, nil
 	}
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -285,9 +285,13 @@ func createPRFromRancher(ctx context.Context, rancherBaseBranch, title, branchNa
 }
 
 func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) error {
-	var matchCommitMessage bool
-	var existsReleaseTitle bool
-	var badFiles bool
+	var (
+		devDependencyPattern = regexp.MustCompile(`dev-v[0-9]+\.[0-9]+`)
+		rcTagPattern         = regexp.MustCompile(`-rc[0-9]+`)
+		matchCommitMessage   bool
+		existsReleaseTitle   bool
+		badFiles             bool
+	)
 
 	httpClient := ecmHTTP.NewClient(time.Second * 15)
 
@@ -317,11 +321,11 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 				return err
 			}
 
-			if regexp.MustCompile(`dev-v[0-9]+\.[0-9]+`).Match(content) {
+			if devDependencyPattern.Match(content) {
 				badFiles = true
 				logrus.Info("error: " + filePath + " contains dev dependencies")
 			}
-			if regexp.MustCompile(`-rc[0-9]+`).Match(content) {
+			if rcTagPattern.Match(content) {
 				badFiles = true
 				logrus.Info("error: " + filePath + " contains rc tags")
 			}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -297,6 +297,9 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 	if repo == "" {
 		repo = rancherRepo
 	}
+	if org == "" {
+		org = rancherOrg
+	}
 	if commitHash != "" {
 		commitData, err := repository.CommitInfo(org, repo, commitHash, &httpClient)
 		if err != nil {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -334,17 +334,17 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 			lineNum := 1
 
 			for scanner.Scan() {
-				line := scanner.Text()
+				line := strings.TrimSpace(scanner.Text())
 				lineByte := []byte(line)
 
 				if devDependencyPattern.Match(lineByte) {
 					badFiles = true
-					logMessage := fmt.Sprintf("error: %s contains dev dependencies (line %d) - %s", filePath, lineNum, line)
+					logMessage := fmt.Sprintf("file: %s, line: %d, content: '%s' contains dev dependencies", filePath, lineNum, line)
 					logrus.Info(logMessage)
 				}
 				if rcTagPattern.Match(lineByte) {
 					badFiles = true
-					logMessage := fmt.Sprintf("error: %s contains rc tags (line %d) - %s", filePath, lineNum, line)
+					logMessage := fmt.Sprintf("file: %s, line: %d, content: '%s' contains rc tags", filePath, lineNum, line)
 					logrus.Info(logMessage)
 				}
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -360,7 +360,7 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 			return "", errors.New("check failed, some files don't match the expected dependencies for a final release candidate")
 		}
 
-		output += "check completed successfully" + "\n"
+		output += "check completed successfully \n"
 		return output, nil
 	}
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -120,8 +120,8 @@ const templateCheckRCDevDeps = `{{- define "componentsFile" -}}
 
 # Min version components with -rc
 {{range .MinFilesWithRC}}
-* {{ .Content }}
-{{- end}}
+* {{ .Content }} ({{ .File }}, line {{ .Line }})
+{{- end}} 
 
 # KDM References with dev branch
 {{range .KDMWithDev}}
@@ -382,6 +382,12 @@ func CheckRancherRCDeps(ctx context.Context, local, forCi bool, org, repo, commi
 
 		for scanner.Scan() {
 			line := scanner.Text()
+			if strings.Contains(filePath, "bin/rancher") {
+				badFiles = true
+				lineContent := ContentLine{File: filePath, Line: lineNum, Content: formatContentLine(line)}
+				content.RancherImages = append(content.RancherImages, lineContent)
+				continue
+			}
 			if devDependencyPattern.MatchString(line) {
 				lineContent := ContentLine{File: filePath, Line: lineNum, Content: formatContentLine(line)}
 				lineContentLower := strings.ToLower(lineContent.Content)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -348,7 +348,6 @@ type Content struct {
 	MinFilesWithRC []ContentLine
 	ChartsWithDev  []ContentLine
 	KDMWithDev     []ContentLine
-	WithDev        []ContentLine
 }
 
 func CheckRancherRCDeps(forCi bool, org, repo, commitHash, files string) error {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -331,13 +331,13 @@ func CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files string) 
 			}
 		}
 		if badFiles {
-			return errors.New("Check failed, some files don't match the expected dependencies for a final release candidate")
+			return errors.New("check failed, some files don't match the expected dependencies for a final release candidate")
 		}
 
-		logrus.Info("Check completed successfully")
+		logrus.Info("check completed successfully")
 		return nil
 	}
 
-	logrus.Info("Skipped check")
+	logrus.Info("skipped check")
 	return nil
 }

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -1,10 +1,15 @@
 package rancher
 
 import (
+	"errors"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNonMirroredRCImages(t *testing.T) {
@@ -58,4 +63,49 @@ func TestRancherHelmChartVersions(t *testing.T) {
 	if !reflect.DeepEqual(expectedVersions, versions) {
 		t.Errorf("expected %v, got %v", expectedVersions, versions)
 	}
+}
+
+func TestCheckRancherFinalRCDeps(t *testing.T) {
+	org := "testOrg"
+	repo := "testRepo"
+	commitHash := "testHash"
+	releaseTitle := "Pre-release v2.7.1-rc1"
+	files := "file1,file2"
+
+	t.Run("Valid CheckRancherFinalRCDeps", func(t *testing.T) {
+		httpClient := &MockHTTPClient{Response: "dev-v2.7.1"}
+		err := CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files, &httpClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid CheckRancherFinalRCDeps with Dev Dependency", func(t *testing.T) {
+		httpClient := &MockHTTPClient{Response: "dev-v3.0"}
+		err := CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files, &httpClient)
+		expectedError := errors.New("Check failed, some files don't match the expected dependencies for a final release candidate")
+		assert.EqualError(t, err, expectedError.Error())
+	})
+
+	t.Run("Invalid CheckRancherFinalRCDeps with RC Tag", func(t *testing.T) {
+		httpClient := &MockHTTPClient{Response: "-rc1"}
+		err := CheckRancherFinalRCDeps(org, repo, commitHash, releaseTitle, files, &httpClient)
+		expectedError := errors.New("Check failed, some files don't match the expected dependencies for a final release candidate")
+		assert.EqualError(t, err, expectedError.Error())
+	})
+
+	t.Run("Skipped CheckRancherFinalRCDeps", func(t *testing.T) {
+		httpClient := &MockHTTPClient{Response: "dev-v2.7.1"}
+		err := CheckRancherFinalRCDeps("", "", "", "", "", &httpClient)
+		assert.NoError(t, err)
+	})
+}
+
+type MockHTTPClient struct {
+	Response string
+}
+
+func (c *MockHTTPClient) Get(url string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(strings.NewReader(c.Response)),
+	}, nil
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -54,6 +54,10 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 // NewGithub creates a value of type github.Client pointer
 // with the given context and Github token.
 func NewGithub(ctx context.Context, token string) *github.Client {
+	if token == "" {
+		return github.NewClient(nil)
+	}
+
 	ts := TokenSource{
 		AccessToken: token,
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -431,22 +428,3 @@ To find more information on specific steps, please see documentation [here](http
 - [ ] QA: Final validation of above PR and tracked through the linked ticket
 - [ ] PJM: Close the milestone in GitHub.
 `
-
-func ContentByFileNameAndCommit(owner, repo, commitHash, filePath string, httpClient *http.Client) ([]byte, error) {
-	rawURL := fmt.Sprintf(ghContentURL+"/%s/%s/%s/%s", owner, repo, commitHash, filePath)
-
-	response, err := http.Get(rawURL)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return nil, errors.New("failed to fetch raw file. status code: " + strconv.Itoa(response.StatusCode))
-	}
-	data, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -495,12 +496,11 @@ func CommitInfo(owner, repo, commitHash string, httpClient *http.Client) (*Commi
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		logrus.Debug("Failed to fetch commit information. Status code:", response.StatusCode)
-		return nil, err
+		return nil, errors.New("failed to fetch commit information. status code: " + strconv.Itoa(response.StatusCode))
 	}
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		logrus.Debug("Error reading response body:", err)
+		logrus.Debug("error reading response body:", err)
 		return nil, err
 	}
 
@@ -508,7 +508,7 @@ func CommitInfo(owner, repo, commitHash string, httpClient *http.Client) (*Commi
 
 	err = json.Unmarshal([]byte(data), &commitResponse)
 	if err != nil {
-		logrus.Debug("Error unmarshaling JSON:", err)
+		logrus.Debug("error unmarshaling JSON:", err)
 		return nil, err
 	}
 
@@ -520,17 +520,16 @@ func ContentByFileNameAndCommit(owner, repo, commitHash, filePath string, httpCl
 
 	response, err := http.Get(rawURL)
 	if err != nil {
-		logrus.Debug("Error fetching raw file:", err)
+		logrus.Debug("error fetching raw file:", err)
 		return nil, err
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		logrus.Debug("Failed to fetch raw file. Status code:", response.StatusCode)
-		return nil, err
+		return nil, errors.New("failed to fetch raw file. status code: " + strconv.Itoa(response.StatusCode))
 	}
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		logrus.Debug("Error reading response body:", err)
+		logrus.Debug("error reading response body:", err)
 		return nil, err
 	}
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -463,7 +463,6 @@ To find more information on specific steps, please see documentation [here](http
 - [ ] PJM: Close the milestone in GitHub.
 `
 
-// Partial Body from commit api, fell free to add more fields if needed
 type Author struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
@@ -529,11 +528,11 @@ func ContentByFileNameAndCommit(owner, repo, commitHash, filePath string, httpCl
 		logrus.Debug("Failed to fetch raw file. Status code:", response.StatusCode)
 		return nil, err
 	}
-
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		logrus.Debug("Error reading response body:", err)
 		return nil, err
 	}
+
 	return data, nil
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-github/v39/github"
 	"github.com/rancher/ecm-distro-tools/types"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -495,7 +494,6 @@ func CommitInfo(owner, repo, commitHash string, httpClient *http.Client) (*Commi
 
 	response, err := httpClient.Get(apiUrl)
 	if err != nil {
-		logrus.Debug("Error making request:", err)
 		return nil, err
 	}
 	defer response.Body.Close()
@@ -509,7 +507,6 @@ func CommitInfo(owner, repo, commitHash string, httpClient *http.Client) (*Commi
 	err = json.NewDecoder(response.Body).Decode(&commitResponse)
 	commitResponseMutex.Unlock()
 	if err != nil {
-		logrus.Debug("error unmarshaling JSON:", err)
 		return nil, err
 	}
 
@@ -521,7 +518,6 @@ func ContentByFileNameAndCommit(owner, repo, commitHash, filePath string, httpCl
 
 	response, err := http.Get(rawURL)
 	if err != nil {
-		logrus.Debug("error fetching raw file:", err)
 		return nil, err
 	}
 	defer response.Body.Close()
@@ -530,7 +526,6 @@ func ContentByFileNameAndCommit(owner, repo, commitHash, filePath string, httpCl
 	}
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		logrus.Debug("error reading response body:", err)
 		return nil, err
 	}
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -25,7 +25,6 @@ const (
 	noneReleaseNote    = "```release-note\r\nNONE\r\n```"
 	httpTimeout        = time.Second * 10
 	ghContentURL       = "https://raw.githubusercontent.com"
-	ghAPIURL           = "https://api.github.com"
 )
 
 // stripBackportTag returns a string with a prefix backport tag removed


### PR DESCRIPTION
#### Proposed Changes ####

- Export a md formatted file and check if repository by given commit contains `dev-` and `rc` tags in a sort of files
- Added command line file
- Added logic to validate all given files 

#### Types of Changes ####

- Command line 

#### Testing ####
How to test:

1 - Compile ecm distro-tools with this branch `make`
2 - Repo with wrong deps: 
Local
```
./cmd/rancher_release/bin/rancher_release-linux-amd64 check-rancher-rc-deps 
```
Remote
```
./cmd/rancher_release/bin/rancher_release-linux-amd64 check-rancher-rc-deps -c aa6b3fdb5b402b7ffbf0b7dfd506e9571c8759e5 
```
Example of exportation:

#### Linked Issues ####

https://github.com/rancher/ecm-distro-tools/issues/272

#### User-Facing Change ####

#### Further Comments ####
