### PR TITLE
#304: add golang docker alpine version check

### DIFF
--- a/cmd/rke2_release/update_image_build_base.go
+++ b/cmd/rke2_release/update_image_build_base.go
@@ -20,6 +20,16 @@ func imageBuildBaseReleaseCommand() *cli.Command {
 				EnvVars:  []string{"GITHUB_TOKEN"},
 				Required: true,
 			},
+			&cli.StringFlag{
+				Name:     "alpine-version",
+				Aliases:  []string{"a"},
+				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:     "dry-run",
+				Aliases:  []string{"r"},
+				Required: false,
+			},
 		},
 		Action: imageBuildBaseRelease,
 	}
@@ -30,7 +40,9 @@ func imageBuildBaseRelease(c *cli.Context) error {
 	if token == "" {
 		return errors.New("env var GITHUB_TOKEN is required")
 	}
+	alpineVersion := c.String("alpine-version")
+	dryRun := c.Bool("dry-run")
 	ctx := context.Background()
 	ghClient := repository.NewGithub(ctx, token)
-	return rke2.ImageBuildBaseRelease(ctx, ghClient)
+	return rke2.ImageBuildBaseRelease(ctx, ghClient, alpineVersion, dryRun)
 }

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -55,12 +55,12 @@ func ImageBuildBaseRelease(ctx context.Context, ghClient *github.Client, alpineV
 			logrus.Infof("Release:\n  Owner: rancher\n  Repo: %s\n  TagName: %s\n  Name: %s\n", imageBuildBaseRepo, imageBuildBaseTag, imageBuildBaseTag)
 			return nil
 		}
-		_, _, err := ghClient.Repositories.CreateRelease(ctx, "rancher", imageBuildBaseRepo, &github.RepositoryRelease{
+		release := &github.RepositoryRelease{
 			TagName:    github.String(imageBuildBaseTag),
 			Name:       github.String(imageBuildBaseTag),
 			Prerelease: github.Bool(false),
-		})
-		if err != nil {
+		}
+		if _, _, err := ghClient.Repositories.CreateRelease(ctx, "rancher", imageBuildBaseRepo, release); err != nil {
 			return err
 		}
 		logrus.Info("created release for version: " + imageBuildBaseTag)

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -39,15 +39,13 @@ func ImageBuildBaseRelease(ctx context.Context, ghClient *github.Client, alpineV
 		version := strings.Split(version.Version, "go")[1]
 		alpineTag := version + "-alpine" + alpineVersion
 
-		err := docker.CheckImageArchs(ctx, "library", "golang", alpineTag, []string{"amd64", "arm64", "s390x"})
-		if err != nil {
+		if err := docker.CheckImageArchs(ctx, "library", "golang", alpineTag, []string{"amd64", "arm64", "s390x"}); err != nil {
 			return err
 		}
 
 		imageBuildBaseTag := "v" + version + "b1"
 		logrus.Info("stripped version: " + imageBuildBaseTag)
-		_, _, err = ghClient.Repositories.GetReleaseByTag(ctx, "rancher", imageBuildBaseRepo, imageBuildBaseTag)
-		if err == nil {
+		if _, _, err := ghClient.Repositories.GetReleaseByTag(ctx, "rancher", imageBuildBaseRepo, imageBuildBaseTag); err == nil {
 			logrus.Info("release " + imageBuildBaseTag + " already exists")
 			continue
 		}
@@ -57,7 +55,7 @@ func ImageBuildBaseRelease(ctx context.Context, ghClient *github.Client, alpineV
 			logrus.Infof("Release:\n  Owner: rancher\n  Repo: %s\n  TagName: %s\n  Name: %s\n", imageBuildBaseRepo, imageBuildBaseTag, imageBuildBaseTag)
 			return nil
 		}
-		_, _, err = ghClient.Repositories.CreateRelease(ctx, "rancher", imageBuildBaseRepo, &github.RepositoryRelease{
+		_, _, err := ghClient.Repositories.CreateRelease(ctx, "rancher", imageBuildBaseRepo, &github.RepositoryRelease{
 			TagName:    github.String(imageBuildBaseTag),
 			Name:       github.String(imageBuildBaseTag),
 			Prerelease: github.Bool(false),


### PR DESCRIPTION
#304 
Before creating a release at image-build-base, checks if a golang alpine docker image exists

## How to test
```
git fetch --all --tags
git switch 304-check-docker-image-build-base
make rke2_release
cmd/rke2_release/bin/rke2_release-linux-amd64 image-build-base-release -a 3.18 -r
```