### PR TITLE
adding configurations for charts

### DIFF
--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -52,6 +52,15 @@ type RKE2 struct {
 	Versions []string `json:"versions"`
 }
 
+// ChartsRelease
+type ChartsRelease struct {
+	Workspace     string `json:"workspace"`
+	ChartsRepoURL string `json:"charts_repo_url"`
+	ChartsForkURL string `json:"charts_fork_url"`
+	DevBranch     string `json:"dev_branch"`
+	ReleaseBranch string `json:"release_branch"`
+}
+
 // User
 type User struct {
 	Email          string `json:"email"`
@@ -85,11 +94,12 @@ type Auth struct {
 
 // Config
 type Config struct {
-	User    *User    `json:"user"`
-	K3s     *K3s     `json:"k3s"`
-	Rancher *Rancher `json:"rancher"`
-	RKE2    *RKE2    `json:"rke2"`
-	Auth    *Auth    `json:"auth"`
+	User    *User          `json:"user"`
+	K3s     *K3s           `json:"k3s"`
+	Rancher *Rancher       `json:"rancher"`
+	RKE2    *RKE2          `json:"rke2"`
+	Charts  *ChartsRelease `json:"charts"`
+	Auth    *Auth          `json:"auth"`
 }
 
 func DefaultConfigPath() (string, error) {
@@ -242,17 +252,17 @@ User
 
 K3s {{ range $k3sVersion, $k3sValue := .K3s.Versions }}
 	{{ $k3sVersion }}:
-		Old K8s Version:  {{ $k3sValue.OldK8sVersion}}	
-		New K8s Version:  {{ $k3sValue.NewK8sVersion}}	
-		Old K8s Client:   {{ $k3sValue.OldK8sClient}}	
-		New K8s Client:   {{ $k3sValue.NewK8sClient}}	
-		Old Suffix:       {{ $k3sValue.OldSuffix}}	
-		New Suffix:       {{ $k3sValue.NewSuffix}}	
-		Release Branch:   {{ $k3sValue.ReleaseBranch}}	
-		Dry Run:          {{ $k3sValue.DryRun}}	
-		K3s Repo Owner:   {{ $k3sValue.K3sRepoOwner}}	
-		K8s Rancher URL:  {{ $k3sValue.K8sRancherURL}}	
-		Workspace:        {{ $k3sValue.Workspace}}	
+		Old K8s Version:  {{ $k3sValue.OldK8sVersion}}
+		New K8s Version:  {{ $k3sValue.NewK8sVersion}}
+		Old K8s Client:   {{ $k3sValue.OldK8sClient}}
+		New K8s Client:   {{ $k3sValue.NewK8sClient}}
+		Old Suffix:       {{ $k3sValue.OldSuffix}}
+		New Suffix:       {{ $k3sValue.NewSuffix}}
+		Release Branch:   {{ $k3sValue.ReleaseBranch}}
+		Dry Run:          {{ $k3sValue.DryRun}}
+		K3s Repo Owner:   {{ $k3sValue.K3sRepoOwner}}
+		K8s Rancher URL:  {{ $k3sValue.K8sRancherURL}}
+		Workspace:        {{ $k3sValue.Workspace}}
 		K3s Upstream URL: {{ $k3sValue.K3sUpstreamURL}}{{ end }}
 
 Rancher {{ range $rancherVersion, $rancherValue := .Rancher.Versions }}

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -222,6 +222,13 @@ func exampleConfig() Config {
 				},
 			},
 		},
+		Charts: &ChartsRelease{
+			Workspace:     filepath.Join(gopath, "src", "github.com", "rancher", "charts"),
+			ChartsRepoURL: "https://github.com/rancher/charts",
+			ChartsForkURL: "",
+			DevBranch:     "dev-v2.9",
+			ReleaseBranch: "release-v2.9",
+		},
 		Auth: &Auth{
 			Drone: &Drone{
 				K3sPR:          "YOUR_TOKEN",
@@ -275,4 +282,11 @@ Rancher {{ range $rancherVersion, $rancherValue := .Rancher.Versions }}
 
 RKE2{{ range .RKE2.Versions }}
 	{{ . }}{{ end}}
+
+Charts
+    Workspace:     {{.Charts.Workspace}}
+    ChartsRepoURL: {{.Charts.ChartsRepoURL}}
+    ChartsForkURL: {{.Charts.ChartsForkURL}}
+    DevBranch:     {{.Charts.DevBranch}}
+    ReleaseBranch: {{.Charts.ReleaseBranch}}
 `


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/444

Adding the configuration options for Charts release process inside ecm-distro-tools.

### Resulting config.json:

```
~/.ecm-distro-tools » cat config.json
{
 "user": {
  "email": "your.name@suse.com",
  "github_username": ""
 },
 "k3s": {
  "versions": {
   "v1.x.y": {
    "old_k8s_version": "v1.x.z",
    "new_k8s_version": "v1.x.y",
    "old_k8s_client": "v0.x.z",
    "new_k8s_client": "v0.x.y",
    "old_suffix": "k3s1",
    "new_suffix": "k3s1",
    "release_branch": "release-1.x",
    "workspace": "/home/nick/WORK/SOFTWARE/go/src/github.com/k3s-io/kubernetes/v1.x.z",
    "k3s_repo_owner": "k3s-io",
    "system_agent_installer_repo_owner": "rancher",
    "k8s_rancher_url": "git@github.com:k3s-io/kubernetes.git",
    "k3s_upstream_url": "git@github.com:k3s-io/k3s.git",
    "dry_run": false
   }
  }
 },
 "rancher": {
  "versions": {
   "v2.x.y": {
    "release_branch": "release/v2.x",
    "rancher_repo_owner": "rancher",
    "issue_number": "",
    "check_images": [],
    "base_registry": "stgregistry.suse.com",
    "registry": "registry.rancher.com",
    "prime_artifacts_bucket": "prime-artifacts",
    "dry_run": false,
    "skip_status_check": false
   }
  }
 },
 "rke2": {
  "versions": [
   "v1.x.y"
  ]
 },
 "charts": {
  "workspace": "/home/nick/WORK/SOFTWARE/go/src/github.com/rancher/charts",
  "charts_repo_url": "https://github.com/rancher/charts",
  "charts_fork_url": "",
  "dev_branch": "dev-v2.9",
  "release_branch": "release-v2.9"
 },
 "auth": {
  "drone": {
   "k3s_pr": "YOUR_TOKEN",
   "k3s_publish": "YOUR_TOKEN",
   "rancher_pr": "YOUR_TOKEN",
   "rancher_publish": "YOUR_TOKEN"
  },
  "github_token": "YOUR_TOKEN",
  "ssh_key_path": "path/to/your/ssh/key"
 }
}
```