### PR TITLE
Tag system agent installer k3s command

### DIFF
--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -28,7 +28,9 @@ release generate k3s tags v1.29.2
 release push k3s tags v1.29.2
 release update k3s references v1.29.2
 release tag k3s rc v1.29.2
+release tag system-agent-installer-k3s rc v1.29.2
 release tag k3s ga v1.29.2
+release tag system-agent-installer-k3s ga v1.29.2
 ```
 
 #### Cache Permissions and Docker:

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -733,14 +733,16 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sR
 		createdRelease, err := repository.CreateRelease(ctx, client, opts)
 		if err != nil {
 			githubErr := err.(*github.ErrorResponse)
-			if strings.Contains(githubErr.Errors[0].Code, "already_exists") {
-				if !rc {
-					return err
-				}
+			if len(githubErr.Errors) > 0 {
+				if strings.Contains(githubErr.Errors[0].Code, "already_exists") {
+					if !rc {
+						return err
+					}
 
-				fmt.Println("RC " + strconv.Itoa(rcNum) + " already exists, trying to create next")
-				rcNum += 1
-				continue
+					fmt.Println("RC " + strconv.Itoa(rcNum) + " already exists, trying to create next")
+					rcNum += 1
+					continue
+				}
 			}
 
 			return err

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -726,7 +726,7 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sR
 	}
 
 	if r.DryRun {
-		fmt.Println("dry run, skipping creating release and verifying if rcs already were created")
+		fmt.Println("dry run, skipping creating release")
 		return nil
 	}
 	createdRelease, err := repository.CreateRelease(ctx, client, opts)

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -698,7 +698,10 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sR
 		return err
 	}
 	if rc {
-		trimmedRCNumber := strings.TrimSuffix(strings.TrimPrefix(latestRC, r.NewK8sVersion+"-rc"), "+k3s1")
+		trimmedRCNumber, _, found := strings.Cut(strings.TrimPrefix(latestRC, r.NewK8sVersion+"-rc"), "+k3s")
+		if !found {
+			return errors.New("failed to parse rc number from " + latestRC)
+		}
 		currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
 		if err != nil {
 			return err

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -72,6 +72,7 @@ type CreateReleaseOpts struct {
 	Owner        string `json:"owner"`
 	Repo         string `json:"repo"`
 	Name         string `json:"name"`
+	Tag          string `json:"tag"`
 	Prerelease   bool   `json:"pre_release"`
 	Branch       string `json:"branch"`
 	ReleaseNotes string `json:"release_notes"`


### PR DESCRIPTION
* Adds a command to tag `system-agent-installer-k3s` releases
* Fixes a bug where in some cases tagging k3s releases would panic