### PR TITLE
#246: Remove docker check from rancher image check

### DIFF
--- a/cmd/rancher_release/check_rancher_image.go
+++ b/cmd/rancher_release/check_rancher_image.go
@@ -1,16 +1,9 @@
 package main
 
 import (
-	"context"
-
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-)
-
-const (
-	rancherOrg  = "rancher"
-	rancherRepo = rancherOrg
 )
 
 func checkRancherImageCommand() *cli.Command {
@@ -32,9 +25,5 @@ func checkRancherImageCommand() *cli.Command {
 func checkRancherImage(c *cli.Context) error {
 	tag := c.String("tag")
 	logrus.Debug("tag: " + tag)
-	rancherArchs := []string{"amd64", "arm64", "s390x"}
-	if err := rancher.CheckRancherDockerImage(context.Background(), rancherOrg, rancherRepo, tag, rancherArchs); err != nil {
-		return err
-	}
 	return rancher.CheckHelmChartVersion(tag)
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -169,7 +169,7 @@ func CheckHelmChartVersion(tag string) error {
 	}
 	var foundVersion bool
 	for _, version := range versions {
-		logrus.Debug("checking version " + version)
+		logrus.Info("checking version " + version)
 		if tag == version {
 			logrus.Info("found chart for version " + version)
 			foundVersion = true
@@ -184,7 +184,7 @@ func CheckHelmChartVersion(tag string) error {
 
 func rancherHelmChartVersions(repoURL string) ([]string, error) {
 	httpClient := ecmHTTP.NewClient(time.Second * 15)
-	logrus.Debug("downloading: " + repoURL)
+	logrus.Info("downloading: " + repoURL)
 	resp, err := httpClient.Get(repoURL)
 	if err != nil {
 		return nil, err

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/rancher/ecm-distro-tools/docker"
 	"github.com/rancher/ecm-distro-tools/exec"
 	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
 	"github.com/rancher/ecm-distro-tools/repository"
@@ -161,10 +160,6 @@ func rancherImages(imagesURL string) (string, error) {
 		return "", err
 	}
 	return string(images), nil
-}
-
-func CheckRancherDockerImage(ctx context.Context, org, repo, tag string, archs []string) error {
-	return docker.CheckImageArchs(ctx, org, repo, tag, archs)
 }
 
 func CheckHelmChartVersion(tag string) error {


### PR DESCRIPTION
Closes: #246 

## Changes
* Remove docker check

## How to test
```
make rancher_release && cmd/rancher_release/bin/rancher_release-darwin-arm64 check-rancher-image -t v2.8.0-rc1
```