### PR TITLE
fix rke2 release typo in release yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
             ${{ github.workspace }}/cmd/rke2_release/bin/rke2_release-freebsd-amd64
             ${{ github.workspace }}/cmd/rke2_release/bin/rke2_release-freebsd-arm64
             ${{ github.workspace }}/cmd/rke2_release/bin/rke2_release-linux-amd64
-            ${{ github.workspace }}/cmd/rke2_release/bin/rke2_release-linux-arm64\
+            ${{ github.workspace }}/cmd/rke2_release/bin/rke2_release-linux-arm64
             ${{ github.workspace }}/cmd/rke2_release/bin/sha256sums-rke2_release.txt
             ${{ github.workspace }}/cmd/semv/bin/semv-darwin-amd64
             ${{ github.workspace }}/cmd/semv/bin/semv-darwin-arm64


### PR DESCRIPTION
* removes `/` in `release.yml` that was causing it to not upload this artifact