### PR TITLE
Add ignore version flag to generate artifacts-index

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -21,7 +21,6 @@ var (
 
 	rke2PrevMilestone                   *string
 	rke2Milestone                       *string
-	artifactsIndexWriteToPath           *string
 	concurrencyLimit                    *int
 	rancherMissingImagesJSONOutput      *bool
 	rancherArtifactsIndexWriteToPath    *string

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -16,15 +16,15 @@ import (
 )
 
 var (
-	k3sPrevMilestone *string
-	k3sMilestone     *string
+	k3sPrevMilestone string
+	k3sMilestone     string
 
-	rke2PrevMilestone                   *string
-	rke2Milestone                       *string
-	concurrencyLimit                    *int
-	rancherMissingImagesJSONOutput      *bool
-	rancherArtifactsIndexWriteToPath    *string
-	rancherArtifactsIndexIgnoreVersions *[]string
+	concurrencyLimit                    int
+	rancherMissingImagesJSONOutput      bool
+	rke2PrevMilestone                   string
+	rke2Milestone                       string
+	rancherArtifactsIndexWriteToPath    string
+	rancherArtifactsIndexIgnoreVersions []string
 )
 
 // generateCmd represents the generate command
@@ -45,7 +45,7 @@ var k3sGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "k3s-io", "k3s", *k3sMilestone, *k3sPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "k3s-io", "k3s", k3sMilestone, k3sPrevMilestone, client)
 		if err != nil {
 			return err
 		}
@@ -86,7 +86,7 @@ var rke2GenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "rke2", *rke2Milestone, *rke2PrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "rke2", rke2Milestone, rke2PrevMilestone, client)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ var rancherGenerateArtifactsIndexSubCmd = &cobra.Command{
 	Use:   "artifacts-index",
 	Short: "Generate artifacts index page",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return rancher.GeneratePrimeArtifactsIndex(*rancherArtifactsIndexWriteToPath, *rancherArtifactsIndexIgnoreVersions)
+		return rancher.GeneratePrimeArtifactsIndex(rancherArtifactsIndexWriteToPath, rancherArtifactsIndexIgnoreVersions)
 	},
 }
 
@@ -122,15 +122,15 @@ var rancherGenerateMissingImagesListSubCmd = &cobra.Command{
 		if !found {
 			return errors.New("verify your config file, version not found: " + version)
 		}
-		missingImages, err := rancher.GenerateMissingImagesList(version, *concurrencyLimit, rancherRelease.CheckImages)
+		missingImages, err := rancher.GenerateMissingImagesList(version, concurrencyLimit, rancherRelease.CheckImages)
 		if err != nil {
 			return err
 		}
 		// if there are missing images, return it as an error so CI also fails
-		if len(missingImages) != 0 && !*rancherMissingImagesJSONOutput {
+		if len(missingImages) != 0 && !rancherMissingImagesJSONOutput {
 			return errors.New("found missing images: " + strings.Join(missingImages, ","))
 		}
-		if *rancherMissingImagesJSONOutput {
+		if rancherMissingImagesJSONOutput {
 			b, err := json.MarshalIndent(missingImages, "", " ")
 			if err != nil {
 				return err
@@ -155,8 +155,8 @@ func init() {
 	generateCmd.AddCommand(rancherGenerateSubCmd)
 
 	// k3s release notes
-	k3sPrevMilestone = k3sGenerateReleaseNotesSubCmd.Flags().StringP("prev-milestone", "p", "", "Previous Milestone")
-	k3sMilestone = k3sGenerateReleaseNotesSubCmd.Flags().StringP("milestone", "m", "", "Milestone")
+	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sMilestone, "milestone", "m", "", "Milestone")
 	if err := k3sGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -167,8 +167,8 @@ func init() {
 	}
 
 	// rke2 release notes
-	rke2PrevMilestone = rke2GenerateReleaseNotesSubCmd.Flags().StringP("prev-milestone", "p", "", "Previous Milestone")
-	rke2Milestone = rke2GenerateReleaseNotesSubCmd.Flags().StringP("milestone", "m", "", "Milestone")
+	rke2GenerateReleaseNotesSubCmd.Flags().StringVarP(&rke2PrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	rke2GenerateReleaseNotesSubCmd.Flags().StringVarP(&rke2Milestone, "milestone", "m", "", "Milestone")
 	if err := rke2GenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -179,14 +179,14 @@ func init() {
 	}
 
 	// rancher artifacts-index
-	rancherArtifactsIndexIgnoreVersions = rancherGenerateArtifactsIndexSubCmd.Flags().StringSliceP("ignore-versions", "i", []string{}, "Versions to ignore on the index")
-	rancherArtifactsIndexWriteToPath = rancherGenerateArtifactsIndexSubCmd.Flags().StringP("write-path", "w", "", "Write To Path")
+	rancherGenerateArtifactsIndexSubCmd.Flags().StringSliceVarP(&rancherArtifactsIndexIgnoreVersions, "ignore-versions", "i", []string{}, "Versions to ignore on the index")
+	rancherGenerateArtifactsIndexSubCmd.Flags().StringVarP(&rancherArtifactsIndexWriteToPath, "write-path", "w", "", "Write To Path")
 	if err := rancherGenerateArtifactsIndexSubCmd.MarkFlagRequired("write-path"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 
 	// rancher generate-missing-images-list
-	concurrencyLimit = rancherGenerateMissingImagesListSubCmd.Flags().IntP("concurrency-limit", "c", 3, "Concurrency Limit")
-	rancherMissingImagesJSONOutput = rancherGenerateMissingImagesListSubCmd.Flags().BoolP("json", "j", false, "JSON Output")
+	rancherGenerateMissingImagesListSubCmd.Flags().IntVarP(&concurrencyLimit, "concurrency-limit", "c", 3, "Concurrency Limit")
+	rancherGenerateMissingImagesListSubCmd.Flags().BoolVarP(&rancherMissingImagesJSONOutput, "json", "j", false, "JSON Output")
 }

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -19,11 +19,13 @@ var (
 	k3sPrevMilestone *string
 	k3sMilestone     *string
 
-	rke2PrevMilestone              *string
-	rke2Milestone                  *string
-	artifactsIndexWriteToPath      *string
-	concurrencyLimit               *int
-	rancherMissingImagesJSONOutput *bool
+	rke2PrevMilestone                   *string
+	rke2Milestone                       *string
+	artifactsIndexWriteToPath           *string
+	concurrencyLimit                    *int
+	rancherMissingImagesJSONOutput      *bool
+	rancherArtifactsIndexWriteToPath    *string
+	rancherArtifactsIndexIgnoreVersions *[]string
 )
 
 // generateCmd represents the generate command
@@ -105,7 +107,7 @@ var rancherGenerateArtifactsIndexSubCmd = &cobra.Command{
 	Use:   "artifacts-index",
 	Short: "Generate artifacts index page",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return rancher.GeneratePrimeArtifactsIndex(*artifactsIndexWriteToPath)
+		return rancher.GeneratePrimeArtifactsIndex(*rancherArtifactsIndexWriteToPath, *rancherArtifactsIndexIgnoreVersions)
 	},
 }
 
@@ -178,7 +180,8 @@ func init() {
 	}
 
 	// rancher artifacts-index
-	artifactsIndexWriteToPath = rancherGenerateArtifactsIndexSubCmd.Flags().StringP("write-path", "w", "", "Write To Path")
+	rancherArtifactsIndexIgnoreVersions = rancherGenerateArtifactsIndexSubCmd.Flags().StringSliceP("ignore-versions", "i", []string{}, "Versions to ignore on the index")
+	rancherArtifactsIndexWriteToPath = rancherGenerateArtifactsIndexSubCmd.Flags().StringP("write-path", "w", "", "Write To Path")
 	if err := rancherGenerateArtifactsIndexSubCmd.MarkFlagRequired("write-path"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -502,7 +502,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
     <title>Rancher Prime Artifacts</title>
     <link rel="icon" type="image/png" href="https://prime.ribs.rancher.io/assets/img/favicon.png">
     <style>
-    body { font-family: Verdana, Geneneva; }
+    body { font-family: 'Courier New', monospace, Verdana, Geneneva; }
     header { display: flex; flex-direction: row; justify-items: center; }
     #rancher-logo { width: 200px; }
     .project { margin-left: 20px; }
@@ -510,7 +510,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
     .release h3 { margin-bottom: 0px; }
     .files { margin-left: 60px; display: flex; flex-direction: column; }
     .release-title { display: flex; flex-direction: row; }
-		.release-title-tag { margin-right: 20px; min-width: 50px; }
+		.release-title-tag { margin-right: 20px; min-width: 70px; }
     .release-title-expand { background-color: #2453ff; color: white; border-radius: 5px; border: none; }
     .release-title-expand:hover, .expand-active{ background-color: white; color: #2453ff; border: 1px solid #2453ff; }
     .hidden { display: none; overflow: hidden; }
@@ -519,7 +519,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
   <body>
     <header>
       <img src="https://prime.ribs.rancher.io/assets/img/rancher-suse-logo-horizontal-color.svg" alt="rancher logo" id="rancher-logo" />
-      <h1>Prime Artifacts</h1>
+      <h1>PRIME ARTIFACTS</h1>
     </header>
     <main>
       <div class="project-rancher project">

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -542,17 +542,17 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
       </div>
     </main>
   <script>
-		hideFiles()
+    hideFiles()
     function expand(tag) {
       const filesId = "release-" + tag + "-files"
       const expandButtonId = "release-" + tag + "-expand"
       document.getElementById(filesId).classList.toggle("hidden")
       document.getElementById(expandButtonId).classList.toggle("expand-active")
     }
-		function hideFiles() {
-			const fileDivs = document.querySelectorAll(".files")
-			fileDivs.forEach(f => f.classList.add("hidden"))
-		}
+    function hideFiles() {
+        const fileDivs = document.querySelectorAll(".files")
+        fileDivs.forEach(f => f.classList.add("hidden"))
+    }
   </script>
   </body>
 </html>

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -500,7 +500,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
     .release h3 { margin-bottom: 0px; }
     .files { margin-left: 60px; display: flex; flex-direction: column; }
     .release-title { display: flex; flex-direction: row; }
-    .release-title-tag { margin-right: 20px; }
+		.release-title-tag { margin-right: 20px; min-width: 50px; }
     .release-title-expand { background-color: #2453ff; color: white; border-radius: 5px; border: none; }
     .release-title-expand:hover, .expand-active{ background-color: white; color: #2453ff; border: 1px solid #2453ff; }
     .hidden { display: none; overflow: hidden; }
@@ -520,7 +520,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
 						<b class="release-title-tag">{{ $version }}</b>
             <button onclick="expand('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">expand</button>
           </div>
-          <div class="files hidden" id="release-{{ $version }}-files">
+          <div class="files" id="release-{{ $version }}-files">
             <ul>
               {{ range index $.VersionsFiles $version }}
               <li><a href="{{ $.BaseURL }}/rancher/{{ $version }}/{{ . }}">{{ $.BaseURL }}/rancher/{{ $version }}/{{ . }}</a></li>
@@ -532,12 +532,17 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
       </div>
     </main>
   <script>
+		hideFiles()
     function expand(tag) {
       const filesId = "release-" + tag + "-files"
       const expandButtonId = "release-" + tag + "-expand"
       document.getElementById(filesId).classList.toggle("hidden")
       document.getElementById(expandButtonId).classList.toggle("expand-active")
     }
+		function hideFiles() {
+			const fileDivs = document.querySelectorAll(".files")
+			fileDivs.forEach(f => f.classList.add("hidden"))
+		}
   </script>
   </body>
 </html>

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -510,7 +510,7 @@ const artifactsIndexTempalte = `{{ define "release-artifacts-index" }}
     .release h3 { margin-bottom: 0px; }
     .files { margin-left: 60px; display: flex; flex-direction: column; }
     .release-title { display: flex; flex-direction: row; }
-		.release-title-tag { margin-right: 20px; min-width: 70px; }
+    .release-title-tag { margin-right: 20px; min-width: 70px; }
     .release-title-expand { background-color: #2453ff; color: white; border-radius: 5px; border: none; }
     .release-title-expand:hover, .expand-active{ background-color: white; color: #2453ff; border: 1px solid #2453ff; }
     .hidden { display: none; overflow: hidden; }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -93,7 +93,7 @@ func GeneratePrimeArtifactsIndex(path string, ignoreVersions []string) error {
 		return err
 	}
 
-	ignore := make(map[string]bool)
+	ignore := make(map[string]bool, len(ignoreVersions))
 	for _, v := range ignoreVersions {
 		ignore[v] = true
 	}


### PR DESCRIPTION
To maintain compatibility with older tests in `rancher/rancher` we need to maintain some artifacts for a non-prime version on the prime artifacts bucket, this is not a problem as long as we don't show it on our index.

* add an ignore version flag to generate artifacts-index
    ```
    release generate rancher artifacts-index -w ./tmp -i v2.6.4
    ```
* show files by default and hide them with javascript, to support users who block javascript
* minor style changes