### PR TITLE
disable cgo

### DIFF
--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,7 +1,7 @@
 BINARIES = gen_release_notes gen_release_report backport semv rancher_release test_coverage upstream_go_version rke2_release release
 ARCHS ?= amd64 arm64
 OSs ?= linux darwin freebsd
-GO_COMPILE = GOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
+GO_COMPILE = GOOS=$${os} GOARCH=$${arch} $(GO) build -tags $(TAGS) -v -ldflags "$(LDFLAGS)" -o $@-$${os}-$${arch}
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
This PR disables CGO to make it easier to support a range of build environments. The resulting binaries are still statically linked. 