### PR TITLE
release fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN zypper update -y && \
 COPY --from=builder /ecm-distro-tools/cmd/backport/bin/backport-linux-amd64 /usr/local/bin/backport
 COPY --from=builder /ecm-distro-tools/cmd/gen_release_notes/bin/gen_release_notes-linux-amd64 /usr/local/bin/gen_release_notes
 COPY --from=builder /ecm-distro-tools/cmd/gen_release_report/bin/gen_release_report-linux-amd64 /usr/local/bin/gen_release_report
-COPY --from=builder /ecm-distro-tools/cmd/k3s_release/bin/k3s_release-linux-amd64 /usr/local/bin/k3s_release
+COPY --from=builder /ecm-distro-tools/cmd/release/bin/release-linux-amd64 /usr/local/bin/release
 COPY --from=builder /ecm-distro-tools/cmd/rancher_release/bin/rancher_release-linux-amd64 /usr/local/bin/rancher_release
 COPY --from=builder /ecm-distro-tools/cmd/rke2_release/bin/rke2_release-linux-amd64 /usr/local/bin/rke2_release
 COPY --from=builder /ecm-distro-tools/cmd/semv/bin/semv-linux-amd64 /usr/local/bin/semv

--- a/cmd/release/cmd/root.go
+++ b/cmd/release/cmd/root.go
@@ -40,9 +40,11 @@ func init() {
 		os.Exit(1)
 	}
 
-	if os.Args[1] == "config" && os.Args[2] == "gen" {
-		fmt.Println("running release config gen, skipping config load")
-		return
+	if len(os.Args) >= 2 {
+		if os.Args[1] == "config" && os.Args[2] == "gen" {
+			fmt.Println("running release config gen, skipping config load")
+			return
+		}
 	}
 	conf, err := config.Load(configPath)
 	if err != nil {


### PR DESCRIPTION
* removes `k3s_build` and add `release` to dockerfile
* fixes a bug where the release cmd would panic if not provided with at least two args