### PR TITLE
Add skip create issue to backport

### DIFF
--- a/cmd/backport/README.md
+++ b/cmd/backport/README.md
@@ -15,6 +15,7 @@ If a commit is provided, `backport` assumes you're running from the repository t
 | `commits`, `c`                      | Commits to be backported, if none is provided, only the issues will be created. When passing this flag, it assumes you're running from the repository this operation is related to (comma separated) | FALSE        |
 | `user`, `u`                         | User to assign new issues to (default: user assignted to the original issue)                                                                                                                         | FALSE        |
 | `dry-run`, `n`                      | Skip creating issues and pushing changes to remote                                                                                                                                                   | FALSE        |
+| `skip-create-issue`, `s`            | Skip creating issues                                                                                                                                                                                 | FALSE        |
 | `github-token`, `g`, `GITHUB_TOKEN` | Github Token                                                                                                                                                                                         | TRUE         |
 
 ### Examples

--- a/cmd/backport/main.go
+++ b/cmd/backport/main.go
@@ -13,13 +13,14 @@ import (
 var version = "development"
 
 type BackportCmdOpts struct {
-	Repo     string
-	Issue    uint
-	Commits  []string
-	Branches []string
-	User     string
-	Owner    string
-	DryRun   bool
+	Repo            string
+	Issue           uint
+	Commits         []string
+	Branches        []string
+	User            string
+	Owner           string
+	DryRun          bool
+	SkipCreateIssue bool
 }
 
 var backportCmdOpts BackportCmdOpts
@@ -40,6 +41,7 @@ func main() {
 	cmd.Flags().StringVarP(&backportCmdOpts.User, "user", "u", "", "user to assign new issues to (default: user assigned to the original issue)")
 	cmd.Flags().StringVarP(&backportCmdOpts.Owner, "owner", "o", "", "owner of the repository, e.g: k3s-io, rancher")
 	cmd.Flags().BoolVarP(&backportCmdOpts.DryRun, "dry-run", "n", false, "skip creating issues and pushing changes to remote")
+	cmd.Flags().BoolVarP(&backportCmdOpts.DryRun, "skip-create-issue", "s", false, "skip creating issues")
 
 	if err := cmd.MarkFlagRequired("repo"); err != nil {
 		logrus.Fatal(err)
@@ -68,13 +70,14 @@ func backport(cmd *cobra.Command, args []string) error {
 	githubClient := repository.NewGithub(ctx, githubToken)
 
 	pbo := &repository.PerformBackportOpts{
-		Owner:    backportCmdOpts.Owner,
-		Repo:     backportCmdOpts.Repo,
-		Branches: backportCmdOpts.Branches,
-		Commits:  backportCmdOpts.Commits,
-		IssueID:  backportCmdOpts.Issue,
-		User:     backportCmdOpts.User,
-		DryRun:   backportCmdOpts.DryRun,
+		Owner:           backportCmdOpts.Owner,
+		Repo:            backportCmdOpts.Repo,
+		Branches:        backportCmdOpts.Branches,
+		Commits:         backportCmdOpts.Commits,
+		IssueID:         backportCmdOpts.Issue,
+		User:            backportCmdOpts.User,
+		DryRun:          backportCmdOpts.DryRun,
+		SkipCreateIssue: backportCmdOpts.SkipCreateIssue,
 	}
 	issues, err := repository.PerformBackport(ctx, githubClient, pbo)
 	if err != nil {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -219,13 +219,14 @@ func CreateBackportIssues(ctx context.Context, client *github.Client, origIssue 
 
 // PerformBackportOpts
 type PerformBackportOpts struct {
-	Owner    string   `json:"owner"`
-	Repo     string   `json:"repo"`
-	Commits  []string `json:"commits"`
-	IssueID  uint     `json:"issue_id"`
-	Branches []string `json:"branches"`
-	User     string   `json:"user"`
-	DryRun   bool     `json:"dry_run"`
+	Owner           string   `json:"owner"`
+	Repo            string   `json:"repo"`
+	Commits         []string `json:"commits"`
+	IssueID         uint     `json:"issue_id"`
+	Branches        []string `json:"branches"`
+	User            string   `json:"user"`
+	DryRun          bool     `json:"dry_run"`
+	SkipCreateIssue bool     `json:"skip_create_issue"`
 }
 
 // PerformBackport creates backport issues, performs a cherry-pick of the
@@ -335,8 +336,8 @@ func PerformBackport(ctx context.Context, client *github.Client, pbo *PerformBac
 		}
 
 		logrus.Info("creating issue | owner: " + pbo.Owner + " | Repo: " + pbo.Repo + " | Branch: " + branch)
-		if pbo.DryRun {
-			logrus.Info("dry run, skipping issue creation")
+		if pbo.DryRun || pbo.SkipCreateIssue {
+			logrus.Info("skipping issue creation")
 			continue
 		}
 		newIssue, err := CreateBackportIssues(ctx, client, origIssue, pbo.Owner, pbo.Repo, branch, pbo.User, &issue)


### PR DESCRIPTION
* Adds a flag to skip creating issues.

Some backports issues were created, but not the branches, so a dev requested the ability to cherry pick and create branches without duplicating issues.