### PR TITLE
fix string comparison on status check and add skip status check flag

### DIFF
--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -22,10 +22,11 @@ type tagRKE2CmdFlags struct {
 }
 
 type tagRancherCmdFlags struct {
-	Tag       *string
-	Branch    *string
-	RepoOwner *string
-	DryRun    *bool
+	Tag             *string
+	Branch          *string
+	RepoOwner       *string
+	SkipStatusCheck *bool
+	DryRun          *bool
 }
 
 var (
@@ -159,7 +160,7 @@ var rancherTagSubCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
-		return rancher.TagRelease(ctx, ghClient, *tagRancherFlags.Tag, *tagRancherFlags.Branch, *tagRancherFlags.RepoOwner, *tagRancherFlags.DryRun)
+		return rancher.TagRelease(ctx, ghClient, *tagRancherFlags.Tag, *tagRancherFlags.Branch, *tagRancherFlags.RepoOwner, *tagRancherFlags.DryRun, *tagRancherFlags.SkipStatusCheck)
 	},
 }
 
@@ -211,6 +212,7 @@ func init() {
 	tagRancherFlags.Tag = rancherTagSubCmd.Flags().StringP("tag", "t", "", "tag to be created. e.g: v2.8.1-rc4")
 	tagRancherFlags.Branch = rancherTagSubCmd.Flags().StringP("branch", "b", "", "branch to be used as the base to create the tag. e.g: release/v2.8")
 	tagRancherFlags.RepoOwner = rancherTagSubCmd.Flags().StringP("repo-owner", "o", "rancher", "repository owner to create the tag in, optional")
+	tagRancherFlags.SkipStatusCheck = rancherTagSubCmd.Flags().BoolP("skip-status-check", "s", false, "skip the github commit status check before creating a tag")
 	tagRancherFlags.DryRun = dryRun
 	if err := rancherTagSubCmd.MarkFlagRequired("tag"); err != nil {
 		fmt.Println(err.Error())

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -334,7 +334,7 @@ func SetChartBranchReferences(ctx context.Context, forkPath, rancherBaseBranch, 
 	return nil
 }
 
-func TagRelease(ctx context.Context, ghClient *github.Client, tag, remoteBranch, repoOwner string, dryRun bool) error {
+func TagRelease(ctx context.Context, ghClient *github.Client, tag, remoteBranch, repoOwner string, dryRun, skipStatusCheck bool) error {
 	fmt.Println("validating tag semver format")
 	if !semver.IsValid(tag) {
 		return errors.New("the tag `" + tag + "` isn't a valid semantic versioning string")
@@ -348,9 +348,11 @@ func TagRelease(ctx context.Context, ghClient *github.Client, tag, remoteBranch,
 		return errors.New("branch commit sha is nil")
 	}
 	fmt.Println("the latest commit on branch " + remoteBranch + " is: " + *branch.Commit.SHA)
-	fmt.Println("checking if CI is passing")
-	if err := commitStateSuccess(ctx, ghClient, repoOwner, rancherRepo, *branch.Commit.SHA); err != nil {
-		return err
+	if !skipStatusCheck {
+		fmt.Println("checking if CI is passing")
+		if err := commitStateSuccess(ctx, ghClient, repoOwner, rancherRepo, *branch.Commit.SHA); err != nil {
+			return err
+		}
 	}
 	fmt.Println("creating tag: " + tag)
 	if dryRun {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -375,7 +375,7 @@ func commitStateSuccess(ctx context.Context, ghClient *github.Client, owner, rep
 	if err != nil {
 		return err
 	}
-	if status.State != github.String("success") {
+	if *status.State != "success" {
 		return errors.New("expected commit " + commit + " to have state 'success', instead, got " + *status.State)
 	}
 	return nil


### PR DESCRIPTION
* Fix a bug where comparing two pointers will always result in a false result.
* Add a `skip-status-check` flag