### PR TITLE
Fix packaging and install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           make all
           make test
+          make package-binaries
       - name: Publish Binaries
         uses: SierraSoftworks/gh-releases@v1.0.7
         with:
@@ -97,8 +98,12 @@ jobs:
             ${{ github.workspace }}/cmd/upstream_go_version/bin/upstream_go_version-linux-amd64
             ${{ github.workspace }}/cmd/upstream_go_version/bin/upstream_go_version-linux-arm64
             ${{ github.workspace }}/cmd/upstream_go_version/bin/sha256sums-upstream_go_version.txt
-            ${{ github.workspace }}/cmd/standup/bin/standup
-            ${{ github.workspace }}/ecm-distro-tools.tgz
+            ${{ github.workspace }}/ecm-distro-tools.darwin-amd64.tar.gz
+            ${{ github.workspace }}/ecm-distro-tools.darwin-arm64.tar.gz
+            ${{ github.workspace }}/ecm-distro-tools.linux-amd64.tar.gz
+            ${{ github.workspace }}/ecm-distro-tools.linux-arm64.tar.gz
+            ${{ github.workspace }}/ecm-distro-tools.freebsd-amd64.tar.gz
+            ${{ github.workspace }}/ecm-distro-tools.freebsd-arm64.tar.gz
       - name: Docker Hub Login
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,25 @@
 name: ECM Distro Tools Release
 on:
- push:
-   tags:
-     - "v*"
+  push:
+    tags:
+      - "v*"
 jobs:
   release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Build ECM Distro Tools
         run: |
-          make all
           make test
           make package-binaries
       - name: Publish Binaries
         uses: SierraSoftworks/gh-releases@v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          overwrite: 'true'
+          overwrite: "true"
           files: |
             ${{ github.workspace }}/bin/bootstrap_hash
             ${{ github.workspace }}/bin/check_for_k8s_release
@@ -55,7 +54,7 @@ jobs:
             ${{ github.workspace }}/cmd/gen_release_report/bin/gen_release_report-freebsd-arm64
             ${{ github.workspace }}/cmd/gen_release_report/bin/gen_release_report-linux-amd64
             ${{ github.workspace }}/cmd/gen_release_report/bin/gen_release_report-linux-arm64
-            ${{ github.workspace }}/cmd/gen_release_report/bin/sha256sums-gen_release_report.
+            ${{ github.workspace }}/cmd/gen_release_report/bin/sha256sums-gen_release_report.txt
             ${{ github.workspace }}/cmd/k3s_release/bin/k3s_release-darwin-amd64
             ${{ github.workspace }}/cmd/k3s_release/bin/k3s_release-darwin-arm64
             ${{ github.workspace }}/cmd/k3s_release/bin/k3s_release-freebsd-amd64

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ data/*
 .DS_Store
 
 .vscode
+
+# build artifacts
+*.tar
+*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ build-image:
 .PHONY: package-binaries
 package-binaries: $(BINARIES)
 	@$(eval export BIN_FILES = $(shell ls bin/))
-	STANDUP_BIN="standup"
 
 	for arch in $(ARCHS); do \
 		for os in $(OSs); do \

--- a/Makefile
+++ b/Makefile
@@ -54,16 +54,20 @@ build-image:
 .PHONY: package-binaries
 package-binaries: $(BINARIES)
 	@$(eval export BIN_FILES = $(shell ls bin/))
+	STANDUP_BIN="standup"
 
-	cd bin                                       && \
-	tar cvf ../ecm-distro-tools.tar $(BIN_FILES) && \
-	cd ../
-
-	for binary in $<; do \
-		cd cmd/$${binary}/bin                   && \
-		tar rvf ../../../ecm-distro-tools.tar * && \
-		cd ../../../;                              \
+	for arch in $(ARCHS); do \
+		for os in $(OSs); do \
+			SUFFIX=$${os}-$${arch}; \
+			cd bin && \
+			tar cvf ../ecm-distro-tools.$${SUFFIX}.tar $(BIN_FILES) && \
+			cd ../; \
+			for binary in $(BINARIES); do \
+				cd cmd/$${binary}/bin && \
+				tar rvf ../../../ecm-distro-tools.$${SUFFIX}.tar $${binary}-$${SUFFIX} && \
+				cd ../../../; \
+			done; \
+			gzip < ecm-distro-tools.$${SUFFIX}.tar > ecm-distro-tools.$${SUFFIX}.tar.gz && \
+			rm -f ecm-distro-tools.$${SUFFIX}.tar; \
+		done; \
 	done
-
-	gzip < ecm-distro-tools.tar > ecm-distro-tools.tgz && \
-	rm -f ecm-distro-tools.tar

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,7 +1,7 @@
 BINARIES = gen_release_notes gen_release_report backport semv k3s_release rancher_release test_coverage upstream_go_version rke2_release
 ARCHS = amd64 arm64
 OSs = linux darwin freebsd
-GO_COMPILE = GOOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
+GO_COMPILE = GOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,4 +1,4 @@
-BINARIES = gen_release_notes gen_release_report backport semv standup k3s_release rancher_release test_coverage upstream_go_version rke2_release
+BINARIES = gen_release_notes gen_release_report backport semv k3s_release rancher_release test_coverage upstream_go_version rke2_release
 ARCHS = amd64 arm64
 OSs = linux darwin freebsd
 GO_COMPILE = GOOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,7 +1,7 @@
 BINARIES = gen_release_notes gen_release_report backport semv standup k3s_release rancher_release test_coverage upstream_go_version rke2_release
 ARCHS = amd64 arm64
 OSs = linux darwin freebsd
-GO_COMPILE = CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
+GO_COMPILE = GOOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)
@@ -9,4 +9,3 @@ GEN_HASH = shasum -a 256 $@-$${os}-$${arch} >> $(BINDIR)/sha256sums-$(BINARY).tx
 else
 GEN_HASH = sha256sum $@-$${os}-$${arch} >> $(BINDIR)/sha256sums-$(BINARY).txt
 endif
-

--- a/cmd/backport/Makefile
+++ b/cmd/backport/Makefile
@@ -13,6 +13,7 @@ $(BINDIR)/$(BINARY): clean
 	for arch in $(ARCHS); do \
 		for os in $(OSs); do \
 			$(GO_COMPILE) ; \
+			$(GEN_HASH); \
 		done; \
 	done
 

--- a/install.sh
+++ b/install.sh
@@ -31,14 +31,12 @@ setup_arch() {
 # setup_tmp creates a temporary directory and cleans up when done.
 setup_tmp() {
     TMP_DIR=$(mktemp -d -t ecm-distro-tools-install.XXXXXXXXXX)
-    TMP_HASH=${TMP_DIR}/ecm-distro-tools.hash
-    TMP_BIN=${TMP_DIR}/ecm-distro-tools.bin
     cleanup() {
         code=$?
         set +e
         trap - EXIT
-        rm -rf ${TMP_DIR}
-        exit $code
+        rm -rf "${TMP_DIR}"
+        exit "$code"
     }
     trap cleanup INT EXIT
 }
@@ -88,8 +86,8 @@ install_binaries() {
     cd "${TMP_DIR}"
     tar -xf "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     rm "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
-    mkdir -p ${INSTALL_DIR}
-    cp -a ${TMP_DIR}/. ${INSTALL_DIR}
+    mkdir -p "${INSTALL_DIR}"
+    cp -a "${TMP_DIR}/." "${INSTALL_DIR}"
 }
 
 { # main

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,14 @@ install_binaries() {
     tar -xf "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     rm "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     mkdir -p "${INSTALL_DIR}"
-    cp -a "${TMP_DIR}/." "${INSTALL_DIR}"
+    for f in * ; do
+      file_name="${f}"
+      if [[ $f == *"-${SUFFIX}" ]]; then
+        file_name=${file_name%"-${SUFFIX}"}
+      fi
+
+      cp "${TMP_DIR}/${f}" "${INSTALL_DIR}/${file_name}"
+    done
 }
 
 { # main

--- a/install.sh
+++ b/install.sh
@@ -87,12 +87,12 @@ install_binaries() {
     tar -xf "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     rm "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     mkdir -p "${INSTALL_DIR}"
+
     for f in * ; do
       file_name="${f}"
-      if [[ $f == *"-${SUFFIX}" ]]; then
+      if echo "${f}" | grep -q "${SUFFIX}"; then
         file_name=${file_name%"-${SUFFIX}"}
       fi
-
       cp "${TMP_DIR}/${f}" "${INSTALL_DIR}/${file_name}"
     done
 }

--- a/install.sh
+++ b/install.sh
@@ -85,14 +85,10 @@ download_tarball() {
 
 # install_binaries installs the binaries from the downloaded tar.
 install_binaries() {
-    echo "install binaries"
     cd "${TMP_DIR}"
     tar -xf "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
-    echo "deleting tarball"
     rm "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
-    echo "creating install dir if not exists"
     mkdir -p ${INSTALL_DIR}
-    echo "copying binaries to install dir"
     cp -a ${TMP_DIR}/. ${INSTALL_DIR}
 }
 


### PR DESCRIPTION
* Creates tarballs for all os and arches
* Fix a bug where all binaries were built just for the build machine arch and os
* Fix a bug in the release action where a sha256sum file was missing `.txt`
* Changes the install folder in the install script to avoid permission issues.
* Install script removes the os and arch suffix for binaries
* Removes standup from packaging. It already wasn't being attached to the releases and when packaging, it was causing some trouble, since it has a different build process from all the other commands.
* Other install script changes