### PR TITLE
#253, #252: automate set refs flags

### DIFF
--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -43,7 +43,7 @@ Updates Rancher KDM branch references in:
 - `package/Dockerfile`
 - `Dockerfile.dapper`
 
-Non-required flags can be automatically set, if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
+Optional flags can be automatically set if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
 
 | **Flag**              | **Description**                                                                                                                                                                               | **Required** |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -45,14 +45,14 @@ Updates Rancher KDM branch references in:
 
 Non-required flags can be automatically set, if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
 
-| **Flag**               | **Description**                                                                                                                                                                               | **Required** |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `fork-path`, `f`       | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
-| `base-branch`, `b`     | The branch you want to update with the new KDM branch. Default is the current branch in your repo.                                                                                            | FALSE        |
-| `new-kdm-branch`, `n`  | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
-| `create-pr`, `p`       | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
-| `github-username`, `u` | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
-| `dry-run`, `r`         | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
+| **Flag**              | **Description**                                                                                                                                                                               | **Required** |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `fork-path`, `f`      | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
+| `base-branch`, `b`    | The branch you want to update with the new KDM branch. Default is the current branch in your repo.                                                                                            | FALSE        |
+| `new-kdm-branch`, `n` | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
+| `create-pr`, `p`      | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
+| `github-user`, `u`    | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
+| `dry-run`, `r`        | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
 
 **Examples**
 

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -45,14 +45,14 @@ Updates Rancher KDM branch references in:
 
 Non-required flags can be automatically set, if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
 
-| **Flag**              | **Description**                                                                                                                                                                               | **Required** |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `fork-path`, `f`      | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
-| `base-branch`, `b`    | The branch you want to update with the new KDM branch. Default is the current branch in your repo.                                                                                            | FALSE        |
-| `new-kdm-branch`, `n` | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
-| `create-pr`, `p`      | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
-| `fork-owner`, `o`     | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
-| `dry-run`, `r`        | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
+| **Flag**               | **Description**                                                                                                                                                                               | **Required** |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `fork-path`, `f`       | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
+| `base-branch`, `b`     | The branch you want to update with the new KDM branch. Default is the current branch in your repo.                                                                                            | FALSE        |
+| `new-kdm-branch`, `n`  | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
+| `create-pr`, `p`       | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
+| `github-username`, `u` | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
+| `dry-run`, `r`         | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
 
 **Examples**
 
@@ -76,7 +76,7 @@ rancher_release set-kdm-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_USE
 ```
 export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
 
-rancher_release set-kdm-branch-refs -f $GOPATH/src/github.com/{YOUR_USERNAME}/rancher -b release/v2.8 -c dev-v2.8 -n dev-v2.8-september-patches -p -o {YOUR_USERNAME}
+rancher_release set-kdm-branch-refs -f $GOPATH/src/github.com/{YOUR_USERNAME}/rancher -b release/v2.8 -c dev-v2.8 -n dev-v2.8-september-patches -p -u {YOUR_USERNAME}
 ```
 
 ### set-charts-branch-refs

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -85,22 +85,34 @@ Updates Rancher branch references in charts:
 
 - `pkg/settings/setting.go`
 - `package/Dockerfile`
-- `Dockerfile.dapper`
+- `scripts/package-env`
 
-| **Flag**                     | **Description**                                                                                                                                                                               | **Required** |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `fork-path`, `f`             | Path for your fork of rancher/rancher.                                                                                                                                                        | TRUE         |
-| `base-branch`, `b`           | The branch you want to update.                                                                                                                                                                | TRUE         |
-| `current-charts-branch`, `c` | Current branch for charts used in the files listed above.                                                                                                                                     | TRUE         |
-| `new-charts-branch`, `n`     | Branch to replace the current in the charts.                                                                                                                                                  | TRUE         |
-| `create-pr`, `p`             | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
-| `fork-owner`, `o`            | GitHub Username of the owner of the rancher fork used in rancher-fork.                                                                                                                        | FALSE        |
-| `dry-run`, `r`               | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
+Non-required flags can be automatically set, if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
+
+| **Flag**                 | **Description**                                                                                                                                                                               | **Required** |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `fork-path`, `f`         | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
+| `base-branch`, `b`       | The branch you want to update with the new charts branch. Default is the current branch in your repo.                                                                                         | FALSE        |
+| `new-charts-branch`, `n` | New branch to replace the current.                                                                                                                                                            | TRUE         |
+| `create-pr`, `p`         | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
+| `github-user`, `u`       | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
+| `dry-run`, `r`           | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
 
 **Examples**
 
 ```
+export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
 
+rancher_release set-charts-branch-refs --new-charts-branch dev-v2.9 --create-pr --dry-run
+```
+
+```
+export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
+
+rancher_release set-charts-branch-refs -n dev-v2.9 -p -r
+```
+
+```
 rancher_release set-charts-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_USERNAME}/rancher \
  --base-branch release/v2.8 \
  --current-charts-branch dev-v2.8 \
@@ -109,7 +121,6 @@ rancher_release set-charts-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_
 ```
 
 ```
-
 export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
 
 rancher_release set-charts-branch-refs -f $GOPATH/src/github.com/{YOUR_USERNAME}/rancher -b release/v2.8 -c dev-v2.8 -n dev-v2.9 -p -o {YOUR_USERNAME}

--- a/cmd/rancher_release/README.md
+++ b/cmd/rancher_release/README.md
@@ -43,17 +43,28 @@ Updates Rancher KDM branch references in:
 - `package/Dockerfile`
 - `Dockerfile.dapper`
 
-| **Flag**                  | **Description**                                                                                                                                                                               | **Required** |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `fork-path`, `f`          | Path for your fork of rancher/rancher.                                                                                                                                                        | TRUE         |
-| `base-branch`, `b`        | The branch you want to update with the new KDM branch.                                                                                                                                        | TRUE         |
-| `current-kdm-branch`, `c` | Current KDM branch used in the files listed above.                                                                                                                                            | TRUE         |
-| `new-kdm-branch`, `n`     | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
-| `create-pr`, `p`          | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
-| `fork-owner`, `o`         | GitHub Username of the owner of the rancher fork used in `rancher-fork`.                                                                                                                      | FALSE        |
-| `dry-run`, `r`            | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
+Non-required flags can be automatically set, if you are inside your rancher fork. ⚠️ If you decide to run this way, please double check your branch and directory ⚠️
+
+| **Flag**              | **Description**                                                                                                                                                                               | **Required** |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `fork-path`, `f`      | Path for your fork of rancher/rancher. Default is the currenty directory you are running the command in.                                                                                      | FALSE        |
+| `base-branch`, `b`    | The branch you want to update with the new KDM branch. Default is the current branch in your repo.                                                                                            | FALSE        |
+| `new-kdm-branch`, `n` | KDM branch to replace the current.                                                                                                                                                            | TRUE         |
+| `create-pr`, `p`      | if true, will try to create a PR against the `base-branch` in rancher/rancher, may fail if your GitHub token doesn’t have the required permission. Requires a GITHUB_TOKEN env var to be set. | FALSE        |
+| `fork-owner`, `o`     | GitHub Username of the owner of the rancher fork used in `rancher-fork`. Default is the username of the `origin` remote                                                                       | FALSE        |
+| `dry-run`, `r`        | Changes will not be pushed to remote and the PR will not be created.                                                                                                                          | FALSE        |
 
 **Examples**
+
+```
+rancher_release set-kdm-branch-refs -n dev-v2.8-september-patches --create-pr --dry-run
+```
+
+```
+export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
+
+rancher_release set-kdm-branch-refs -n dev-v2.8-september-patches -p -r
+```
 
 ```
 rancher_release set-kdm-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_USERNAME}/rancher \
@@ -89,10 +100,12 @@ Updates Rancher branch references in charts:
 **Examples**
 
 ```
+
 rancher_release set-charts-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_USERNAME}/rancher \
-    --base-branch release/v2.8 \
-    --current-charts-branch dev-v2.8 \
-    --new-charts-branch dev-v2.9
+ --base-branch release/v2.8 \
+ --current-charts-branch dev-v2.8 \
+ --new-charts-branch dev-v2.9
+
 ```
 
 ```
@@ -100,6 +113,7 @@ rancher_release set-charts-branch-refs --fork-path $GOPATH/src/github.com/{YOUR_
 export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
 
 rancher_release set-charts-branch-refs -f $GOPATH/src/github.com/{YOUR_USERNAME}/rancher -b release/v2.8 -c dev-v2.8 -n dev-v2.9 -p -o {YOUR_USERNAME}
+
 ```
 
 ### label-issues
@@ -112,11 +126,10 @@ Given a release candidate, updates each GitHub issue belonging to its milestone 
 rancher_release label-issues -t v2.8.1-rc1 --dry-run
 # Updating 2 issues
 # #1 Issue one (v2.8.x)
-#   [Waiting for RC] -> [To Test] 
+#   [Waiting for RC] -> [To Test]
 # #2 Issue two (v2.8.x)
-#   [Waiting for RC] -> [To Test] 
+#   [Waiting for RC] -> [To Test]
 ```
-
 
 ## Contributions
 

--- a/cmd/rancher_release/set_chart_branch_references.go
+++ b/cmd/rancher_release/set_chart_branch_references.go
@@ -64,24 +64,25 @@ func setChartsBranchReferencesCommand() *cli.Command {
 }
 
 func setChartBranchReferences(c *cli.Context) error {
-	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
-		forkPath, err = os.Getwd()
+		fp, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		logrus.Info("fork path: " + forkPath)
+		logrus.Info("fork path: " + fp)
 		if err := isGitRepo(forkPath); err != nil {
 			return err
 		}
+		forkPath = fp
 	}
 	baseBranch := c.String("base-branch")
 	if baseBranch == "" {
-		baseBranch, err = currentBranch(forkPath)
+		bb, err := currentBranch(forkPath)
 		if err != nil {
 			return err
 		}
+		baseBranch = bb
 		logrus.Info("base branch: " + baseBranch)
 	}
 	newBranch := c.String("new-charts-branch")
@@ -94,9 +95,11 @@ func setChartBranchReferences(c *cli.Context) error {
 	logrus.Info("create PR: " + strconv.FormatBool(createPR))
 	if createPR {
 		if githubUser == "" {
-			if githubUser, err = gitRepoOwner(forkPath); err != nil {
+			gu, err := gitRepoOwner(forkPath)
+			if err != nil {
 				return err
 			}
+			githubUser = gu
 			logrus.Info("github username: ", githubUser)
 		}
 		if githubToken == "" {
@@ -104,5 +107,14 @@ func setChartBranchReferences(c *cli.Context) error {
 		}
 	}
 
-	return rancher.SetChartBranchReferences(context.Background(), forkPath, baseBranch, newBranch, githubUser, githubToken, createPR, dryRun)
+	return rancher.SetChartBranchReferences(
+		context.Background(),
+		forkPath,
+		baseBranch,
+		newBranch,
+		githubUser,
+		githubToken,
+		createPR,
+		dryRun,
+	)
 }

--- a/cmd/rancher_release/set_chart_branch_references.go
+++ b/cmd/rancher_release/set_chart_branch_references.go
@@ -31,7 +31,7 @@ func setChartsBranchReferencesCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:     "new-charts-branch",
 				Aliases:  []string{"n"},
-				Usage:    "branch to be replaced in charts in the repo",
+				Usage:    "new branch to replace the current",
 				Required: true,
 			},
 			&cli.BoolFlag{

--- a/cmd/rancher_release/set_chart_branch_references.go
+++ b/cmd/rancher_release/set_chart_branch_references.go
@@ -64,6 +64,7 @@ func setChartsBranchReferencesCommand() *cli.Command {
 }
 
 func setChartBranchReferences(c *cli.Context) error {
+	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
 		forkPath, err = os.Getwd()

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -80,7 +80,7 @@ func setKDMBranchReferences(c *cli.Context) error {
 	}
 	baseBranch := c.String("base-branch")
 	if baseBranch == "" {
-		baseBranch, err := currentBranch(forkPath)
+		baseBranch, err = currentBranch(forkPath)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,6 @@ func setKDMBranchReferences(c *cli.Context) error {
 			return errors.New("'create-pr' requires the 'GITHUB_TOKEN' env var")
 		}
 	}
-
 	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, forkOwner, githubToken, createPR, dryRun)
 }
 

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -69,7 +69,7 @@ func setKDMBranchReferences(c *cli.Context) error {
 	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
-		forkPath, err = cmdPath()
+		forkPath, err = os.Getwd()
 		if err != nil {
 			return err
 		}
@@ -106,14 +106,6 @@ func setKDMBranchReferences(c *cli.Context) error {
 		}
 	}
 	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, forkOwner, githubToken, createPR, dryRun)
-}
-
-func cmdPath() (string, error) {
-	path, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return path, nil
 }
 
 func gitRepoOwner(path string) (string, error) {

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -13,6 +13,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var err error
+
 func setKDMBranchReferencesCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "set-kdm-branch-refs",
@@ -66,7 +68,6 @@ func setKDMBranchReferencesCommand() *cli.Command {
 }
 
 func setKDMBranchReferences(c *cli.Context) error {
-	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
 		forkPath, err = os.Getwd()

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -13,8 +13,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var err error
-
 func setKDMBranchReferencesCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "set-kdm-branch-refs",
@@ -68,6 +66,7 @@ func setKDMBranchReferencesCommand() *cli.Command {
 }
 
 func setKDMBranchReferences(c *cli.Context) error {
+	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
 		forkPath, err = os.Getwd()

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -3,8 +3,13 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"strconv"
+	"strings"
 
+	"github.com/rancher/ecm-distro-tools/exec"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -17,19 +22,13 @@ func setKDMBranchReferencesCommand() *cli.Command {
 				Name:     "fork-path",
 				Aliases:  []string{"f"},
 				Usage:    "rancher repo fork directory path",
-				Required: true,
+				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "base-branch",
 				Aliases:  []string{"b"},
 				Usage:    "rancher branch to use as a base, e.g: release/v2.8",
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "current-kdm-branch",
-				Aliases:  []string{"c"},
-				Usage:    "current kdm branch set in the repo",
-				Required: true,
+				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "new-kdm-branch",
@@ -67,22 +66,105 @@ func setKDMBranchReferencesCommand() *cli.Command {
 }
 
 func setKDMBranchReferences(c *cli.Context) error {
+	var err error
 	forkPath := c.String("fork-path")
+	if forkPath == "" {
+		forkPath, err = cmdPath()
+		if err != nil {
+			return err
+		}
+		logrus.Info("fork path: " + forkPath)
+		if err := isGitRepo(forkPath); err != nil {
+			return err
+		}
+	}
 	baseBranch := c.String("base-branch")
-	currentKDMBranch := c.String("current-kdm-branch")
+	if baseBranch == "" {
+		baseBranch, err := currentBranch(forkPath)
+		if err != nil {
+			return err
+		}
+		logrus.Info("base branch: " + baseBranch)
+	}
 	newKDMBranch := c.String("new-kdm-branch")
-	createPR := c.Bool("create-pr")
+	logrus.Info("new KDM Branch: " + newKDMBranch)
 	forkOwner := c.String("fork-owner")
 	githubToken := c.String("github-token")
 	dryRun := c.Bool("dry-run")
+	logrus.Info("dry run: " + strconv.FormatBool(dryRun))
+	createPR := c.Bool("create-pr")
+	logrus.Info("create PR: " + strconv.FormatBool(createPR))
 	if createPR {
 		if forkOwner == "" {
-			return errors.New("'create-pr' requires 'fork-owner'")
+			if forkOwner, err = gitRepoOwner(forkPath); err != nil {
+				return err
+			}
+			logrus.Info("fork owner: ", forkOwner)
 		}
 		if githubToken == "" {
 			return errors.New("'create-pr' requires the 'GITHUB_TOKEN' env var")
 		}
 	}
 
-	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, currentKDMBranch, newKDMBranch, forkOwner, githubToken, createPR, dryRun)
+	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, forkOwner, githubToken, createPR, dryRun)
+}
+
+func cmdPath() (string, error) {
+	path, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func gitRepoOwner(path string) (string, error) {
+	originURL, err := gitOriginURL(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(originURL, "https") {
+		return repoOwnerHTTPS(originURL), nil
+	}
+	return repoOwnerSSH(originURL), nil
+}
+
+func currentBranch(path string) (string, error) {
+	result, err := exec.RunCommand(path, "git", "branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
+}
+
+func gitOriginURL(path string) (string, error) {
+	result, err := exec.RunCommand(path, "git", "ls-remote", "--get-url", "origin")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
+}
+
+func repoOwnerHTTPS(URL string) string {
+	// https://github.com/rancher/rancher.git
+	ownerAndRepo := strings.Split(URL, ".com/")[1]
+	owner := strings.Split(ownerAndRepo, "/")[0]
+	return owner
+}
+
+func repoOwnerSSH(URL string) string {
+	// git@github.com:rancher/rancher.git
+	ownerAndRepo := strings.Split(URL, ":")[1]
+	owner := strings.Split(ownerAndRepo, "/")[0]
+	return owner
+}
+
+func isGitRepo(path string) error {
+	result, err := exec.RunCommand(path, "git", "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(result) != "true" {
+		return errors.New("path is not a git directory")
+	}
+	return nil
 }

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -42,8 +42,8 @@ func setKDMBranchReferencesCommand() *cli.Command {
 				Usage:   "if true, a PR will be created from your fork to the rancher repo base branch and a variable 'GITHUB_TOKEN' must be exported",
 			},
 			&cli.StringFlag{
-				Name:     "fork-owner",
-				Aliases:  []string{"o"},
+				Name:     "github-username",
+				Aliases:  []string{"u"},
 				Usage:    "github username of the owner of the fork, only required if 'create-pr' is true",
 				Required: false,
 			},
@@ -88,24 +88,24 @@ func setKDMBranchReferences(c *cli.Context) error {
 	}
 	newKDMBranch := c.String("new-kdm-branch")
 	logrus.Info("new KDM Branch: " + newKDMBranch)
-	forkOwner := c.String("fork-owner")
+	githubUsername := c.String("github-username")
 	githubToken := c.String("github-token")
 	dryRun := c.Bool("dry-run")
 	logrus.Info("dry run: " + strconv.FormatBool(dryRun))
 	createPR := c.Bool("create-pr")
 	logrus.Info("create PR: " + strconv.FormatBool(createPR))
 	if createPR {
-		if forkOwner == "" {
-			if forkOwner, err = gitRepoOwner(forkPath); err != nil {
+		if githubUsername == "" {
+			if githubUsername, err = gitRepoOwner(forkPath); err != nil {
 				return err
 			}
-			logrus.Info("fork owner: ", forkOwner)
+			logrus.Info("github username: ", githubUsername)
 		}
 		if githubToken == "" {
 			return errors.New("'create-pr' requires the 'GITHUB_TOKEN' env var")
 		}
 	}
-	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, forkOwner, githubToken, createPR, dryRun)
+	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, githubUsername, githubToken, createPR, dryRun)
 }
 
 func gitRepoOwner(path string) (string, error) {

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -135,15 +135,15 @@ func gitOriginURL(path string) (string, error) {
 	return strings.TrimSpace(result), nil
 }
 
-func repoOwnerHTTPS(URL string) string {
+func repoOwnerHTTPS(url string) string {
 	// https://github.com/rancher/rancher.git
-	ownerAndRepo := strings.Split(URL, ".com/")[1]
+	ownerAndRepo := strings.Split(url, ".com/")[1]
 	return strings.Split(ownerAndRepo, "/")[0]
 }
 
-func repoOwnerSSH(URL string) string {
+func repoOwnerSSH(url string) string {
 	// git@github.com:rancher/rancher.git
-	ownerAndRepo := strings.Split(URL, ":")[1]
+	ownerAndRepo := strings.Split(url, ":")[1]
 	return strings.Split(ownerAndRepo, "/")[0]
 }
 

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -66,24 +66,25 @@ func setKDMBranchReferencesCommand() *cli.Command {
 }
 
 func setKDMBranchReferences(c *cli.Context) error {
-	var err error
 	forkPath := c.String("fork-path")
 	if forkPath == "" {
-		forkPath, err = os.Getwd()
+		fp, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		logrus.Info("fork path: " + forkPath)
+		logrus.Info("fork path: " + fp)
 		if err := isGitRepo(forkPath); err != nil {
 			return err
 		}
+		forkPath = fp
 	}
 	baseBranch := c.String("base-branch")
 	if baseBranch == "" {
-		baseBranch, err = currentBranch(forkPath)
+		bb, err := currentBranch(forkPath)
 		if err != nil {
 			return err
 		}
+		baseBranch = bb
 		logrus.Info("base branch: " + baseBranch)
 	}
 	newKDMBranch := c.String("new-kdm-branch")
@@ -96,16 +97,27 @@ func setKDMBranchReferences(c *cli.Context) error {
 	logrus.Info("create PR: " + strconv.FormatBool(createPR))
 	if createPR {
 		if githubUser == "" {
-			if githubUser, err = gitRepoOwner(forkPath); err != nil {
+			gu, err := gitRepoOwner(forkPath)
+			if err != nil {
 				return err
 			}
+			githubUser = gu
 			logrus.Info("github username: ", githubUser)
 		}
 		if githubToken == "" {
 			return errors.New("'create-pr' requires the 'GITHUB_TOKEN' env var")
 		}
 	}
-	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, githubUser, githubToken, createPR, dryRun)
+	return rancher.SetKDMBranchReferences(
+		context.Background(),
+		forkPath,
+		baseBranch,
+		newKDMBranch,
+		githubUser,
+		githubToken,
+		createPR,
+		dryRun,
+	)
 }
 
 func gitRepoOwner(path string) (string, error) {

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -44,7 +44,7 @@ func setKDMBranchReferencesCommand() *cli.Command {
 				Usage:   "if true, a PR will be created from your fork to the rancher repo base branch and a variable 'GITHUB_TOKEN' must be exported",
 			},
 			&cli.StringFlag{
-				Name:     "github-username",
+				Name:     "github-user",
 				Aliases:  []string{"u"},
 				Usage:    "github username of the owner of the fork, only required if 'create-pr' is true",
 				Required: false,
@@ -89,24 +89,24 @@ func setKDMBranchReferences(c *cli.Context) error {
 	}
 	newKDMBranch := c.String("new-kdm-branch")
 	logrus.Info("new KDM Branch: " + newKDMBranch)
-	githubUsername := c.String("github-username")
+	githubUser := c.String("github-user")
 	githubToken := c.String("github-token")
 	dryRun := c.Bool("dry-run")
 	logrus.Info("dry run: " + strconv.FormatBool(dryRun))
 	createPR := c.Bool("create-pr")
 	logrus.Info("create PR: " + strconv.FormatBool(createPR))
 	if createPR {
-		if githubUsername == "" {
-			if githubUsername, err = gitRepoOwner(forkPath); err != nil {
+		if githubUser == "" {
+			if githubUser, err = gitRepoOwner(forkPath); err != nil {
 				return err
 			}
-			logrus.Info("github username: ", githubUsername)
+			logrus.Info("github username: ", githubUser)
 		}
 		if githubToken == "" {
 			return errors.New("'create-pr' requires the 'GITHUB_TOKEN' env var")
 		}
 	}
-	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, githubUsername, githubToken, createPR, dryRun)
+	return rancher.SetKDMBranchReferences(context.Background(), forkPath, baseBranch, newKDMBranch, githubUser, githubToken, createPR, dryRun)
 }
 
 func gitRepoOwner(path string) (string, error) {

--- a/cmd/rancher_release/set_kdm_branch_references.go
+++ b/cmd/rancher_release/set_kdm_branch_references.go
@@ -138,15 +138,13 @@ func gitOriginURL(path string) (string, error) {
 func repoOwnerHTTPS(URL string) string {
 	// https://github.com/rancher/rancher.git
 	ownerAndRepo := strings.Split(URL, ".com/")[1]
-	owner := strings.Split(ownerAndRepo, "/")[0]
-	return owner
+	return strings.Split(ownerAndRepo, "/")[0]
 }
 
 func repoOwnerSSH(URL string) string {
 	// git@github.com:rancher/rancher.git
 	ownerAndRepo := strings.Split(URL, ":")[1]
-	owner := strings.Split(ownerAndRepo, "/")[0]
-	return owner
+	return strings.Split(ownerAndRepo, "/")[0]
 }
 
 func isGitRepo(path string) error {

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -23,28 +23,29 @@ func RunCommand(dir, cmd string, args ...string) (string, error) {
 	return outb.String(), nil
 }
 
-func RunTemplatedScript(path, fileName, script string, args interface{}) error {
+func RunTemplatedScript(path, fileName, script string, args interface{}) (string, error) {
 	if _, err := os.Stat(path); err != nil {
-		return err
+		return "", err
 	}
 	scriptPath := filepath.Join(path, fileName)
 	f, err := os.Create(scriptPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer f.Close()
 	if err := os.Chmod(scriptPath, 0755); err != nil {
-		return err
+		return "", err
 	}
 	tmpl, err := template.New(script).Parse(script)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := tmpl.Execute(f, args); err != nil {
-		return err
+		return "", err
 	}
-	if _, err := RunCommand(path, "bash", "./"+fileName); err != nil {
-		return err
+	output, err := RunCommand(path, "bash", "./"+fileName)
+	if err != nil {
+		return "", err
 	}
-	return nil
+	return output, nil
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -216,7 +216,7 @@ func rancherHelmChartVersions(repoURL string) ([]string, error) {
 	return versions, nil
 }
 
-func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newKDMBranch, githubUsername, githubToken string, createPR, dryRun bool) error {
+func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newKDMBranch, githubUser, githubToken string, createPR, dryRun bool) error {
 	branchName := "kdm-set-" + newKDMBranch
 	data := SetBranchReferencesArgs{
 		RancherRepoPath:   forkPath,
@@ -243,7 +243,7 @@ func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, ne
 		}
 		ghClient := repository.NewGithub(ctx, githubToken)
 
-		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, githubUsername, ghClient); err != nil {
+		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, githubUser, ghClient); err != nil {
 			return err
 		}
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -240,9 +240,10 @@ func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, ne
 
 	if createPR {
 		prName := "Update KDM to " + newKDMBranch
-		logrus.Info("creating PR: " + prName)
+		logrus.Info("creating PR")
 		if dryRun {
 			logrus.Info("dry run, PR will not be created")
+			logrus.Info("PR:\n  Name: " + prName + "\n  From: " + githubUser + ":" + branchName + "\n  To rancher:" + rancherBaseBranch)
 			return nil
 		}
 		ghClient := repository.NewGithub(ctx, githubToken)
@@ -254,7 +255,7 @@ func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, ne
 	return nil
 }
 
-func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newBranch, forkOwner, githubToken string, createPR, dryRun bool) error {
+func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newBranch, githubUser, githubToken string, createPR, dryRun bool) error {
 	branchName := "charts-set-" + newBranch
 	data := SetBranchReferencesArgs{
 		RancherRepoPath:   forkPath,
@@ -273,14 +274,15 @@ func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, 
 
 	if createPR {
 		prName := "Update charts branch references to " + newBranch
-		logrus.Info("creating PR: " + prName)
+		logrus.Info("creating PR")
 		if dryRun {
 			logrus.Info("dry run, PR will not be created")
+			logrus.Info("PR:\n  Name: " + prName + "\n  From: " + githubUser + ":" + branchName + "\n  To rancher:" + rancherBaseBranch)
 			return nil
 		}
 		ghClient := repository.NewGithub(ctx, githubToken)
 
-		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, forkOwner, ghClient); err != nil {
+		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, githubUser, ghClient); err != nil {
 			return err
 		}
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -31,16 +31,20 @@ set -e
 
 BRANCH_NAME={{ .BranchName }}
 DRY_RUN={{ .DryRun }}
+echo "branch name: ${BRANCH_NAME}"
+echo "dry run: ${DRY_RUN}"
 
+echo "navigating into the rancher repo"
 cd {{ .RancherRepoPath }}
+echo "adding upstream remote if not exists"
 git remote -v | grep -w upstream || git remote add upstream https://github.com/rancher/rancher.git
+echo "fetching upstream"
 git fetch upstream
+echo "stashing local changes"
 git stash
-if [ 'git branch --list ${BRANCH_NAME}' ]
-then
-   echo "Branch name ${BRANCH_NAME} already exists, deleting"
-   git branch -D ${BRANCH_NAME}
-fi
+echo "if local branch already exists, delete it"
+git branch -D ${BRANCH_NAME} &>/dev/null || true
+echo "creating local branch"
 git checkout -B ${BRANCH_NAME} upstream/{{.RancherBaseBranch}}
 git clean -xfd`
 	setKDMBranchReferencesScript = `
@@ -72,16 +76,16 @@ git commit --all --signoff -m "update kdm branch to {{ .NewBranch }}"`
 OS=$(uname -s)
 case ${OS} in
 Darwin)
-	sed -i '' 's/NewSetting(\"chart-default-branch\", \"{{ .CurrentBranch }}\")/NewSetting(\"chart-default-branch\", \"{{ .NewBranch }}\")/' pkg/settings/setting.go
-	sed -i '' 's/SYSTEM_CHART_DEFAULT_BRANCH={{ .CurrentBranch }}/SYSTEM_CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
-	sed -i '' 's/CHART_DEFAULT_BRANCH={{ .CurrentBranch }}/CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
-	sed -i '' 's/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .CurrentBranch }}"}/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .NewBranch }}"}/' scripts/package-env
+	sed -i '' 's/NewSetting("chart-default-branch", ".*")/NewSetting("chart-default-branch", "{{ .NewBranch }}")/' pkg/settings/setting.go
+	sed -i '' 's/ARG\ SYSTEM_CHART_DEFAULT_BRANCH=.*$/ARG\ SYSTEM_CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
+	sed -i '' 's/ARG\ CHART_DEFAULT_BRANCH=.*$/ARG\ CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
+	sed -i '' 's/{SYSTEM_CHART_DEFAULT_BRANCH:-".*"}/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .NewBranch }}"}/' scripts/package-env
 	;;
 Linux)
-	sed -i 's/NewSetting("chart-default-branch", "{{ .CurrentBranch }}")/NewSetting("chart-default-branch", "{{ .NewBranch }}")/' pkg/settings/setting.go
-	sed -i 's/SYSTEM_CHART_DEFAULT_BRANCH={{ .CurrentBranch }}/SYSTEM_CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
-	sed -i 's/CHART_DEFAULT_BRANCH={{ .CurrentBranch }}/CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
-	sed -i 's/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .CurrentBranch }}"}/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .NewBranch }}"}/' scripts/package-env
+	sed -i 's/NewSetting("chart-default-branch", ".*")/NewSetting("chart-default-branch", "{{ .NewBranch }}")/' pkg/settings/setting.go
+	sed -i 's/ARG\ SYSTEM_CHART_DEFAULT_BRANCH=.*$/ARG\ SYSTEM_CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
+	sed -i 's/ARG\ CHART_DEFAULT_BRANCH=.*$/ARG\ CHART_DEFAULT_BRANCH={{ .NewBranch }}/' package/Dockerfile
+	sed -i 's/{SYSTEM_CHART_DEFAULT_BRANCH:-".*"}/{SYSTEM_CHART_DEFAULT_BRANCH:-"{{ .NewBranch }}"}/' scripts/package-env
 	;;
 *)
 	>&2 echo "$(OS) not supported yet"
@@ -101,7 +105,6 @@ fi`
 
 type SetBranchReferencesArgs struct {
 	RancherRepoPath   string
-	CurrentBranch     string
 	NewBranch         string
 	RancherBaseBranch string
 	BranchName        string
@@ -251,25 +254,33 @@ func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, ne
 	return nil
 }
 
-func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, currentBranch, newBranch, forkOwner, githubToken string, createPR, dryRun bool) error {
+func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newBranch, forkOwner, githubToken string, createPR, dryRun bool) error {
 	branchName := "charts-set-" + newBranch
 	data := SetBranchReferencesArgs{
 		RancherRepoPath:   forkPath,
-		CurrentBranch:     currentBranch,
 		NewBranch:         newBranch,
 		RancherBaseBranch: rancherBaseBranch,
 		DryRun:            dryRun,
 		BranchName:        branchName,
 	}
 	script := cloneCheckoutRancherScript + setChartBranchReferencesScript + pushChangesScript
-	if _, err := exec.RunTemplatedScript(forkPath, setChartReferencesScriptFileName, script, data); err != nil {
+	logrus.Info("running update files script")
+	output, err := exec.RunTemplatedScript(forkPath, setChartReferencesScriptFileName, script, data)
+	if err != nil {
 		return err
 	}
+	logrus.Info(output)
 
-	if createPR && !dryRun {
+	if createPR {
+		prName := "Update charts branch references to " + newBranch
+		logrus.Info("creating PR: " + prName)
+		if dryRun {
+			logrus.Info("dry run, PR will not be created")
+			return nil
+		}
 		ghClient := repository.NewGithub(ctx, githubToken)
 
-		if err := createPRFromRancher(ctx, rancherBaseBranch, "Update charts branch references to "+newBranch, branchName, forkOwner, ghClient); err != nil {
+		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, forkOwner, ghClient); err != nil {
 			return err
 		}
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -216,7 +216,7 @@ func rancherHelmChartVersions(repoURL string) ([]string, error) {
 	return versions, nil
 }
 
-func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newKDMBranch, forkOwner, githubToken string, createPR, dryRun bool) error {
+func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, newKDMBranch, githubUsername, githubToken string, createPR, dryRun bool) error {
 	branchName := "kdm-set-" + newKDMBranch
 	data := SetBranchReferencesArgs{
 		RancherRepoPath:   forkPath,
@@ -243,7 +243,7 @@ func SetKDMBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, ne
 		}
 		ghClient := repository.NewGithub(ctx, githubToken)
 
-		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, forkOwner, ghClient); err != nil {
+		if err := createPRFromRancher(ctx, rancherBaseBranch, prName, branchName, githubUsername, ghClient); err != nil {
 			return err
 		}
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -44,7 +44,8 @@ fi
 git checkout -B ${BRANCH_NAME} upstream/{{.RancherBaseBranch}}
 git clean -xfd`
 	setKDMBranchReferencesScript = `
-echo "Current set KDM Branch: $(cat Dockerfile.dapper | grep CATTLE_KDM_BRANCH)"
+echo "\nCurrent set KDM Branch: $(cat Dockerfile.dapper | grep CATTLE_KDM_BRANCH)"
+echo "\nUpdating\n    - pkg/settings/setting.go\n    - package/Dockerfile\n    - Dockerfile.dapper"
 
 OS=$(uname -s)
 case ${OS} in


### PR DESCRIPTION
Closes: #253
Closes: #252
Removes the requirement for some flags and adds functions to get those infos automatically

## How to test
```
export GITHUB_TOKEN=1
cd ${YOUR_LOCAL_RANCHER_REPO}
rancher_release-darwin-arm64 set-kdm-branch-refs --new-kdm-branch T1 --create-pr --dry-run
```
```
export GITHUB_TOKEN=1
cd ${YOUR_LOCAL_RANCHER_REPO}
rancher_release-darwin-arm64 set-charts-branch-refs -n T2 -p -r
```