### PR TITLE
#275: update bci images

### DIFF
--- a/cmd/rke2_release/README.md
+++ b/cmd/rke2_release/README.md
@@ -64,6 +64,8 @@ rke2_release image-build list-repos
 #### update
 Updates references to the `hardened-build-base` docker image in the `rancher/image-build-*` repos.
 
+The GitHub Token must have the `pull requests read/write`  permission.
+
 | **Flag**                            | **Description** | **Required** |
 | ----------------------------------- | --------------- | ------------ |
 | `github-token`, `g`, `GITHUB_TOKEN` | Github Token    | TRUE         |

--- a/cmd/rke2_release/README.md
+++ b/cmd/rke2_release/README.md
@@ -35,6 +35,75 @@ rke2_release components -l image-build-k8s-metrics-server
 image-build-k8s-metrics-server|v0.6.3-build20231009
 ```
 
+### image-build
+
+#### list-repos
+List all repos supported by this command
+
+```sh
+rke2_release image-build list-repos
+
+> INFO[0000] Supported repos: 
+    image-build-sriov-network-resources-injector
+    image-build-containerd
+    image-build-multus
+    image-build-ib-sriov-cni
+    image-build-sriov-network-device-plugin
+    image-build-cni-plugins
+    image-build-rke2-cloud-provider
+    image-build-dns-nodecache
+    image-build-k8s-metrics-server
+    image-build-calico
+    image-build-flannel
+    image-build-sriov-cni
+    image-build-whereabouts
+    image-build-etcd
+    image-build-runc  
+```
+
+#### update
+Updates references to the `hardened-build-base` docker image in the `rancher/image-build-*` repos.
+
+| **Flag**                            | **Description** | **Required** |
+| ----------------------------------- | --------------- | ------------ |
+| `github-token`, `g`, `GITHUB_TOKEN` | Github Token    | TRUE         |
+| `repo`, `r` | What image-build repo to update, use `rke2_release image-build list-repos` for a full list    | TRUE         |
+| `owner`, `o` |  Owner of the repo, default is 'rancher' only used for testing purposes   | FALSE         |
+| `repo-path`, `p` |  Local copy of the image-build repo that is being updated   | TRUE         |
+| `working-dir`, `w` |  Directory in which the temporary scripts will be created, default is /tmp   | FALSE         |
+| `build-base-tag`, `t` |   hardened-build-base Docker image tag to update the references in the repo to  | TRUE         |
+| `dry-run`, `d` |  Don't push changes to remote and don't create the PR, just log the information   | FALSE         |
+| `create-pr`, `p` |  If not set, the images will be pushed to a new branch, but a PR won't be created  | FALSE         |
+
+**Examples**
+
+```sh
+export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
+
+rke2_release image-build update --repo image-build-calico --repo-path /tmp/image-build-calico --build-base-tag v1.21.3b1 --create-pr --dry-run
+```
+
+```sh
+export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
+
+rke2_release image-build update -r image-build-calico -p /tmp/image-build-calico -t v1.21.3b1 -p -d
+```
+ 
+### Components
+
+```sh
+rke2_release components -l all
+image-build-base                            |v1.21.3b1
+image-build-calico                          |v3.26.1-build20231009
+image-build-cni-plugins                     |v1.2.0-build20231009
+...
+```
+
+```sh
+rke2_release components -l image-build-k8s-metrics-server
+image-build-k8s-metrics-server|v0.6.3-build20231009
+```
+
 ## Contributions
 
 - File Issue with details of the problem, feature request, etc.

--- a/cmd/rke2_release/README.md
+++ b/cmd/rke2_release/README.md
@@ -73,7 +73,7 @@ Updates references to the `hardened-build-base` docker image in the `rancher/ima
 | `working-dir`, `w` |  Directory in which the temporary scripts will be created, default is /tmp   | FALSE         |
 | `build-base-tag`, `t` |   hardened-build-base Docker image tag to update the references in the repo to  | TRUE         |
 | `dry-run`, `d` |  Don't push changes to remote and don't create the PR, just log the information   | FALSE         |
-| `create-pr`, `p` |  If not set, the images will be pushed to a new branch, but a PR won't be created  | FALSE         |
+| `create-pr`, `c` |  If not set, the images will be pushed to a new branch, but a PR won't be created  | FALSE         |
 
 **Examples**
 
@@ -86,7 +86,7 @@ rke2_release image-build update --repo image-build-calico --repo-path /tmp/image
 ```sh
 export GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
 
-rke2_release image-build update -r image-build-calico -p /tmp/image-build-calico -t v1.21.3b1 -p -d
+rke2_release image-build update -r image-build-calico -p /tmp/image-build-calico -t v1.21.3b1 -c -d
 ```
  
 ### Components

--- a/cmd/rke2_release/main.go
+++ b/cmd/rke2_release/main.go
@@ -29,7 +29,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		imageBuildBaseReleaseCommand(),
 		componentsCommand(),
-		updateImageBuildCommand(),
+		imageBuildCommand(),
 	}
 	app.Flags = rootFlags
 

--- a/cmd/rke2_release/main.go
+++ b/cmd/rke2_release/main.go
@@ -29,6 +29,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		imageBuildBaseReleaseCommand(),
 		componentsCommand(),
+		updateImageBuildCommand(),
 	}
 	app.Flags = rootFlags
 

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rancher/ecm-distro-tools/release/rke2"
 	"github.com/rancher/ecm-distro-tools/repository"
@@ -23,31 +22,45 @@ func updateImageBuildCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:     "repo",
 				Aliases:  []string{"r"},
+				Usage:    "what image-build repo to update, use `rke2_release update-image-build list-repos` for a full list",
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "owner",
 				Aliases:  []string{"o"},
-				Required: true,
+				Usage:    "Owner of the repo, default is 'rancher' only used for testing purposes",
+				Value:    "rancher",
+				Required: false,
 			},
 			&cli.StringFlag{
-				Name:     "clone-dir",
+				Name:     "repo-path",
 				Aliases:  []string{"c"},
+				Usage:    "Local copy of the image-build repo that is being updated",
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "working-dir",
 				Aliases:  []string{"w"},
+				Usage:    "Directory in which the temporary scripts will be created, default is /tmp",
+				Value:    "/tmp",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "build-base-tag",
+				Aliases:  []string{"t"},
+				Usage:    "hardened-build-base Docker image tag to update the references in the repo to",
 				Required: true,
 			},
 			&cli.BoolFlag{
 				Name:     "dry-run",
 				Aliases:  []string{"d"},
+				Usage:    "don't push changes to remote and don't create the PR, just log the information",
 				Required: false,
 			},
 			&cli.BoolFlag{
 				Name:     "create-pr",
 				Aliases:  []string{"p"},
+				Usage:    "If not set, the images will be pushed to a new branch, but a PR won't be created",
 				Required: false,
 			},
 		},
@@ -57,16 +70,14 @@ func updateImageBuildCommand() *cli.Command {
 
 func updateImageBuild(c *cli.Context) error {
 	token := c.String("github-token")
-	if token == "" {
-		return errors.New("env var GITHUB_TOKEN is required")
-	}
 	repo := c.String("repo")
 	owner := c.String("owner")
-	cloneDir := c.String("clone-dir")
+	repoPath := c.String("repo-path")
 	workingDir := c.String("working-dir")
+	buildBaseTag := c.String("build-base-tag")
 	dryRun := c.Bool("dry-run")
 	createPR := c.Bool("create-pr")
 	ctx := context.Background()
 	ghClient := repository.NewGithub(ctx, token)
-	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, cloneDir, workingDir, dryRun, createPR)
+	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, repoPath, workingDir, buildBaseTag, dryRun, createPR)
 }

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -43,7 +43,7 @@ func imageBuildCommand() *cli.Command {
 					},
 					&cli.StringFlag{
 						Name:     "repo-path",
-						Aliases:  []string{"c"},
+						Aliases:  []string{"p"},
 						Usage:    "Local copy of the image-build repo that is being updated",
 						Required: true,
 					},
@@ -68,7 +68,7 @@ func imageBuildCommand() *cli.Command {
 					},
 					&cli.BoolFlag{
 						Name:     "create-pr",
-						Aliases:  []string{"p"},
+						Aliases:  []string{"c"},
 						Usage:    "If not set, the images will be pushed to a new branch, but a PR won't be created",
 						Required: false,
 					},

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -5,66 +5,77 @@ import (
 
 	"github.com/rancher/ecm-distro-tools/release/rke2"
 	"github.com/rancher/ecm-distro-tools/repository"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
-func updateImageBuildCommand() *cli.Command {
+func imageBuildCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "update-image-build",
-		Usage: "checks if a new release is available at rancher/image-build-base and updates the references at the rancher/image-build repos",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:     "github-token",
-				Aliases:  []string{"g"},
-				EnvVars:  []string{"GITHUB_TOKEN"},
-				Required: true,
+		Name: "image-build",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "list-repos",
+				Usage:  "List all repos supported by this command",
+				Action: listRepos,
 			},
-			&cli.StringFlag{
-				Name:     "repo",
-				Aliases:  []string{"r"},
-				Usage:    "what image-build repo to update, use `rke2_release update-image-build list-repos` for a full list",
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "owner",
-				Aliases:  []string{"o"},
-				Usage:    "Owner of the repo, default is 'rancher' only used for testing purposes",
-				Value:    "rancher",
-				Required: false,
-			},
-			&cli.StringFlag{
-				Name:     "repo-path",
-				Aliases:  []string{"c"},
-				Usage:    "Local copy of the image-build repo that is being updated",
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "working-dir",
-				Aliases:  []string{"w"},
-				Usage:    "Directory in which the temporary scripts will be created, default is /tmp",
-				Value:    "/tmp",
-				Required: false,
-			},
-			&cli.StringFlag{
-				Name:     "build-base-tag",
-				Aliases:  []string{"t"},
-				Usage:    "hardened-build-base Docker image tag to update the references in the repo to",
-				Required: true,
-			},
-			&cli.BoolFlag{
-				Name:     "dry-run",
-				Aliases:  []string{"d"},
-				Usage:    "don't push changes to remote and don't create the PR, just log the information",
-				Required: false,
-			},
-			&cli.BoolFlag{
-				Name:     "create-pr",
-				Aliases:  []string{"p"},
-				Usage:    "If not set, the images will be pushed to a new branch, but a PR won't be created",
-				Required: false,
+			{
+				Name:  "update",
+				Usage: "updates hardened-build-base references in the rancher/image-build-* repos",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "github-token",
+						Aliases:  []string{"g"},
+						EnvVars:  []string{"GITHUB_TOKEN"},
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "repo",
+						Aliases:  []string{"r"},
+						Usage:    "What image-build repo to update, use `rke2_release image-build list-repos` for a full list",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "owner",
+						Aliases:  []string{"o"},
+						Usage:    "Owner of the repo, default is 'rancher' only used for testing purposes",
+						Value:    "rancher",
+						Required: false,
+					},
+					&cli.StringFlag{
+						Name:     "repo-path",
+						Aliases:  []string{"c"},
+						Usage:    "Local copy of the image-build repo that is being updated",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "working-dir",
+						Aliases:  []string{"w"},
+						Usage:    "Directory in which the temporary scripts will be created, default is /tmp",
+						Value:    "/tmp",
+						Required: false,
+					},
+					&cli.StringFlag{
+						Name:     "build-base-tag",
+						Aliases:  []string{"t"},
+						Usage:    "hardened-build-base Docker image tag to update the references in the repo to",
+						Required: true,
+					},
+					&cli.BoolFlag{
+						Name:     "dry-run",
+						Aliases:  []string{"d"},
+						Usage:    "Don't push changes to remote and don't create the PR, just log the information",
+						Required: false,
+					},
+					&cli.BoolFlag{
+						Name:     "create-pr",
+						Aliases:  []string{"p"},
+						Usage:    "If not set, the images will be pushed to a new branch, but a PR won't be created",
+						Required: false,
+					},
+				},
+				Action: updateImageBuild,
 			},
 		},
-		Action: updateImageBuild,
 	}
 }
 
@@ -80,4 +91,13 @@ func updateImageBuild(c *cli.Context) error {
 	ctx := context.Background()
 	ghClient := repository.NewGithub(ctx, token)
 	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, repoPath, workingDir, buildBaseTag, dryRun, createPR)
+}
+
+func listRepos(c *cli.Context) error {
+	repos := ""
+	for k := range rke2.ImageBuildRepos {
+		repos += "  " + k + "\n"
+	}
+	logrus.Info("Supported repos: \n" + repos)
+	return nil
 }

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/ecm-distro-tools/release/rke2"
+	"github.com/rancher/ecm-distro-tools/repository"
+	"github.com/urfave/cli/v2"
+)
+
+func updateImageBuildCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "update-image-build",
+		Usage: "checks if a new release is available at rancher/image-build-base and updates the references at the rancher/image-build repos",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "github-token",
+				Aliases:  []string{"g"},
+				EnvVars:  []string{"GITHUB_TOKEN"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "repo",
+				Aliases:  []string{"r"},
+				Required: true,
+			},
+		},
+		Action: updateImageBuild,
+	}
+}
+
+func updateImageBuild(c *cli.Context) error {
+	token := c.String("github-token")
+	if token == "" {
+		return errors.New("env var GITHUB_TOKEN is required")
+	}
+	repo := c.String("repo")
+	ctx := context.Background()
+	ghClient := repository.NewGithub(ctx, token)
+	return rke2.UpdateImageBuild(ctx, ghClient, repo)
+}

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -35,6 +35,11 @@ func updateImageBuildCommand() *cli.Command {
 				Aliases:  []string{"c"},
 				Required: true,
 			},
+			&cli.StringFlag{
+				Name:     "working-dir",
+				Aliases:  []string{"w"},
+				Required: true,
+			},
 			&cli.BoolFlag{
 				Name:     "dry-run",
 				Aliases:  []string{"d"},
@@ -58,9 +63,10 @@ func updateImageBuild(c *cli.Context) error {
 	repo := c.String("repo")
 	owner := c.String("owner")
 	cloneDir := c.String("clone-dir")
+	workingDir := c.String("working-dir")
 	dryRun := c.Bool("dry-run")
 	createPR := c.Bool("create-pr")
 	ctx := context.Background()
 	ghClient := repository.NewGithub(ctx, token)
-	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, cloneDir, dryRun, createPR)
+	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, cloneDir, workingDir, dryRun, createPR)
 }

--- a/cmd/rke2_release/update_image_build.go
+++ b/cmd/rke2_release/update_image_build.go
@@ -25,6 +25,26 @@ func updateImageBuildCommand() *cli.Command {
 				Aliases:  []string{"r"},
 				Required: true,
 			},
+			&cli.StringFlag{
+				Name:     "owner",
+				Aliases:  []string{"o"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "clone-dir",
+				Aliases:  []string{"c"},
+				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:     "dry-run",
+				Aliases:  []string{"d"},
+				Required: false,
+			},
+			&cli.BoolFlag{
+				Name:     "create-pr",
+				Aliases:  []string{"p"},
+				Required: false,
+			},
 		},
 		Action: updateImageBuild,
 	}
@@ -36,7 +56,11 @@ func updateImageBuild(c *cli.Context) error {
 		return errors.New("env var GITHUB_TOKEN is required")
 	}
 	repo := c.String("repo")
+	owner := c.String("owner")
+	cloneDir := c.String("clone-dir")
+	dryRun := c.Bool("dry-run")
+	createPR := c.Bool("create-pr")
 	ctx := context.Background()
 	ghClient := repository.NewGithub(ctx, token)
-	return rke2.UpdateImageBuild(ctx, ghClient, repo)
+	return rke2.UpdateImageBuild(ctx, ghClient, repo, owner, cloneDir, dryRun, createPR)
 }

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -10,33 +10,66 @@ import (
 
 	"github.com/google/go-github/v39/github"
 	"github.com/rancher/ecm-distro-tools/docker"
+	"github.com/rancher/ecm-distro-tools/exec"
 	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	goDevURL               = "https://go.dev/dl/?mode=json"
-	imageBuildBaseRepo     = "image-build-base"
-	updateImageBuildScript = `#!/bin/sh
+	goDevURL                       = "https://go.dev/dl/?mode=json"
+	imageBuildBaseRepo             = "image-build-base"
+	updateImageBuildScriptFileName = "update_image_build_base.sh"
+	updateImageBuildScript         = `#!/bin/sh
 set -e
 REPO_NAME={{ .RepoName }}
 REPO_ORG={{ .RepoOrg }}
 DRY_RUN={{ .DryRun }}
+CLONE_DIR={{ .CloneDir }}
+NEW_TAG={{ .NewTag }}
 BRANCH_NAME={{ .BranchName }}
-CLONE_DIR=/tmp/${REPO_NAME}
 echo "repo name: ${REPO_NAME}"
 echo "org name: ${REPO_ORG}"
 echo "dry run: ${DRY_RUN}"
+echo "current tag: ${CURRENT_TAG}"
+echo "branch name: ${BRANCH_NAME}"
 
 echo "cloning ${REPO_ORG}/${REPO_NAME} into ${CLONE_DIR}"
-git clone git@github.com:${REPO_ORG}/${REPO_NAME}.git ${CLONE_DIR}
+git clone "git@github.com:${REPO_ORG}/${REPO_NAME}.git" "${CLONE_DIR}"
 echo "navigating to the repo dir"
-cd ${CLONE_DIR}
+cd "${CLONE_DIR}"
+CURRENT_TAG=$(cat .hardened-build-base-version)
+echo "new tag: ${NEW_TAG}"
 echo "creating local branch"
-git checkout -B ${BRANCH_NAME} origin/main
+git checkout -B "${BRANCH_NAME}" master
 git clean -xfd
-`
+OS=$(uname -s)
+case ${OS} in
+Darwin)
+	sed -i '' "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" Dockerfile
+	;;
+Linux)
+	sed -i "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" Dockerfile
+	;;
+*)
+	>&2 echo "$(OS) not supported yet"
+	exit 1
+	;;
+esac
+git add Dockerfile
+git commit -m "update hardened-build-base to ${NEW_TAG}"
+if [ "${DRY_RUN}" = false ]; then
+	git push --set-upstream origin ${BRANCH_NAME}
+fi`
 )
+
+type UpdateImageBuildArgs struct {
+	RepoName   string
+	RepoOwner  string
+	BranchName string
+	DryRun     bool
+	CloneDir   string
+	NewTag     string
+}
 
 var imageBuildRepos map[string]bool = map[string]bool{
 	"image-build-dns-nodecache":                    true,
@@ -124,9 +157,58 @@ func goVersions(goDevURL string) ([]goVersionRecord, error) {
 	return versions, nil
 }
 
-func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo string) error {
+func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo, owner, cloneDir string, dryRun, createPR bool) error {
 	if _, ok := imageBuildRepos[repo]; !ok {
 		return errors.New("invalid repo, please review the `imageBuildRepos` map")
 	}
+	newTag, err := latestTag(ctx, ghClient, owner, repo)
+	if err != nil {
+		return err
+	}
+	branchName := "update-to-" + newTag
+	data := UpdateImageBuildArgs{
+		RepoName:   repo,
+		RepoOwner:  owner,
+		BranchName: branchName,
+		DryRun:     dryRun,
+		CloneDir:   cloneDir,
+		NewTag:     newTag,
+	}
+	output, err := exec.RunTemplatedScript(cloneDir, updateImageBuildScriptFileName, updateImageBuildScript, data)
+	if err != nil {
+		return err
+	}
+	logrus.Info(output)
+	if createPR {
+		prName := "Update hardened build base to " + newTag
+		logrus.Info("preparing PR")
+		if dryRun {
+			logrus.Info("dry run, PR will not be created")
+			logrus.Info("PR:\n  Name: " + prName + "\n  From: " + owner + ":" + branchName + "\n  To rancher:master")
+			return nil
+		}
+		if err := createPRFromRancher(ctx, ghClient, prName, branchName, owner, repo); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func createPRFromRancher(ctx context.Context, ghClient *github.Client, title, branchName, forkOwner, repo string) error {
+	pull := &github.NewPullRequest{
+		Title:               &title,
+		Base:                github.String("master"),
+		Head:                github.String(forkOwner + ":" + branchName),
+		MaintainerCanModify: github.Bool(true),
+	}
+	_, _, err := ghClient.PullRequests.Create(ctx, "rancher", repo, pull)
+	return err
+}
+
+func latestTag(ctx context.Context, ghClient *github.Client, owner, repo string) (string, error) {
+	release, _, err := ghClient.Repositories.GetLatestRelease(ctx, owner, repo)
+	if err != nil {
+		return "", err
+	}
+	return *release.TagName, nil
 }

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -83,7 +83,7 @@ type UpdateImageBuildArgs struct {
 	CurrentTag string
 }
 
-var imageBuildRepos map[string]bool = map[string]bool{
+var ImageBuildRepos map[string]bool = map[string]bool{
 	"image-build-dns-nodecache":                    true,
 	"image-build-k8s-metrics-server":               true,
 	"image-build-sriov-cni":                        true,
@@ -170,8 +170,8 @@ func goVersions(goDevURL string) ([]goVersionRecord, error) {
 }
 
 func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo, owner, repoPath, workingDir, newTag string, dryRun, createPR bool) error {
-	if _, ok := imageBuildRepos[repo]; !ok {
-		return errors.New("invalid repo, please review the `imageBuildRepos` map")
+	if _, ok := ImageBuildRepos[repo]; !ok {
+		return errors.New("invalid repo, please review the supported repos list")
 	}
 	branchName := "update-to-" + newTag
 	data := UpdateImageBuildArgs{

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -199,7 +199,7 @@ func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo, owner,
 	if createPR {
 		prName := "Update hardened build base to " + newTag
 		logrus.Info("preparing PR")
-		logrus.Info("PR:\n  Name: " + prName + "\n  From: " + owner + ":" + branchName + "\n  To rancher:" + imageBuildDefaultBranch)
+		logrus.Info("PR:\n  Name: " + prName + "\n  From: " + owner + ":" + branchName + "\n  To " + owner + ":" + imageBuildDefaultBranch)
 		if dryRun {
 			logrus.Info("dry run, PR will not be created")
 			return nil
@@ -212,13 +212,13 @@ func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo, owner,
 	return nil
 }
 
-func createPRFromRancher(ctx context.Context, ghClient *github.Client, title, branchName, forkOwner, repo, baseBranch string) error {
+func createPRFromRancher(ctx context.Context, ghClient *github.Client, title, branchName, owner, repo, baseBranch string) error {
 	pull := &github.NewPullRequest{
 		Title:               &title,
 		Base:                github.String(baseBranch),
-		Head:                github.String(forkOwner + ":" + branchName),
+		Head:                github.String(owner + ":" + branchName),
 		MaintainerCanModify: github.Bool(true),
 	}
-	_, _, err := ghClient.PullRequests.Create(ctx, "rancher", repo, pull)
+	_, _, err := ghClient.PullRequests.Create(ctx, owner, repo, pull)
 	return err
 }

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -23,22 +23,22 @@ const (
 	updateImageBuildScriptFileName    = "update_image_build_base.sh"
 	getHardenedBuildTagScript         = `#!/bin/sh
 set -e
-REPO_PATH={{ .RepoPath }}
-DEFAULT_BRANCH={{ .DefaultBranch }}
+REPO_PATH="{{ .RepoPath }}"
+DEFAULT_BRANCH="{{ .DefaultBranch }}"
 cd "${REPO_PATH}"
-git stash
-git switch "${DEFAULT_BRANCH}"
-git pull origin "${DEFAULT_BRANCH}"
+git stash >/dev/null
+git switch "${DEFAULT_BRANCH}" >/dev/null
+git pull origin "${DEFAULT_BRANCH}" >/dev/null
 grep -o -e "hardened-build-base:.*$" Dockerfile
 `
 	updateImageBuildScript = `#!/bin/sh
 set -e
 DRY_RUN={{ .DryRun }}
-NEW_TAG={{ .NewTag }}
-REPO_PATH={{ .RepoPath }}
-BRANCH_NAME={{ .BranchName }}
-CURRENT_TAG={{ .CurrentTag }}
-DEFAULT_BRANCH={{ .DefaultBranch }}
+NEW_TAG="{{ .NewTag }}"
+REPO_PATH="{{ .RepoPath }}"
+BRANCH_NAME="{{ .BranchName }}"
+CURRENT_TAG="{{ .CurrentTag }}"
+DEFAULT_BRANCH="{{ .DefaultBranch }}"
 echo "dry run: ${DRY_RUN}"
 echo "current tag: ${CURRENT_TAG}"
 echo "branch name: ${BRANCH_NAME}"
@@ -74,13 +74,14 @@ fi`
 )
 
 type UpdateImageBuildArgs struct {
-	RepoName   string
-	RepoOwner  string
-	BranchName string
-	DryRun     bool
-	RepoPath   string
-	NewTag     string
-	CurrentTag string
+	RepoName      string
+	RepoOwner     string
+	BranchName    string
+	DryRun        bool
+	RepoPath      string
+	NewTag        string
+	CurrentTag    string
+	DefaultBranch string
 }
 
 var ImageBuildRepos map[string]bool = map[string]bool{
@@ -175,12 +176,13 @@ func UpdateImageBuild(ctx context.Context, ghClient *github.Client, repo, owner,
 	}
 	branchName := "update-to-" + newTag
 	data := UpdateImageBuildArgs{
-		RepoName:   repo,
-		RepoOwner:  owner,
-		BranchName: branchName,
-		DryRun:     dryRun,
-		RepoPath:   repoPath,
-		NewTag:     newTag,
+		RepoName:      repo,
+		RepoOwner:     owner,
+		BranchName:    branchName,
+		DryRun:        dryRun,
+		RepoPath:      repoPath,
+		NewTag:        newTag,
+		DefaultBranch: imageBuildDefaultBranch,
 	}
 	currentTagOutput, err := exec.RunTemplatedScript(workingDir, getHardenedBuildTagScriptFileName, getHardenedBuildTagScript, data)
 	if err != nil {

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -58,9 +58,11 @@ OS=$(uname -s)
 case ${OS} in
 Darwin)
 	sed -i '' "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" Dockerfile
+	sed -i '' "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" .drone.yml
 	;;
 Linux)
 	sed -i "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" Dockerfile
+	sed -i "s/hardened-build-base:${CURRENT_TAG}/hardened-build-base:${NEW_TAG}/" .drone.yml
 	;;
 *)
 	>&2 echo "$(OS) not supported yet"
@@ -68,6 +70,7 @@ Linux)
 	;;
 esac
 git add Dockerfile
+git add .drone.yml
 git commit -m "update hardened-build-base to ${NEW_TAG}"
 if [ "${DRY_RUN}" = false ]; then
 	git push --set-upstream origin ${BRANCH_NAME}


### PR DESCRIPTION
Issue: #275 

* Adds a command to update `image-build-*` repos
It's going to be added as a gh action in those repos, similar to what we've done in `image-build-base`

Create a fork of one of the `image-build-*` repos, like `image-build-calico`
## How to test
refer to the examples in the added documentation
Remember to set `--owner {your-username}`