### PR TITLE
add generate prime artifacts index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 _obj
 _test
 .vagrant/
+tmp/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -107,11 +107,7 @@ var rancherGenerateArtifactsIndexSubCmd = &cobra.Command{
 	Use:   "artifacts-index",
 	Short: "Generate artifacts index page",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := rancher.GeneratePrimeArtifactsIndex(*artifactsIndexWriteToPath); err != nil {
-			return err
-		}
-
-		return nil
+		return rancher.GeneratePrimeArtifactsIndex(*artifactsIndexWriteToPath)
 	},
 }
 

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
+	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +17,9 @@ var (
 	k3sPrevMilestone *string
 	k3sMilestone     *string
 
-	rke2PrevMilestone *string
-	rke2Milestone     *string
+	rke2PrevMilestone         *string
+	rke2Milestone             *string
+	artifactsIndexWriteToPath *string
 )
 
 // generateCmd represents the generate command
@@ -96,15 +98,34 @@ var rke2GenerateReleaseNotesSubCmd = &cobra.Command{
 	},
 }
 
+var rancherGenerateSubCmd = &cobra.Command{
+	Use:   "rancher",
+	Short: "Generate rancher related artifacts",
+}
+
+var rancherGenerateArtifactsIndexSubCmd = &cobra.Command{
+	Use:   "artifacts-index",
+	Short: "Generate artifacts index page",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := rancher.GeneratePrimeArtifactsIndex(*artifactsIndexWriteToPath); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
 	k3sGenerateSubCmd.AddCommand(k3sGenerateReleaseNotesSubCmd)
 	k3sGenerateSubCmd.AddCommand(k3sGenerateTagsSubCmd)
 	rke2GenerateSubCmd.AddCommand(rke2GenerateReleaseNotesSubCmd)
+	rancherGenerateSubCmd.AddCommand(rancherGenerateArtifactsIndexSubCmd)
 
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
+	generateCmd.AddCommand(rancherGenerateSubCmd)
 
 	// k3s release notes
 	k3sPrevMilestone = k3sGenerateReleaseNotesSubCmd.Flags().StringP("prev-milestone", "p", "", "Previous Milestone")
@@ -126,6 +147,13 @@ func init() {
 		os.Exit(1)
 	}
 	if err := rke2GenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// rancher artifacts-index
+	artifactsIndexWriteToPath = rancherGenerateArtifactsIndexSubCmd.Flags().StringP("write-path", "w", "", "Write To Path")
+	if err := rancherGenerateArtifactsIndexSubCmd.MarkFlagRequired("write-path"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -200,11 +200,11 @@ func GeneratePrimeArtifactsIndex(writeToPath string) error {
 	}
 	defer resp.Body.Close()
 	contentDecoder := xml.NewDecoder(resp.Body)
-	listBucket := new(ListBucketResult)
+	var listBucket ListBucketResult
 	if err := contentDecoder.Decode(listBucket); err != nil {
 		return err
 	}
-	content := generateArtifactsIndexContent(*listBucket)
+	content := generateArtifactsIndexContent(listBucket)
 	gaIndex, err := generatePrimeArtifactsHTML(content.GA)
 	if err != nil {
 		return err

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -241,7 +240,6 @@ func generateArtifactsIndexContent(listBucket ListBucketResult) ArtifactsIndexCo
 		key := keyFile[0]
 		file := keyFile[1]
 
-		log.Print("adding: " + key + "/" + file)
 		// only non ga releases contains '-' e.g: -rc, -debug
 		if strings.Contains(key, "-") {
 			indexContent.PreRelease.Versions[key] = append(indexContent.PreRelease.Versions[key], file)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -200,7 +200,7 @@ func GeneratePrimeArtifactsIndex(path string) error {
 	defer resp.Body.Close()
 	contentDecoder := xml.NewDecoder(resp.Body)
 	var listBucket ListBucketResult
-	if err := contentDecoder.Decode(listBucket); err != nil {
+	if err := contentDecoder.Decode(&listBucket); err != nil {
 		return err
 	}
 	content := generateArtifactsIndexContent(listBucket)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -241,8 +241,7 @@ func generateArtifactsIndexContent(listBucket ListBucketResult) ArtifactsIndexCo
 		key := keyFile[0]
 		file := keyFile[1]
 
-		log.Print("key: " + key + " | file: " + file)
-
+		log.Print("adding: " + key + "/" + file)
 		// only non ga releases contains '-' e.g: -rc, -debug
 		if strings.Contains(key, "-") {
 			indexContent.PreRelease.Versions[key] = append(indexContent.PreRelease.Versions[key], file)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -188,7 +188,7 @@ type ArtifactsIndexContentGroup struct {
 	BaseURL  string              `json:"baseUrl"`
 }
 
-func GeneratePrimeArtifactsIndex(writeToPath string) error {
+func GeneratePrimeArtifactsIndex(path string) error {
 	client := ecmHTTP.NewClient(time.Second * 15)
 	resp, err := client.Get(rancherArtifactsListURL)
 	if err != nil {
@@ -212,10 +212,10 @@ func GeneratePrimeArtifactsIndex(writeToPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(writeToPath, "index.html"), gaIndex, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(path, "index.html"), gaIndex, 0644); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(writeToPath, "index-prerelease.html"), preReleaseIndex, 0644)
+	return os.WriteFile(filepath.Join(path, "index-prerelease.html"), preReleaseIndex, 0644)
 }
 
 func generateArtifactsIndexContent(listBucket ListBucketResult) ArtifactsIndexContent {


### PR DESCRIPTION
Closes: #374 
Add a new subcommand to generate the rancher-prime index
```
release generate rancher artifacts-index -w /tmp
```
It will generate two html files, `index.html` with all the GA releases and `index-prerelease.html` with all the rcs alphas and debug releases.

This implementation uses the s3 bucket list endpoint, an alternative would be to maintain json map with all the versions and artifacts in the bucket. I chose not to use this approach because it would add another layer of complexity that isn't needed for now, if we need this for any reason, the foundation is set to update build upon.
