### PR TITLE
add generate config command

### DIFF
--- a/cmd/k3s_release/generate_config.go
+++ b/cmd/k3s_release/generate_config.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"github.com/rancher/ecm-distro-tools/release/k3s"
+	"github.com/urfave/cli/v2"
+)
+
+func generateConfigCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "generate-config",
+		Usage: "Generate a k3s release configuration file",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "version",
+				Aliases:  []string{"v"},
+				Usage:    "version to generate the config for",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "ssh-path",
+				Aliases:  []string{"s"},
+				Usage:    "ssh key path",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "generate-path",
+				Aliases:  []string{"g"},
+				Usage:    "path to generate the configuration in",
+				Value:    ".",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "workspace",
+				Aliases:  []string{"w"},
+				Usage:    "directory to clone repositories and create files",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "handler",
+				Aliases:  []string{"r"},
+				Usage:    "your github handler",
+				Required: true,
+			},
+		},
+		Action: generateConfg,
+	}
+}
+
+func generateConfg(c *cli.Context) error {
+	version := c.String("version")
+	sshPath := c.String("ssh-path")
+	generatePath := c.String("generate-path")
+	workspace := c.String("workspace")
+	handler := c.String("handler")
+	return k3s.GenerateConfig(version, sshPath, generatePath, workspace, handler)
+}

--- a/cmd/k3s_release/main.go
+++ b/cmd/k3s_release/main.go
@@ -32,6 +32,7 @@ func main() {
 		modifyK3SCommand(),
 		tagRCReleaseCommand(),
 		tagReleaseCommand(),
+		generateConfigCommand(),
 	}
 	app.Flags = rootFlags
 

--- a/release/k3s/k3s_test.go
+++ b/release/k3s/k3s_test.go
@@ -1,0 +1,29 @@
+package k3s
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetK3sChannels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"type":"collection","links":{"self":"…/v1-release/channels"},"actions":{},"resourceType":"channels","data":[{"id":"latest","type":"channel","links":{"self":"…/v1-release/channels/latest"},"name":"latest","latest":"v1.29.0+k3s1","latestRegexp":".*","excludeRegexp":"(^[^+]+-|v1\\.25\\.5\\+k3s1|v1\\.26\\.0\\+k3s1)"},{"id":"v1.29","type":"channel","links":{"self":"…/v1-release/channels/v1.29"},"name":"v1.29","latest":"v1.29.0+k3s1","latestRegexp":"v1\\.29\\..*","excludeRegexp":"^[^+]+-"}]}`))
+	}))
+	defer server.Close()
+
+	channels, err := getK3sChannels(server.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	if channels.Data[0].ID != "latest" {
+		t.Error("first entry should be latest")
+	}
+	if channels.Data[1].ID != "v1.29" {
+		t.Error("second entry should be v1.29")
+	}
+	if channels.Data[1].Latest != "v1.29.0+k3s1" {
+		t.Error("v1.29 latest version should be v1.29.0+k3s1")
+	}
+}


### PR DESCRIPTION
This command uses the provided information to generate a k3s release config file.

Example:
```bash
generate-config -s ~/.ssh/id_ed25519 -w $GOPATH/src/github.com/kubernetes/ -r tashima42 -v 1.25
```
Generates:
```json
{
 "old_k8s_version": "1.25.16",
 "new_k8s_version": "1.25.17",
 "old_k8s_client": "0.25.16",
 "new_k8s_client": "0.25.17",
 "old_k3s_suffix": "k3s4",
 "new_k3s_suffix": "k3s1",
 "release_branch": "release-1.25",
 "workspace": "/Users/pedrosuse/go/src/github.com/kubernetes",
 "handler": "tashima42",
 "email": "pedro.tashima@suse.com",
 "ssh_key_path": "/Users/pedrosuse/.ssh/id_ed25519"
}
```