### PR TITLE
Add version to commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build ECM Distro Tools
         run: |
+          export VERSION=${GITHUB_REF_NAME}
           make test
           make package-binaries
       - name: Publish Binaries

--- a/cmd/backport/Makefile
+++ b/cmd/backport/Makefile
@@ -5,8 +5,8 @@ GO = go
 BINDIR := bin
 BINARY := backport
 
-VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
+VERSION           ?= snapshot-${GIT_SHA}
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
 $(BINDIR)/$(BINARY): clean

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "development"
+
 type BackportCmdOpts struct {
 	Repo     string
 	Issue    uint
@@ -24,10 +26,11 @@ var backportCmdOpts BackportCmdOpts
 
 func main() {
 	cmd := &cobra.Command{
-		Use:   "backport",
-		Short: "Generate backport issues and cherry pick commits to branches",
-		Long:  "The backport utility needs to be executed inside the repository you want to perform the actions",
-		RunE:  backport,
+		Use:     "backport",
+		Short:   "Generate backport issues and cherry pick commits to branches",
+		Long:    "The backport utility needs to be executed inside the repository you want to perform the actions",
+		RunE:    backport,
+		Version: version,
 	}
 
 	cmd.Flags().StringVarP(&backportCmdOpts.Repo, "repo", "r", "", "name of the repository to perform the backport (k3s, rke2)")

--- a/cmd/release/Makefile
+++ b/cmd/release/Makefile
@@ -5,8 +5,8 @@ GO = go
 BINDIR := bin
 BINARY := release
 
-VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
+VERSION           ?= snapshot-${GIT_SHA}
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
 

--- a/cmd/release/cmd/root.go
+++ b/cmd/release/cmd/root.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (
@@ -28,6 +25,10 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+func SetVersion(version string) {
+	rootCmd.Version = version
 }
 
 func init() {

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -2,6 +2,9 @@ package main
 
 import "github.com/rancher/ecm-distro-tools/cmd/release/cmd"
 
+var version = "development"
+
 func main() {
+	cmd.SetVersion(version)
 	cmd.Execute()
 }

--- a/cmd/semv/Makefile
+++ b/cmd/semv/Makefile
@@ -5,8 +5,8 @@ GO = go
 BINDIR := bin
 BINARY := semv
 
-VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
+VERSION           ?= snapshot-${GIT_SHA}
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
 

--- a/cmd/test_coverage/Makefile
+++ b/cmd/test_coverage/Makefile
@@ -5,8 +5,8 @@ GO = go
 BINDIR := bin
 BINARY := test_coverage
 
-VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
+VERSION           ?= snapshot-${GIT_SHA}
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
 

--- a/cmd/test_coverage/main.go
+++ b/cmd/test_coverage/main.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	version   = "development"
 	rootFlags = []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "verbose",
@@ -45,6 +46,7 @@ func main() {
 	app.UseShortOptionHandling = true
 	app.Flags = rootFlags
 	app.Action = coverage
+	app.Version = version
 	err := app.Run(os.Args)
 	if err != nil {
 		logrus.Fatal(err)

--- a/cmd/upstream_go_version/Makefile
+++ b/cmd/upstream_go_version/Makefile
@@ -5,8 +5,8 @@ GO = go
 BINDIR := bin
 BINARY := upstream_go_version
 
-VERSION           = v0.1.0
 GIT_SHA           = $(shell git rev-parse HEAD)
+VERSION           ?= snapshot-${GIT_SHA}
 override LDFLAGS += -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY) -extldflags '-static -Wl,--fatal-warnings'
 TAGS              = "netgo osusergo no_stage static_build"
 


### PR DESCRIPTION
Adds version information to some commands.
Commands that this wasn't added to will be deprecated soon in favor of the new `release` command