### PR TITLE
Add rancher image digests cmd

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -25,6 +25,9 @@ var (
 	rke2Milestone                       string
 	rancherArtifactsIndexWriteToPath    string
 	rancherArtifactsIndexIgnoreVersions []string
+	rancherImagesDigestsOutputFile      string
+	rancherImagesDigestsRegistry        string
+	rancherImagesDigestsArtifactURL     string
 )
 
 // generateCmd represents the generate command
@@ -141,6 +144,14 @@ var rancherGenerateMissingImagesListSubCmd = &cobra.Command{
 	},
 }
 
+var rancherGenerateDockerImagesDigestsSubCmd = &cobra.Command{
+	Use:   "docker-images-digests",
+	Short: "Generate a file with images digests from an images list",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rancher.GenerateDockerImageDigests(rancherImagesDigestsOutputFile, rancherImagesDigestsArtifactURL, rancherImagesDigestsRegistry)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
@@ -149,6 +160,7 @@ func init() {
 	rke2GenerateSubCmd.AddCommand(rke2GenerateReleaseNotesSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateArtifactsIndexSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateMissingImagesListSubCmd)
+	rancherGenerateSubCmd.AddCommand(rancherGenerateDockerImagesDigestsSubCmd)
 
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
@@ -186,7 +198,24 @@ func init() {
 		os.Exit(1)
 	}
 
-	// rancher generate-missing-images-list
+	// rancher generate missing-images-list
 	rancherGenerateMissingImagesListSubCmd.Flags().IntVarP(&concurrencyLimit, "concurrency-limit", "c", 3, "Concurrency Limit")
 	rancherGenerateMissingImagesListSubCmd.Flags().BoolVarP(&rancherMissingImagesJSONOutput, "json", "j", false, "JSON Output")
+
+	// rancher generate docker-images-digests
+	rancherGenerateDockerImagesDigestsSubCmd.Flags().StringVarP(&rancherImagesDigestsOutputFile, "output-file", "o", "", "Output file path")
+	if err := rancherGenerateDockerImagesDigestsSubCmd.MarkFlagRequired("output-file"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	rancherGenerateDockerImagesDigestsSubCmd.Flags().StringVarP(&rancherImagesDigestsArtifactURL, "artifact-url", "a", "", "Images list artifact URL")
+	if err := rancherGenerateDockerImagesDigestsSubCmd.MarkFlagRequired("artifact-url"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	rancherGenerateDockerImagesDigestsSubCmd.Flags().StringVarP(&rancherImagesDigestsRegistry, "registry", "r", "", "Docker Registry e.g: docker.io")
+	if err := rancherGenerateDockerImagesDigestsSubCmd.MarkFlagRequired("registry"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -471,7 +471,6 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 	}
 
 	var digests = make(imageDigest)
-	var auth string
 	var repositoryAuths = make(map[string]string)
 
 	for _, imageAndVersion := range imagesList {
@@ -486,7 +485,7 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 		image := splitImage[0]
 		imageVersion := splitImage[1]
 
-		auth, ok = repositoryAuths[image]
+		auth, ok := repositoryAuths[image]
 		if !ok {
 			auth, err := registryAuth(rgInfo.AuthURL, rgInfo.Service, image)
 			if err != nil {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -471,6 +471,8 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 	}
 
 	var digests = make(imageDigest)
+	var auth string
+	var repositoryAuths = make(map[string]string)
 
 	for _, imageAndVersion := range imagesList {
 		if imageAndVersion == "" || imageAndVersion == " " {
@@ -484,9 +486,13 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 		image := splitImage[0]
 		imageVersion := splitImage[1]
 
-		auth, err := registryAuth(rgInfo.AuthURL, rgInfo.Service, image)
-		if err != nil {
-			return err
+		auth, ok = repositoryAuths[image]
+		if !ok {
+			auth, err := registryAuth(rgInfo.AuthURL, rgInfo.Service, image)
+			if err != nil {
+				return err
+			}
+			repositoryAuths[image] = auth
 		}
 		digest, statusCode, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, auth)
 		slog.Info("status code: " + strconv.Itoa(statusCode))

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -464,7 +464,6 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 	if err != nil {
 		return err
 	}
-	slog.Info("images: ", imagesList)
 
 	rgInfo, ok := registriesInfo[registry]
 	if !ok {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -10,11 +10,14 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,17 +38,48 @@ import (
 )
 
 const (
-	rancherOrg               = "rancher"
-	rancherRepo              = rancherOrg
-	rancherImagesBaseURL     = "https://github.com/rancher/rancher/releases/download/"
-	rancherImagesFileName    = "/rancher-images.txt"
-	rancherHelmRepositoryURL = "https://releases.rancher.com/server-charts/latest/index.yaml"
-	rancherArtifactsListURL  = "https://prime-artifacts.s3.amazonaws.com"
-	rancherArtifactsBaseURL  = "https://prime.ribs.rancher.io"
-	rancherRegistryBaseURL   = "https://registry.rancher.com"
-	sccSUSEBaseURL           = "https://scc.suse.com"
-	sccSUSEService           = "SUSE+Linux+Docker+Registry"
+	rancherOrg                    = "rancher"
+	rancherRepo                   = rancherOrg
+	rancherImagesBaseURL          = "https://github.com/rancher/rancher/releases/download/"
+	rancherImagesFileName         = "/rancher-images.txt"
+	rancherHelmRepositoryURL      = "https://releases.rancher.com/server-charts/latest/index.yaml"
+	rancherArtifactsListURL       = "https://prime-artifacts.s3.amazonaws.com"
+	rancherArtifactsBaseURL       = "https://prime.ribs.rancher.io"
+	rancherRegistryBaseURL        = "https://registry.rancher.com"
+	stagingRancherRegistryBaseURL = "https://stgregistry.suse.com"
+	sccSUSEURL                    = "https://scc.suse.com/api/registry/authorize"
+	stagingSccSUSEURL             = "https://stgscc.suse.com/api/registry/authorize"
+	dockerRegistryURL             = "https://registry.docker.io"
+	dockerAuthURL                 = "https://auth.docker.io/token"
+	sccSUSEService                = "SUSE+Linux+Docker+Registry"
+	dockerService                 = "registry.docker.io"
 )
+
+var (
+	rancherRegistryInfo = registryInfo{
+		BaseURL: rancherRegistryBaseURL,
+		AuthURL: sccSUSEURL,
+		Service: sccSUSEService,
+	}
+	stagingRancherRegistryInfo = registryInfo{
+		BaseURL: stagingRancherRegistryBaseURL,
+		AuthURL: stagingSccSUSEURL,
+		Service: sccSUSEService,
+	}
+	dockerRegistryInfo = registryInfo{
+		BaseURL: dockerRegistryURL,
+		AuthURL: dockerAuthURL,
+		Service: dockerService,
+	}
+)
+
+type registryInfo struct {
+	BaseURL string
+	AuthURL string
+	Service string
+}
+
+type imageDigest map[string]string
 
 type RancherRCDepsLine struct {
 	Line    int    `json:"line"`
@@ -387,7 +421,7 @@ func GenerateMissingImagesList(version string, concurrencyLimit int, images []st
 					var err error
 					auth, ok = repositoryAuths[image]
 					if !ok {
-						auth, err = registryAuth(sccSUSEService, image)
+						auth, err = registryAuth(sccSUSEURL, sccSUSEService, image)
 						if err != nil {
 							cancel()
 							return err
@@ -395,7 +429,7 @@ func GenerateMissingImagesList(version string, concurrencyLimit int, images []st
 						repositoryAuths[image] = auth
 					}
 					mu.Unlock()
-					exists, err := checkIfImageExists(image, imageVersion, auth)
+					exists, err := checkIfImageExists(rancherRegistryBaseURL, image, imageVersion, auth)
 					if err != nil {
 						cancel()
 						return err
@@ -423,12 +457,125 @@ func GenerateMissingImagesList(version string, concurrencyLimit int, images []st
 	return missingImages, nil
 }
 
-func checkIfImageExists(img, imgVersion, auth string) (bool, error) {
-	log.Println("checking image: " + img + ":" + imgVersion)
-	httpClient := ecmHTTP.NewClient(time.Second * 5)
-	req, err := http.NewRequest("GET", rancherRegistryBaseURL+"/v2/"+img+"/manifests/"+imgVersion, nil)
+func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) error {
+	imagesList, err := artifactImageList(imagesFileURL, registry)
 	if err != nil {
-		return false, err
+		return err
+	}
+
+	var rgInfo registryInfo
+
+	switch registry {
+	case "docker.io":
+		rgInfo = dockerRegistryInfo
+	case "registry.rancher.com":
+		rgInfo = rancherRegistryInfo
+	case "stgregistry.suse.com":
+		rgInfo = stagingRancherRegistryInfo
+	}
+
+	var digests imageDigest
+
+	for _, imageAndVersion := range imagesList {
+		if !strings.Contains(imageAndVersion, ":") {
+			return errors.New("malformed image name: , missing ':'")
+		}
+		splitImage := strings.Split(imageAndVersion, ":")
+		image := splitImage[0]
+		imageVersion := splitImage[1]
+
+		auth, err := registryAuth(rgInfo.AuthURL, rgInfo.Service, image)
+		if err != nil {
+			return err
+		}
+		digest, _, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, auth)
+		if err != nil {
+			return err
+		}
+		digests[imageAndVersion] = digest
+	}
+	return createAssetFile(outputFile, digests)
+}
+
+func createAssetFile(outputFile string, contents fmt.Stringer) error {
+	fo, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer fo.Close()
+	_, err = fo.Write([]byte(contents.String()))
+	return err
+}
+
+func artifactImageList(imagesFileURL, registry string) ([]string, error) {
+	client := http.Client{Timeout: time.Second * 15}
+	res, err := client.Get(imagesFileURL)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	list, err := getLinesFromReader(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(list) == 0 {
+		return list, fmt.Errorf("no outputFile %s found or contents were empty, can not proceed", imagesFileURL)
+	}
+
+	for k, im := range list {
+		list[k] = cleanImage(im, registry)
+	}
+
+	return list, nil
+}
+
+func cleanImage(image, registry string) string {
+	if image == "" {
+		return ""
+	}
+
+	switch registry {
+	case "docker.io":
+		if len(strings.Split(image, "/")) == 1 {
+			image = path.Join("library", image)
+		}
+	}
+
+	return path.Join(registry, image)
+}
+
+func (d imageDigest) String() string {
+	var o strings.Builder
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&o, "%s %s\n", k, d[k])
+	}
+	return o.String()
+}
+
+func getLinesFromReader(body io.Reader) ([]string, error) {
+	lines, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(lines) == 0 {
+		return []string{}, errors.New("file was empty")
+	}
+
+	return strings.Split(string(lines), "\n"), nil
+}
+
+func dockerImageDigest(registryBaseURL, img, imgVersion, auth string) (string, int, error) {
+	httpClient := ecmHTTP.NewClient(time.Second * 5)
+	req, err := http.NewRequest("GET", registryBaseURL+"/v2/"+img+"/manifests/"+imgVersion, nil)
+	if err != nil {
+		return "", 0, err
 	}
 	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 	req.Header.Add("Accept", "application/vnd.oci.image.manifest.v1+json")
@@ -441,21 +588,37 @@ func checkIfImageExists(img, imgVersion, auth string) (bool, error) {
 	req.Header.Add("Authorization", "Bearer "+auth)
 	res, err := httpClient.Do(req)
 	if err != nil {
-		return false, err
+		return "", 0, err
 	}
 	if res.StatusCode == http.StatusNotFound {
+		return "", res.StatusCode, nil
+	}
+	dockerDigest := res.Header.Get("Docker-Content-Digest")
+	if dockerDigest == "" {
+		return "", 0, errors.New("missing digest header")
+	}
+	return dockerDigest, res.StatusCode, nil
+}
+
+func checkIfImageExists(registryBaseURL, img, imgVersion, auth string) (bool, error) {
+	log.Println("checking image: " + img + ":" + imgVersion)
+	_, statusCode, err := dockerImageDigest(registryBaseURL, img, imgVersion, auth)
+	if err != nil {
+		return false, err
+	}
+	if statusCode == http.StatusNotFound {
 		return false, nil
 	}
-	if res.StatusCode != http.StatusOK {
-		return false, errors.New("expected status code to be 200, got: " + strconv.Itoa(res.StatusCode))
+	if statusCode != http.StatusOK {
+		return false, errors.New("expected status code to be 200, got: " + strconv.Itoa(statusCode))
 	}
 	return true, nil
 }
 
-func registryAuth(service, image string) (string, error) {
+func registryAuth(authURL, service, image string) (string, error) {
 	httpClient := ecmHTTP.NewClient(time.Second * 5)
 	scope := "repository:" + image + ":pull"
-	res, err := httpClient.Get(sccSUSEBaseURL + "/api/registry/authorize?scope=" + scope + "&service=" + service)
+	res, err := httpClient.Get(authURL + "?scope=" + scope + "&service=" + service)
 	if err != nil {
 		return "", err
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -485,15 +485,14 @@ func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string) erro
 		image := splitImage[0]
 		imageVersion := splitImage[1]
 
-		auth, ok := repositoryAuths[image]
-		if !ok {
+		if _, ok := repositoryAuths[image]; !ok {
 			auth, err := registryAuth(rgInfo.AuthURL, rgInfo.Service, image)
 			if err != nil {
 				return err
 			}
 			repositoryAuths[image] = auth
 		}
-		digest, statusCode, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, auth)
+		digest, statusCode, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, repositoryAuths[image])
 		slog.Info("status code: " + strconv.Itoa(statusCode))
 		if err != nil {
 			return err

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -50,7 +50,7 @@ const (
 	stagingRancherRegistryBaseURL = "https://stgregistry.suse.com"
 	sccSUSEURL                    = "https://scc.suse.com/api/registry/authorize"
 	stagingSccSUSEURL             = "https://stgscc.suse.com/api/registry/authorize"
-	dockerRegistryURL             = "https://registry.docker.io"
+	dockerRegistryURL             = "https://registry-1.docker.io"
 	dockerAuthURL                 = "https://auth.docker.io/token"
 	sccSUSEService                = "SUSE+Linux+Docker+Registry"
 	dockerService                 = "registry.docker.io"


### PR DESCRIPTION
Add a command that generates a file with the digests of an image list

```bash
release generate rancher docker-images-digests \
    --artifact-url "https://prime.ribs.rancher.io/rancher/v2.8.4/rancher-windows-images.txt" \
    --output-file ./tmp/rancher-images-digests-windows-1809.txt \
    --registry "registry.rancher.com"
```