### PR TITLE
#335: add config view command

### DIFF
--- a/cmd/release/cmd/config.go
+++ b/cmd/release/cmd/config.go
@@ -33,8 +33,13 @@ var viewConfigSubCmd = &cobra.Command{
 	Use:   "view",
 	Short: "view config",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Here we are!")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		conf, err := rootConfig.String()
+		if err != nil {
+			return err
+		}
+		fmt.Println(conf)
+		return nil
 	},
 }
 

--- a/cmd/release/cmd/root.go
+++ b/cmd/release/cmd/root.go
@@ -4,11 +4,8 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -26,29 +23,21 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(1)
+		logrus.Fatal(err)
 	}
 }
 
 func init() {
-	rootCmd.Flags().BoolP("debug", "d", false, "Debug")
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Debug")
 
-	homeDir, err := os.UserHomeDir()
+	configPath, err := config.DefaultConfigPath()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		logrus.Fatal(err)
+	}
+	conf, err := config.Load(configPath)
+	if err != nil {
+		logrus.Fatal(err)
 	}
 
-	const (
-		ecmDistroDir   = ".ecm-distro-tools"
-		configFileName = "config.json"
-	)
-	configFile := filepath.Join(homeDir, ecmDistroDir, configFileName)
-
-	conf, err := config.Load(configFile)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
 	rootConfig = conf
 }

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -4,6 +4,12 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
+)
+
+const (
+	ecmDistroDir   = ".ecm-distro-tools"
+	configFileName = "config.json"
 )
 
 // K3sRelease
@@ -57,6 +63,14 @@ type Config struct {
 	Auth *Auth `json:"auth"`
 }
 
+func DefaultConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", nil
+	}
+	return filepath.Join(homeDir, ecmDistroDir, configFileName), nil
+}
+
 // Load reads the given config file and returns a struct
 // containing the necessary values to perform a release.
 func Load(configFile string) (*Config, error) {
@@ -73,4 +87,12 @@ func read(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (c *Config) String() (string, error) {
+	b, err := json.MarshalIndent(c, "", " ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }


### PR DESCRIPTION
Closes: #335 
Adds the config view command

```bash
cmd/release/bin/release-darwin-arm64 config view
```