### PR TITLE
#335: view config

### DIFF
--- a/cmd/release/cmd/config.go
+++ b/cmd/release/cmd/config.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -42,7 +41,7 @@ var viewConfigSubCmd = &cobra.Command{
 	Short: "view config",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.New("not implemented yet")
+		return config.View(rootConfig)
 	},
 }
 

--- a/cmd/release/cmd/config.go
+++ b/cmd/release/cmd/config.go
@@ -11,8 +11,7 @@ import (
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "",
-	Long:  ``,
+	Short: "Manage the ecm distro tools cli config file",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			rootCmd.Help()
@@ -23,8 +22,7 @@ var configCmd = &cobra.Command{
 
 var genConfigSubCmd = &cobra.Command{
 	Use:   "gen",
-	Short: "generate config",
-	Long:  `generates a new config in the default location if it doesn't exists`,
+	Short: "Generates a config file in the default location if it doesn't exists",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Generate(); err != nil {
 			return err
@@ -38,8 +36,7 @@ var genConfigSubCmd = &cobra.Command{
 
 var viewConfigSubCmd = &cobra.Command{
 	Use:   "view",
-	Short: "view config",
-	Long:  ``,
+	Short: "Print the parsed config to stdout",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return config.View(rootConfig)
 	},
@@ -47,7 +44,7 @@ var viewConfigSubCmd = &cobra.Command{
 
 var editConfigSubCmd = &cobra.Command{
 	Use:   "edit",
-	Short: "edit config",
+	Short: "Open the config file in your default editor",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return config.OpenOnEditor()

--- a/cmd/release/cmd/config.go
+++ b/cmd/release/cmd/config.go
@@ -11,7 +11,7 @@ import (
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Manage the ecm distro tools cli config file",
+	Short: "Manage the release cli config file",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			rootCmd.Help()

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -23,7 +23,7 @@ var (
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "",
+	Short: "Various utilities to generate release artifacts",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 || len(args) > 2 {
 			rootCmd.Help()
@@ -34,12 +34,12 @@ var generateCmd = &cobra.Command{
 
 var k3sGenerateSubCmd = &cobra.Command{
 	Use:   "k3s",
-	Short: "",
+	Short: "Generate k3s related artifacts",
 }
 
 var k3sGenerateReleaseNotesSubCmd = &cobra.Command{
 	Use:   "release-notes",
-	Short: "",
+	Short: "Generate k3s release notes",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
@@ -57,7 +57,7 @@ var k3sGenerateReleaseNotesSubCmd = &cobra.Command{
 
 var k3sGenerateTagsSubCmd = &cobra.Command{
 	Use:   "tags [version]",
-	Short: "generate k8s tags for a given version",
+	Short: "Generate k8s tags for a given version",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [version]")
@@ -75,12 +75,12 @@ var k3sGenerateTagsSubCmd = &cobra.Command{
 
 var rke2GenerateSubCmd = &cobra.Command{
 	Use:   "rke2",
-	Short: "",
+	Short: "Generate rke2 related artifacts",
 }
 
 var rke2GenerateReleaseNotesSubCmd = &cobra.Command{
 	Use:   "release-notes",
-	Short: "",
+	Short: "Generate rke2 release notes",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)

--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -15,7 +15,6 @@ var rancherImageTag *string
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List resources",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		//
 	},
@@ -24,7 +23,6 @@ var listCmd = &cobra.Command{
 var rancherListSubCmd = &cobra.Command{
 	Use:   "rancher",
 	Short: "List Rancher resources",
-	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("arguments required")

--- a/cmd/release/cmd/push.go
+++ b/cmd/release/cmd/push.go
@@ -11,17 +11,17 @@ import (
 
 var pushCmd = &cobra.Command{
 	Use:   "push",
-	Short: "",
+	Short: "Push things from your local to a remote",
 }
 
 var pushK3sCmd = &cobra.Command{
 	Use:   "k3s [version]",
-	Short: "",
+	Short: "Push k3s artifacts",
 }
 
 var pushK3sTagsCmd = &cobra.Command{
 	Use:   "tags [version]",
-	Short: "push k8s tags to remote",
+	Short: "Push k3s-io/kubernetes tags to remote",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [version]")

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -36,8 +36,7 @@ var (
 // tagCmd represents the tag command.
 var tagCmd = &cobra.Command{
 	Use:   "tag",
-	Short: "",
-	Long:  ``,
+	Short: "Tag releases",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			rootCmd.Help()
@@ -48,8 +47,7 @@ var tagCmd = &cobra.Command{
 
 var k3sTagSubCmd = &cobra.Command{
 	Use:   "k3s [ga,rc] [version]",
-	Short: "",
-	Long:  ``,
+	Short: "Tag k3s releases",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.New("expected at least two arguments: [ga,rc] [version]")
@@ -71,8 +69,7 @@ var k3sTagSubCmd = &cobra.Command{
 
 var rke2TagSubCmd = &cobra.Command{
 	Use:   "rke2",
-	Short: "",
-	Long:  ``,
+	Short: "Tag rke2 releases",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(*tagRKE2Flags.AlpineVersion) != 2 {
 			return errors.New("invalid release version")
@@ -152,8 +149,7 @@ var rke2TagSubCmd = &cobra.Command{
 
 var rancherTagSubCmd = &cobra.Command{
 	Use:   "rancher",
-	Short: "",
-	Long:  ``,
+	Short: "Tag Rancher releases",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -21,7 +21,7 @@ var updateK3sCmd = &cobra.Command{
 
 var updateK3sReferencesCmd = &cobra.Command{
 	Use:   "references [version]",
-	Short: "Update k8s and go references in a k3s repo and create a PR",
+	Short: "Update k8s and Go references in a k3s repo and create a PR",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [version]")

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -11,17 +11,17 @@ import (
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "",
+	Short: "Update files and other utilities",
 }
 
 var updateK3sCmd = &cobra.Command{
 	Use:   "k3s",
-	Short: "",
+	Short: "Update k3s files",
 }
 
 var updateK3sReferencesCmd = &cobra.Command{
 	Use:   "references [version]",
-	Short: "update k8s and go references in a k3s repo and create a PR",
+	Short: "Update k8s and go references in a k3s repo and create a PR",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [version]")

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
 const (
@@ -178,9 +179,35 @@ func exampleConfig() Config {
 	}
 }
 
-const configViewTemplate = `RKE2 Version
+func View(config *Config) error {
+	tmp, err := template.New("ecm").Parse(configViewTemplate)
+	if err != nil {
+		return err
+	}
+	return tmp.Execute(os.Stdout, config)
+}
+
+const configViewTemplate = `ECM distro tools config
 ------------
-{{- range .RKE2.Versions }}
-{{ . -}}+rke2r1
-{{- end}}
+User
+	Email:           {{ .User.Email }}
+	Github Username: {{ .User.GithubUsername }}
+------------
+K3s {{ range $version, $value := .K3s.Versions }}
+	{{ $version }}:
+		Old K8s Version:  {{ $value.OldK8sVersion}}	
+		New K8s Version:  {{ $value.NewK8sVersion}}	
+		Old K8s Client:   {{ $value.OldK8sClient}}	
+		New K8s Client:   {{ $value.NewK8sClient}}	
+		Old Suffix:       {{ $value.OldSuffix}}	
+		New Suffix:       {{ $value.NewSuffix}}	
+		Release Branch:   {{ $value.ReleaseBranch}}	
+		Dry Run:          {{ $value.DryRun}}	
+		K3s Repo Owner:   {{ $value.K3sRepoOwner}}	
+		K8s Rancher URL:  {{ $value.K8sRancherURL}}	
+		Workspace:        {{ $value.Workspace}}	
+		K3s Upstream URL: {{ $value.K3sUpstreamURL}}{{ end }}
+------------
+RKE2{{ range .RKE2.Versions }}
+	{{ . }}{{ end}}
 `

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -188,11 +188,11 @@ func View(config *Config) error {
 }
 
 const configViewTemplate = `Release config
-------------
+
 User
 	Email:           {{ .User.Email }}
 	Github Username: {{ .User.GithubUsername }}
-------------
+
 K3s {{ range $version, $value := .K3s.Versions }}
 	{{ $version }}:
 		Old K8s Version:  {{ $value.OldK8sVersion}}	
@@ -207,7 +207,7 @@ K3s {{ range $version, $value := .K3s.Versions }}
 		K8s Rancher URL:  {{ $value.K8sRancherURL}}	
 		Workspace:        {{ $value.Workspace}}	
 		K3s Upstream URL: {{ $value.K3sUpstreamURL}}{{ end }}
-------------
+
 RKE2{{ range .RKE2.Versions }}
 	{{ . }}{{ end}}
 `

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -187,7 +187,7 @@ func View(config *Config) error {
 	return tmp.Execute(os.Stdout, config)
 }
 
-const configViewTemplate = `ECM distro tools config
+const configViewTemplate = `Release config
 ------------
 User
 	Email:           {{ .User.Email }}


### PR DESCRIPTION
Closes: #335 
Adds functionality to the `release config view` command

```
Release config

User
	Email:           pedro.tashima@suse.com
	Github Username: Tashima42

K3s 
	v1.26.13:
		Old K8s Version:  v1.26.12	
		New K8s Version:  v1.26.13	
		Old K8s Client:   v0.26.12	
		New K8s Client:   v0.26.13	
		Old Suffix:       k3s1	
		New Suffix:       k3s1	
		Release Branch:   release-1.26	
		Dry Run:          true	
		K3s Repo Owner:   k3s-io	
		K8s Rancher URL:  git@github.com:k3s-io/kubernetes.git	
		Workspace:        /Users/pedrosuse/go/src/github.com/v1.26.13	
		K3s Upstream URL: git@github.com:k3s-io/k3s.git

RKE2
	v1.x.y
```