### PR TITLE
K3s release improvements

### DIFF
--- a/cmd/k3s_release/README.md
+++ b/cmd/k3s_release/README.md
@@ -23,11 +23,13 @@ Please reference the help menu from the binary.
 | new_k8s_version | Latest released k8s patch version                                                                          |
 | old_k8s_client  | Previous k8s client patch version, usually the same as the k8s version, but with a major of 0 instead of 1 |
 | new_k8s_client  | Latest released k8s client patch version                                                                   |
-| old_k3s_suffix | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                              |
-| new_k3s_suffix | Suffix for the next version `k3s1`                                                                          |
+| old_k3s_suffix  | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                             |
+| new_k3s_suffix  | Suffix for the next version `k3s1`                                                                         |
 | release_branch  | Branch in `k3s-io/k3s` for the minor version e.g: `release-1.28`                                           |
 | workspace       | Local directory to clone repos and create files                                                            |
 | handler         | Your Github username                                                                                       |
+| k3s_remote      | Custom K3S Remote, not required, defaults to `k3s-io`                                                      |
+| k8s_rancher_url | Custom K8s Fork URL, not required, defaults to `git@github.com:k3s-io/kubernetes.git`                      |
 | email           | Email to signoff commits                                                                                   |
 | ssh_key_path    | Path for the local private ssh key                                                                         |
 

--- a/cmd/k3s_release/README.md
+++ b/cmd/k3s_release/README.md
@@ -17,21 +17,22 @@ Please reference the help menu from the binary.
 * An SSH key is also required, follow the Github [Documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) to generate one.
 
 ## Configuration
-| Name            | Description                                                                                                |
-|-----------------|------------------------------------------------------------------------------------------------------------|
-| old_k8s_version | Previous k8s patch version                                                                                 |
-| new_k8s_version | Latest released k8s patch version                                                                          |
-| old_k8s_client  | Previous k8s client patch version, usually the same as the k8s version, but with a major of 0 instead of 1 |
-| new_k8s_client  | Latest released k8s client patch version                                                                   |
-| old_k3s_suffix  | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                             |
-| new_k3s_suffix  | Suffix for the next version `k3s1`                                                                         |
-| release_branch  | Branch in `k3s-io/k3s` for the minor version e.g: `release-1.28`                                           |
-| workspace       | Local directory to clone repos and create files                                                            |
-| handler         | Your Github username                                                                                       |
-| k3s_remote      | Custom K3S Remote, not required, defaults to `k3s-io`                                                      |
-| k8s_rancher_url | Custom K8s Fork URL, not required, defaults to `git@github.com:k3s-io/kubernetes.git`                      |
-| email           | Email to signoff commits                                                                                   |
-| ssh_key_path    | Path for the local private ssh key                                                                         |
+| Name             | Description                                                                                                |
+|------------------|------------------------------------------------------------------------------------------------------------|
+| old_k8s_version  | Previous k8s patch version                                                                                 |
+| new_k8s_version  | Latest released k8s patch version                                                                          |
+| old_k8s_client   | Previous k8s client patch version, usually the same as the k8s version, but with a major of 0 instead of 1 |
+| new_k8s_client   | Latest released k8s client patch version                                                                   |
+| old_k3s_suffix   | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                             |
+| new_k3s_suffix   | Suffix for the next version `k3s1`                                                                         |
+| release_branch   | Branch in `k3s-io/k3s` for the minor version e.g: `release-1.28`                                           |
+| workspace        | Local directory to clone repos and create files                                                            |
+| handler          | Your Github username                                                                                       |
+| k3s_remote       | Custom K3S Remote, not required, defaults to `k3s-io`                                                      |
+| k8s_rancher_url  | Custom K8s Fork URL, not required, defaults to `git@github.com:k3s-io/kubernetes.git`                      |
+| k3s_upstream_url | Custom K3s Upstream URL, not required, defaults to `https://github.com/k3s-io/k3s`                         |
+| email            | Email to signoff commits                                                                                   |
+| ssh_key_path     | Path for the local private ssh key                                                                         |
 
 Example:
 ```json

--- a/cmd/k3s_release/README.md
+++ b/cmd/k3s_release/README.md
@@ -23,13 +23,12 @@ Please reference the help menu from the binary.
 | new_k8s_version | Latest released k8s patch version                                                                          |
 | old_k8s_client  | Previous k8s client patch version, usually the same as the k8s version, but with a major of 0 instead of 1 |
 | new_k8s_client  | Latest released k8s client patch version                                                                   |
-| old_k3s_suffix | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                             |
-| new_k3s_suffix | Suffix for the next version `k3s1`                                                                         |
+| old_k3s_suffix | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                              |
+| new_k3s_suffix | Suffix for the next version `k3s1`                                                                          |
 | release_branch  | Branch in `k3s-io/k3s` for the minor version e.g: `release-1.28`                                           |
 | workspace       | Local directory to clone repos and create files                                                            |
 | handler         | Your Github username                                                                                       |
 | email           | Email to signoff commits                                                                                   |
-| token           | Github Token described [above](#requirements)                                                              |
 | ssh_key_path    | Path for the local private ssh key                                                                         |
 
 Example:
@@ -45,9 +44,12 @@ Example:
   "workspace": "$GOPATH/src/github.com/kubernetes",
   "handler": "YourUsername",
   "email": "your.name@suse.com",
-  "token": "${GITHUB_TOKEN}",
   "ssh_key_path": "$HOME/.ssh/github"
 }
+```
+Export your Github token as an environment variable:
+```bash
+export GITHUB_TOKEN=your_token
 ```
 
 ## Contributions

--- a/cmd/k3s_release/README.md
+++ b/cmd/k3s_release/README.md
@@ -4,6 +4,52 @@ k3s_release is a utility that performs the bulk of the actions to complete a K3s
 
 Please reference the help menu from the binary.
 
+## Requirements
+* OS: Linux
+* Docker
+* Git
+* Go (At least the version used upstream for kubernetes)
+* Sed (GNU)
+* All commands require a Github token (classic) with the following permissions:
+  * Be generated on behalf of an account with access to the `k3s-io/k3s` repo
+  * `repo`
+  * `write:packages`    
+* An SSH key is also required, follow the Github [Documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) to generate one.
+
+## Configuration
+| Name            | Description                                                                                                |
+|-----------------|------------------------------------------------------------------------------------------------------------|
+| old_k8s_version | Previous k8s patch version                                                                                 |
+| new_k8s_version | Latest released k8s patch version                                                                          |
+| old_k8s_client  | Previous k8s client patch version, usually the same as the k8s version, but with a major of 0 instead of 1 |
+| new_k8s_client  | Latest released k8s client patch version                                                                   |
+| old_k3s_suffix | Previous patch version suffix e.g: `k3s1`, this is used to update dependencies                             |
+| new_k3s_suffix | Suffix for the next version `k3s1`                                                                         |
+| release_branch  | Branch in `k3s-io/k3s` for the minor version e.g: `release-1.28`                                           |
+| workspace       | Local directory to clone repos and create files                                                            |
+| handler         | Your Github username                                                                                       |
+| email           | Email to signoff commits                                                                                   |
+| token           | Github Token described [above](#requirements)                                                              |
+| ssh_key_path    | Path for the local private ssh key                                                                         |
+
+Example:
+```json
+{
+  "old_k8s_version": "v1.28.4",
+  "new_k8s_version": "v1.28.5",
+  "old_k8s_client": "v0.28.4",
+  "new_k8s_client": "v0.28.5",
+  "old_k3s_version": "k3s1",
+  "new_k3s_version": "k3s1",
+  "release_branch": "release-1.28",
+  "workspace": "$GOPATH/src/github.com/kubernetes",
+  "handler": "YourUsername",
+  "email": "your.name@suse.com",
+  "token": "${GITHUB_TOKEN}",
+  "ssh_key_path": "$HOME/.ssh/github"
+}
+```
+
 ## Contributions
 
 * File Issue with details of the problem, feature request, etc.

--- a/cmd/k3s_release/README.md
+++ b/cmd/k3s_release/README.md
@@ -52,6 +52,22 @@ Export your Github token as an environment variable:
 export GITHUB_TOKEN=your_token
 ```
 
+## Errors
+
+### Cache Permissions and Docker:
+```bash
+$ k3s_release create-tags -c config-2-26.json
+> FATA[0014] failed to rebase and create tags: chown: changing ownership of '/home/go/.cache': Operation not permitted
+failed to initialize build cache at /home/go/.cache: mkdir /home/go/.cache/00: permission denied 
+```
+Verify if the `$GOPATH/.cache` directory is owned by the same user that is running the command. If not, change the ownership of the directory:
+```bash
+$ ls -la $GOPATH/
+> drwxr-xr-x  2 root root 4096 Dec 20 15:50 .cache
+$ sudo chown $USER $GOPATH/.cache
+```
+
+
 ## Contributions
 
 * File Issue with details of the problem, feature request, etc.

--- a/cmd/k3s_release/create_tags.go
+++ b/cmd/k3s_release/create_tags.go
@@ -30,7 +30,7 @@ func createTags(c *cli.Context) error {
 		logrus.Fatalf("config file: %v", err)
 	}
 
-	client, err := k3s.NewGithubClient(ctx, release.Token)
+	client, err := k3s.NewGithubClient(ctx, release.GithubToken)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}

--- a/cmd/k3s_release/modify_k3s.go
+++ b/cmd/k3s_release/modify_k3s.go
@@ -27,7 +27,7 @@ func modifyK3S(c *cli.Context) error {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
 
-	client, err := k3s.NewGithubClient(ctx, release.Token)
+	client, err := k3s.NewGithubClient(ctx, release.GithubToken)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}

--- a/cmd/k3s_release/modify_k3s.go
+++ b/cmd/k3s_release/modify_k3s.go
@@ -38,9 +38,12 @@ func modifyK3S(c *cli.Context) error {
 	}
 
 	logrus.Info("Creating pull request")
+	if release.DryRun {
+		logrus.Info("Dry Run, Skipping Pull Request")
+		return nil
+	}
 	if err := release.CreatePRFromK3S(ctx, client); err != nil {
 		logrus.Fatalf("failed to create a new PR: %v", err)
 	}
-
 	return nil
 }

--- a/cmd/k3s_release/push_tags.go
+++ b/cmd/k3s_release/push_tags.go
@@ -8,10 +8,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	k3sRemote = "k3s-io"
-)
-
 func pushTagsCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "push-tags",
@@ -44,7 +40,7 @@ func pushTags(c *cli.Context) error {
 	}
 
 	logrus.Infof("pushing tags to github")
-	if err := release.PushTags(ctx, tags, client, k3sRemote); err != nil {
+	if err := release.PushTags(ctx, tags, client); err != nil {
 		logrus.Fatalf("failed to push tags: %v", err)
 	}
 

--- a/cmd/k3s_release/push_tags.go
+++ b/cmd/k3s_release/push_tags.go
@@ -32,7 +32,7 @@ func pushTags(c *cli.Context) error {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
 
-	client, err := k3s.NewGithubClient(ctx, release.Token)
+	client, err := k3s.NewGithubClient(ctx, release.GithubToken)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}

--- a/cmd/k3s_release/tag_rc_release.go
+++ b/cmd/k3s_release/tag_rc_release.go
@@ -10,10 +10,10 @@ import (
 
 func tagRCReleaseCommand() *cli.Command {
 	return &cli.Command{
-		Name:    "tag-rc-release",
-		Usage:   "tag rc release for k3s repo",
-		Flags:   rootFlags,
-		Action:  createRCRelease,
+		Name:   "tag-rc-release",
+		Usage:  "tag rc release for k3s repo",
+		Flags:  rootFlags,
+		Action: createRCRelease,
 	}
 }
 
@@ -27,7 +27,7 @@ func createRCRelease(c *cli.Context) error {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
 
-	client, err := k3s.NewGithubClient(ctx, release.Token)
+	client, err := k3s.NewGithubClient(ctx, release.GithubToken)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}

--- a/cmd/k3s_release/tag_release.go
+++ b/cmd/k3s_release/tag_release.go
@@ -27,7 +27,7 @@ func createRelease(c *cli.Context) error {
 		logrus.Fatalf("failed to read config file: %v", err)
 	}
 
-	client, err := k3s.NewGithubClient(ctx, release.Token)
+	client, err := k3s.NewGithubClient(ctx, release.GithubToken)
 	if err != nil {
 		logrus.Fatalf("failed to initialize a new github client from token: %v", err)
 	}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -511,7 +511,7 @@ func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *githu
 
 	k3sRemote, err := repo.Remote(r.K3sRemote)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to find remote %s: %s", r.K3sRemote, err.Error())
 	}
 
 	cfg.Remotes["origin"] = originRemote.Config()
@@ -613,7 +613,7 @@ func (r *Release) CreatePRFromK3S(ctx context.Context, ghClient *github.Client) 
 	}
 
 	// creating a pr from your fork branch
-	_, _, err := ghClient.PullRequests.Create(ctx, "k3s-io", repo, pull)
+	_, _, err := ghClient.PullRequests.Create(ctx, r.K3sRemote, repo, pull)
 
 	return err
 }
@@ -715,7 +715,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 		opts := &repository.CreateReleaseOpts{
 			Repo:         k3sRepo,
 			Name:         name,
-			Owner:        "k3s-io",
+			Owner:        r.K3sRemote,
 			Prerelease:   rc,
 			Branch:       r.ReleaseBranch,
 			Draft:        !rc,
@@ -723,12 +723,12 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 		}
 
 		if !rc {
-			latestRc, err := release.LatestRC(ctx, "k3s-io", k3sRepo, r.NewK8SVersion, client)
+			latestRc, err := release.LatestRC(ctx, r.K3sRemote, k3sRepo, r.NewK8SVersion, client)
 			if err != nil {
 				return err
 			}
 
-			buff, err := release.GenReleaseNotes(ctx, "k3s-io", k3sRepo, latestRc, oldName, client)
+			buff, err := release.GenReleaseNotes(ctx, r.K3sRemote, k3sRepo, latestRc, oldName, client)
 			if err != nil {
 				return err
 			}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -489,7 +489,7 @@ func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *githu
 	}
 
 	for i, tagCmd := range tagsCmds {
-		logrus.Infof("pushing tag %d/%d", i, len(tagsCmds))
+		logrus.Infof("pushing tag %d/%d", i+1, len(tagsCmds))
 		tagCmdStr := tagCmd
 		tag := strings.Split(tagCmdStr, " ")[3]
 		if err := repo.Push(&git.PushOptions{

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -398,10 +398,8 @@ func (r *Release) setupGitArtifacts() (string, error) {
 }
 
 func (r *Release) runTagScript(gitConfigFile, wrapperImageTag string) (string, error) {
-	const (
-		containerK8sPath     = "/home/go/src/kubernetes"
-		containerGoCachePath = "/home/go/.cache"
-	)
+	const containerK8sPath = "/home/go/src/kubernetes"
+	const containerGoCachePath = "/home/go/.cache"
 	uid := strconv.Itoa(os.Getuid())
 	gid := strconv.Itoa(os.Getgid())
 
@@ -414,28 +412,19 @@ func (r *Release) runTagScript(gitConfigFile, wrapperImageTag string) (string, e
 	k8sDir := filepath.Join(r.Workspace, "kubernetes")
 
 	// prep the docker run command
-	goWrapper := []string{
+	args := []string{
 		"run",
-		"-u",
-		uid + ":" + gid,
-		"-v",
-		gopath + ":/home/go:rw",
-		"-v",
-		gitConfigFile + ":/home/go/.gitconfig:rw",
-		"-v",
-		k8sDir + ":" + containerK8sPath + ":rw",
-		"-v",
-		gopath + "/.cache:" + containerGoCachePath + ":rw",
-		"-e",
-		"HOME=/home/go",
-		"-e",
-		"GOCACHE=" + containerGoCachePath,
-		"-w",
-		containerK8sPath,
+		"-u", uid + ":" + gid,
+		"-v", gopath + ":/home/go:rw",
+		"-v", gitConfigFile + ":/home/go/.gitconfig:rw",
+		"-v", k8sDir + ":" + containerK8sPath + ":rw",
+		"-v", gopath + "/.cache:" + containerGoCachePath + ":rw",
+		"-e", "HOME=/home/go",
+		"-e", "GOCACHE=" + containerGoCachePath,
+		"-w", containerK8sPath,
 		wrapperImageTag,
+		"./tag.sh", r.NewK8SVersion + "-k3s1",
 	}
-
-	args := append(goWrapper, "./tag.sh", r.NewK8SVersion+"-k3s1")
 
 	return ecmExec.RunCommand(k8sDir, "docker", args...)
 }

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -79,7 +79,7 @@ type Release struct {
 	OldK3SVersion string `json:"old_k3s_version"`
 	NewK3SVersion string `json:"new_k3s_version"`
 	OldGoVersion  string `json:"old_go_version"`
-	NewGoVersion  string `json:"-"`
+	NewGoVersion  string `json:"new_go_version"`
 	ReleaseBranch string `json:"release_branch"`
 	Workspace     string `json:"workspace"`
 	Handler       string `json:"handler"`
@@ -669,6 +669,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 		opts := &repository.CreateReleaseOpts{
 			Repo:         k3sRepo,
 			Name:         name,
+			Owner:        "k3s-io",
 			Prerelease:   rc,
 			Branch:       r.ReleaseBranch,
 			Draft:        !rc,
@@ -690,6 +691,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 
 		if _, err := repository.CreateRelease(ctx, client, opts); err != nil {
 			githubErr := err.(*github.ErrorResponse)
+			logrus.Printf("error: %+v", githubErr)
 			if strings.Contains(githubErr.Errors[0].Code, "already_exists") {
 				if !rc {
 					return err

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -734,7 +734,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 
 		if _, err := repository.CreateRelease(ctx, client, opts); err != nil {
 			githubErr := err.(*github.ErrorResponse)
-			logrus.Printf("error: %+v", githubErr)
+			logrus.Debugf("error: %+v", githubErr)
 			if strings.Contains(githubErr.Errors[0].Code, "already_exists") {
 				if !rc {
 					return err

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -520,6 +520,7 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 		}
 	}
 
+	logrus.Info("creating modify script")
 	modifyScriptPath := filepath.Join(r.Workspace, "modify_script.sh")
 	f, err := os.Create(modifyScriptPath)
 	if err != nil {
@@ -542,6 +543,7 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 		return err
 	}
 
+	logrus.Info("running modify script")
 	if _, err := ecmExec.RunCommand(r.Workspace, "bash", "./modify_script.sh"); err != nil {
 		return err
 	}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -44,8 +44,8 @@ ARG UID=1000
 ARG GID=1000
 RUN addgroup -S -g $GID ecmgroup && adduser -S -G ecmgroup -u $UID user
 USER user`
-
-	modifyScript = `#!/bin/bash
+	modifyScriptName = "modify_script.sh"
+	modifyScript     = `#!/bin/bash
 set -ex
 OS=$(uname -s)
 DRY_RUN={{ .DryRun }}
@@ -562,7 +562,7 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 	r.NewGoVersion = goVersion
 
 	logrus.Info("creating modify script")
-	modifyScriptPath := filepath.Join(r.Workspace, "modify_script.sh")
+	modifyScriptPath := filepath.Join(r.Workspace, modifyScriptName)
 	f, err := os.Create(modifyScriptPath)
 	if err != nil {
 		return err
@@ -575,7 +575,7 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 	funcMap := template.FuncMap{
 		"replaceAll": strings.ReplaceAll,
 	}
-	tmpl, err := template.New("modify_script.sh").Funcs(funcMap).Parse(modifyScript)
+	tmpl, err := template.New(modifyScriptName).Funcs(funcMap).Parse(modifyScript)
 	if err != nil {
 		return err
 	}
@@ -585,7 +585,7 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 	}
 
 	logrus.Info("running modify script")
-	out, err := ecmExec.RunCommand(r.Workspace, "bash", "./modify_script.sh")
+	out, err := ecmExec.RunCommand(r.Workspace, "bash", "./"+modifyScriptName)
 	if err != nil {
 		return err
 	}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -141,6 +141,10 @@ func NewRelease(configPath string) (*Release, error) {
 	}
 	release.GithubToken = githubToken
 
+	if !release.DryRun {
+		release.DryRun = false
+	}
+
 	if release.K3sRemote == "" {
 		release.K3sRemote = rancherRemote
 	}
@@ -696,8 +700,8 @@ func cleanGitRepo(dir string) error {
 
 func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc bool) error {
 	rcNum := 1
-	name := r.NewK8SClient + "+" + r.NewK3SSuffix
-	oldName := r.OldK8SVersion + "+" + r.OldK8SVersion
+	name := r.NewK8SVersion + "+" + r.NewK3SSuffix
+	oldName := r.OldK8SVersion + "+" + r.OldK3SSuffix
 
 	for {
 		if rc {
@@ -708,7 +712,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 			Repo:         k3sRepo,
 			Name:         name,
 			Owner:        r.K3sRemote,
-			Prerelease:   rc,
+			Prerelease:   true,
 			Branch:       r.ReleaseBranch,
 			Draft:        !rc,
 			ReleaseNotes: "",
@@ -720,6 +724,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 				return err
 			}
 
+			logrus.Infof("k3sRemote: %s | k3sRepo: %s | latestRc: %s | oldName: %s", r.K3sRemote, k3sRepo, latestRc, oldName)
 			buff, err := release.GenReleaseNotes(ctx, r.K3sRemote, k3sRepo, latestRc, oldName, client)
 			if err != nil {
 				return err

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -528,9 +528,13 @@ func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *githu
 	}
 
 	for i, tagCmd := range tagsCmds {
-		logrus.Infof("pushing tag %d/%d", i+1, len(tagsCmds))
 		tagCmdStr := tagCmd
 		tag := strings.Split(tagCmdStr, " ")[3]
+		logrus.Infof("pushing tag %d/%d: %s", i+1, len(tagsCmds), tag)
+		if r.DryRun {
+			logrus.Info("Dry run, skipping tag creation")
+			continue
+		}
 		if err := repo.Push(&git.PushOptions{
 			RemoteName: remote,
 			Auth:       gitAuth,

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -544,9 +544,11 @@ func (r *Release) ModifyAndPush(_ context.Context) error {
 	}
 
 	logrus.Info("running modify script")
-	if _, err := ecmExec.RunCommand(r.Workspace, "bash", "./modify_script.sh"); err != nil {
+	out, err := ecmExec.RunCommand(r.Workspace, "bash", "./modify_script.sh")
+	if err != nil {
 		return err
 	}
+	logrus.Info(out)
 
 	return nil
 }

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -59,6 +59,7 @@ const (
 		sed -Ei "\|github.com/k3s-io/kubernetes| s|{{ replaceAll .OldK8SVersion "." "\\." }}-{{ .OldK3SVersion }}|{{ replaceAll .NewK8SVersion "." "\\." }}-{{ .NewK3SVersion }}|" go.mod
 		sed -Ei "s/k8s.io\/kubernetes v\S+/k8s.io\/kubernetes {{ replaceAll .NewK8SVersion "." "\\." }}/" go.mod
 		sed -Ei "s/{{ replaceAll .OldK8SClient "." "\\." }}/{{ replaceAll .NewK8SClient "." "\\." }}/g" go.mod # This should only change ~6 lines in go.mod
+		sed -Ei "s/{{ replaceAll .OldGoVersion "." "\\." }}/{{ replaceAll .NewGoVersion "." "\\." }}/g" Dockerfile.* .github/workflows/integration.yaml .github/workflows/unitcoverage.yaml
 		
 		go mod tidy
 		# There is no need for running make since the changes will be only for go.mod
@@ -77,6 +78,8 @@ type Release struct {
 	NewK8SClient  string `json:"new_k8s_client"`
 	OldK3SVersion string `json:"old_k3s_version"`
 	NewK3SVersion string `json:"new_k3s_version"`
+	OldGoVersion  string `json:"old_go_version"`
+	NewGoVersion  string `json:"-"`
 	ReleaseBranch string `json:"release_branch"`
 	Workspace     string `json:"workspace"`
 	Handler       string `json:"handler"`

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -536,7 +536,7 @@ func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *githu
 			},
 		}); err != nil {
 			if err != git.NoErrAlreadyUpToDate {
-				logrus.Fatal("failed to push tag: " + err.Error())
+				return errors.New("failed to push tag: " + err.Error())
 			}
 		}
 	}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -464,7 +464,7 @@ func (r *Release) TagsFromFile(_ context.Context) ([]string, error) {
 
 }
 
-func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *github.Client, remote string) error {
+func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *github.Client) error {
 	// here we can use go-git library or ecmExec.RunCommand function
 	// I am using go-git library to enhance code quality
 	gitConfigFile, err := r.setupGitArtifacts()
@@ -525,7 +525,7 @@ func (r *Release) PushTags(_ context.Context, tagsCmds []string, ghClient *githu
 			continue
 		}
 		if err := repo.Push(&git.PushOptions{
-			RemoteName: remote,
+			RemoteName: r.K3sRemote,
 			Auth:       gitAuth,
 			Progress:   os.Stdout,
 			RefSpecs: []config.RefSpec{

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -743,6 +743,7 @@ func (r *Release) CreateRelease(ctx context.Context, client *github.Client, rc b
 					return err
 				}
 
+				logrus.Printf("RC %d already exists, trying to create next", rcNum)
 				rcNum += 1
 				continue
 			}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -99,7 +99,7 @@ type Release struct {
 	Workspace     string `json:"workspace"`
 	Handler       string `json:"handler"`
 	Email         string `json:"email"`
-	Token         string `json:"token"`
+	GithubToken   string `json:"-"`
 	SSHKeyPath    string `json:"ssh_key_path"`
 	DryRun        bool   `json:"dry_run"`
 }
@@ -127,6 +127,12 @@ func NewRelease(configPath string) (*Release, error) {
 	if !filepath.IsAbs(release.Workspace) {
 		return nil, errors.New("workspace path must be an absolute path")
 	}
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, errors.New("missing GITHUB_TOKEN env var")
+	}
+	release.GithubToken = githubToken
 
 	return &release, nil
 }


### PR DESCRIPTION
# Changes:
* Closes: #323 adds the missing `k3s-io` remote to create the PR against.
* Closes: #322 the go version wasn't being updated in the modify command, this was added.
* Adds macOS support
* Adds dry run for the modify script
* Renames `OldK3SVersion` and `NewK3SVersion` to `OldK3SSuffix` and `NewK3SSuffix` to reflect their usage in the code
* Renames `Token` to `GithubToken`
* Moves `GithubToken` out of the config to an env var
* Adds some customization parameters to run the commands against forks instead of `k3s-io`

# How to test
* Fork [tashima42/k3s](https://github.com/Tashima42/k3s) and [tashima42/kubernetes](https://github.com/Tashima42/kubernetes) copying all tags, not just `master`
Config:
```json
{
  "old_k8s_version": "v1.27.4",
  "new_k8s_version": "v1.27.5",
  "old_k8s_client": "v0.27.4",
  "new_k8s_client": "v0.27.5",
  "old_k3s_suffix": "k3s1",
  "new_k3s_suffix": "k3s1",
  "release_branch": "release-1.27",
  "workspace": "$GOPATH/src/github.com/kubernetes",
  "handler": "YOURHANDLER",
  "email": "your.email@suse.com",
  "ssh_key_path": "$HOME/.ssh/id_ed25519",
  "k3s_remote": "YOURHANDLER",
  "k8s_rancher_url": "git@github.com:YOURHANDLER/kubernetes.git",
  "k3s_upstream_url": "https://github.com/YOURHANDLER/k3s",
  "dry_run": true
}
```
```bash
cat config-template.json | envsubst > config.json
export GITHUB_TOKEN=your_token
k3s_release create-tags -c config.json
k3s_release push-tags -c config.json
k3s_release modify-k3s -c config.json
k3s_release tag-rc-release -c config.json
k3s_release tag-release -c config.json
```