### PR TITLE
updated infra for rocky and suseliberty

### DIFF
--- a/qa/infra/amis/ami_rocky.json
+++ b/qa/infra/amis/ami_rocky.json
@@ -54,6 +54,6 @@
     },
     {
         "type": "shell",
-        "inline": "sudo chmod +x /tmp/disable_nm_cloud_setup.sh && sudo /tmp/disable_nm_cloud_setup.sh rhel9"
+        "inline": "sudo chmod +x /tmp/disable_nm_cloud_setup.sh && sudo /tmp/disable_nm_cloud_setup.sh"
     }]
 }

--- a/qa/infra/amis/ami_rocky.json
+++ b/qa/infra/amis/ami_rocky.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "name":"Rocky-8.8",
-        "source_ami":"ami-0425d70f0df70df0e",
+        "name":"Rocky-9.3-Minimal-NM-Cloud-Disabled",
+        "source_ami":"ami-07035d7f5e09a5d19",
         "access_key":"",
         "secret_key":"",
         "region":"us-east-2",

--- a/qa/infra/amis/ami_suseliberty.json
+++ b/qa/infra/amis/ami_suseliberty.json
@@ -45,6 +45,6 @@
     },
     {
         "type": "shell",
-        "inline": "sudo chmod +x /tmp/disable_nm_cloud_setup.sh && sudo /tmp/disable_nm_cloud_setup.sh rhel9"
+        "inline": "sudo chmod +x /tmp/disable_nm_cloud_setup.sh && sudo /tmp/disable_nm_cloud_setup.sh"
     }]
 }

--- a/qa/infra/amis/ami_suseliberty.json
+++ b/qa/infra/amis/ami_suseliberty.json
@@ -1,12 +1,12 @@
 {
     "variables": {
-        "name":"Rocky-8.8",
-        "source_ami":"ami-0425d70f0df70df0e",
+        "name":"SuseLiberty-8.9",
+        "source_ami":"ami-0649f5b1130930a5f",
         "access_key":"",
         "secret_key":"",
         "region":"us-east-2",
         "instance_type": "t3.medium",
-        "os_version": "8.8",
+        "os_version": "8.9",
         "arch_type": "x86_64"
     },
     "builders": [{
@@ -24,7 +24,7 @@
         "source_ami": "{{user `source_ami`}}",
         "instance_type": "{{user `instance_type`}}",
         "communicator": "ssh",
-        "ssh_username": "rocky",
+        "ssh_username": "ec2-user",
         "force_deregister": true,
         "run_tags":{"Name":"{{user `name`}}"}
     }],
@@ -37,15 +37,6 @@
     {
         "type": "shell",
         "inline": "sudo chmod +x /tmp/setup_rocky_repo_mirrors.sh && sudo /tmp/setup_rocky_repo_mirrors.sh {{user `os_version`}} {{user `arch_type`}}"
-    },
-    {
-        "type": "file",
-        "source": "enable_fips.sh",
-        "destination": "/tmp/enable_fips.sh"
-    },
-    {
-        "type": "shell",
-        "inline": "sudo chmod +x /tmp/enable_fips.sh && sudo /tmp/enable_fips.sh rhel8"
     },
     {
         "type": "file",

--- a/qa/infra/amis/setup_rocky_repo_mirrors.sh
+++ b/qa/infra/amis/setup_rocky_repo_mirrors.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Use rocky's repo mirrors for Suse Liberty 8.9 setup
+# Refer: https://github.com/k3s-io/k3s/issues/10367#issuecomment-2181517372
+RELEASE_VER="$1"
+BASE_ARCH="$2"
+CONTENT_DIR="pub/rocky"
+APPSTREAM_FILE="/tmp/repo_content_file"
+DEVEL_FILE="/tmp/repo_content_file"
+
+echo "[appstream]
+name=Rocky Linux ${RELEASE_VER} - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=${BASE_ARCH}&repo=AppStream-${RELEASE_VER}
+#baseurl=http://dl.rockylinux.org/${CONTENT_DIR}/${RELEASE_VER}/AppStream/${BASE_ARCH}/os/
+gpgcheck=0
+enabled=1" > "${APPSTREAM_FILE}"
+
+cat "${APPSTREAM_FILE}" | sudo tee -a /etc/yum.repos.d/Appstream.repo
+
+echo "[develrepo]
+name=Rocky Linux ${RELEASE_VER} - Devel
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=${BASE_ARCH}&repo=rocky-devel-${RELEASE_VER}
+#baseurl=https://dl.rockylinux.org/${CONTENT_DIR}/${RELEASE_VER}/devel/${BASE_ARCH}/os/
+gpgcheck=0
+enabled=1" > "${DEVEL_FILE}"
+
+cat "${DEVEL_FILE}" | sudo tee -a /etc/yum.repos.d/Devel.repo


### PR DESCRIPTION
Rocky has moved the iptables to the rocky-devel-<version> repo. 
Suse liberty uses repo of rocky to download/install selinux and iptables. 

Updating both Rocky and Suse liberty json to have the correct repo added to the infra. 
Also disable the nm-cloud-setup service as needed. 

Also, it doesnt look like disable_nm_cloud_setup.sh accepts any arguments in the script. removing the rocky9/rhel9 arguments that are passed into the script, which do not seem to be used. 