### PR TITLE
#332: add backport label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/MetalBlueberry/go-plotly v0.4.0
 	github.com/spf13/cobra v1.8.0
 	github.com/urfave/cli/v2 v2.25.7
+	golang.org/x/text v0.8.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rancher/ecm-distro-tools/types"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -190,7 +192,8 @@ type ChangeLog struct {
 
 // CreateBackportIssues
 func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue *github.Issue, owner, repo, branch, user string, i *Issue) (*github.Issue, error) {
-	title := fmt.Sprintf(i.Title, strings.Title(branch), origIssue.GetTitle())
+	caser := cases.Title(language.English)
+	title := fmt.Sprintf(i.Title, caser.String(branch), origIssue.GetTitle())
 	body := fmt.Sprintf(i.Body, origIssue.GetTitle(), *origIssue.Number)
 
 	var assignee *string

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -207,6 +207,7 @@ func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue 
 	issue, _, err := client.Issues.Create(ctx, owner, repo, &github.IssueRequest{
 		Title:    github.String(title),
 		Body:     github.String(body),
+		Labels:   &[]string{"kind/backport"},
 		Assignee: assignee,
 	})
 	if err != nil {


### PR DESCRIPTION
Closes: #332 
* Replaces the deprecated usage of `strings.Title`
* Adds the label `kind/backport` to the issue creation