### PR TITLE
Feature implementation: release list charts

### DIFF
--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -62,7 +62,13 @@ var chartsListSubCmd = &cobra.Command{
 			return errors.New("verify your config file, chart configuration not implemented correctly, you must insert workspace path and your forked repo url")
 		}
 
-		return charts.ListLifecycleStatus(context.Background(), config, branch, chart)
+		resp, err := charts.List(context.Background(), config, branch, chart)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(resp)
+		return nil
 	},
 }
 

--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -46,7 +46,7 @@ var chartsListSubCmd = &cobra.Command{
 	Short: "List Charts assets versions state for release process",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		var branch, chart string = "", ""
+		var branch, chart string
 
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [branch]")
@@ -62,11 +62,7 @@ var chartsListSubCmd = &cobra.Command{
 			return errors.New("verify your config file, chart configuration not implemented correctly, you must insert workspace path and your forked repo url")
 		}
 
-		err := charts.ListLifecycleStatus(context.Background(), config, branch, chart)
-		if err != nil {
-			return err
-		}
-		return nil
+		return charts.ListLifecycleStatus(context.Background(), config, branch, chart)
 	},
 }
 

--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rancher/ecm-distro-tools/release/charts"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/spf13/cobra"
 )
@@ -40,8 +41,38 @@ var rancherListRCDepsSubCmd = &cobra.Command{
 	},
 }
 
+var chartsListSubCmd = &cobra.Command{
+	Use:   "charts [branch] [charts](optional)",
+	Short: "List Charts assets versions state for release process",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		var branch, chart string = "", ""
+
+		if len(args) < 1 {
+			return errors.New("expected at least one argument: [branch]")
+		}
+		branch = args[0]
+
+		if len(args) > 1 {
+			chart = args[1]
+		}
+
+		config := rootConfig.Charts
+		if config.Workspace == "" || config.ChartsForkURL == "" {
+			return errors.New("verify your config file, chart configuration not implemented correctly, you must insert workspace path and your forked repo url")
+		}
+
+		err := charts.ListLifecycleStatus(context.Background(), config, branch, chart)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
 func init() {
 	rancherListSubCmd.AddCommand(rancherListRCDepsSubCmd)
 	listCmd.AddCommand(rancherListSubCmd)
+	listCmd.AddCommand(chartsListSubCmd)
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -45,7 +45,6 @@ var chartsListSubCmd = &cobra.Command{
 	Use:   "charts [branch] [charts](optional)",
 	Short: "List Charts assets versions state for release process",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		var branch, chart string
 
 		if len(args) < 1 {

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
 )
 
-// ListLifecycleStatus prints the lifecycle status of the charts
-func ListLifecycleStatus(ctx context.Context, c *config.ChartsRelease, branch, chart string) error {
+// List prints the lifecycle status of the charts
+func List(ctx context.Context, c *config.ChartsRelease, branch, chart string) (string, error) {
 	var branchArg, chartArg string
 
 	branchArg = "--branch-version=" + branch
@@ -21,12 +21,11 @@ func ListLifecycleStatus(ctx context.Context, c *config.ChartsRelease, branch, c
 
 	output, err := runChartsBuildScripts(c.Workspace, "lifecycle-status", branchArg, chartArg)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	fmt.Println(string(output))
-	fmt.Printf("generated log files for inspection at: \n%s\n", c.Workspace+"/logs/")
-	return nil
+	response := string(output) + fmt.Sprintf("\ngenerated log files for inspection at: \n%s\n", c.Workspace+"/logs/")
+	return response, nil
 }
 
 func runChartsBuildScripts(chartsRepoPath string, args ...string) ([]byte, error) {

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -7,39 +7,38 @@ import (
 	"os/exec"
 	"strings"
 
-	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/rancher/ecm-distro-tools/cmd/release/config"
 )
 
 // ListLifecycleStatus prints the lifecycle status of the charts
-func ListLifecycleStatus(ctx context.Context, c *ecmConfig.ChartsRelease, branch, chart string) error {
-
-	var branchArg, chartArg string = "", ""
+func ListLifecycleStatus(ctx context.Context, c *config.ChartsRelease, branch, chart string) error {
+	var branchArg, chartArg string
 
 	branchArg = "--branch-version=" + branch
 	if chart != "" {
 		chartArg = "--chart=" + chart
 	}
 
-	err := executeChartsBuildScripts(c.Workspace, "lifecycle-status", branchArg, chartArg)
+	output, err := runChartsBuildScripts(c.Workspace, "lifecycle-status", branchArg, chartArg)
 	if err != nil {
 		return err
 	}
 
+	fmt.Println(string(output))
 	fmt.Printf("generated log files for inspection at: \n%s\n", c.Workspace+"/logs/")
 	return nil
 }
 
-func executeChartsBuildScripts(chartsRepoPath string, args ...string) error {
+func runChartsBuildScripts(chartsRepoPath string, args ...string) ([]byte, error) {
 	// save current working dir
 	ecmWorkDir, err := os.Getwd()
 	if err != nil {
-		return err
+		return []byte{}, err
 	}
 
 	// change working dir to the charts repo
-	err = os.Chdir(chartsRepoPath)
-	if err != nil {
-		return err
+	if err := os.Chdir(chartsRepoPath); err != nil {
+		return []byte{}, err
 	}
 
 	bin := strings.Join([]string{chartsRepoPath, "bin", "charts-build-scripts"}, string(os.PathSeparator))
@@ -47,15 +46,13 @@ func executeChartsBuildScripts(chartsRepoPath string, args ...string) error {
 	cmd := exec.Command(bin, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to execute charts-build-scripts: %w, output: %s", err, output)
+		return []byte{}, err
 	}
-	fmt.Printf("charts-build-scripts output: %s\n", output)
 
 	// Change back working dir for the caller
-	err = os.Chdir(ecmWorkDir)
-	if err != nil {
-		return err
+	if err := os.Chdir(ecmWorkDir); err != nil {
+		return []byte{}, err
 	}
 
-	return nil
+	return output, nil
 }

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -1,0 +1,61 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+)
+
+// ListLifecycleStatus prints the lifecycle status of the charts
+func ListLifecycleStatus(ctx context.Context, c *ecmConfig.ChartsRelease, branch, chart string) error {
+
+	var branchArg, chartArg string = "", ""
+
+	branchArg = "--branch-version=" + branch
+	if chart != "" {
+		chartArg = "--chart=" + chart
+	}
+
+	err := executeChartsBuildScripts(c.Workspace, "lifecycle-status", branchArg, chartArg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("generated log files for inspection at: \n%s\n", c.Workspace+"/logs/")
+	return nil
+}
+
+func executeChartsBuildScripts(chartsRepoPath string, args ...string) error {
+	// save current working dir
+	ecmWorkDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// change working dir to the charts repo
+	err = os.Chdir(chartsRepoPath)
+	if err != nil {
+		return err
+	}
+
+	bin := strings.Join([]string{chartsRepoPath, "bin", "charts-build-scripts"}, string(os.PathSeparator))
+
+	cmd := exec.Command(bin, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to execute charts-build-scripts: %w, output: %s", err, output)
+	}
+	fmt.Printf("charts-build-scripts output: %s\n", output)
+
+	// Change back working dir for the caller
+	err = os.Chdir(ecmWorkDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -19,7 +19,7 @@ func List(ctx context.Context, c *config.ChartsRelease, branch, chart string) (s
 		chartArg = "--chart=" + chart
 	}
 
-	output, err := runChartsBuildScripts(c.Workspace, "lifecycle-status", branchArg, chartArg)
+	output, err := runChartsBuild(c.Workspace, "lifecycle-status", branchArg, chartArg)
 	if err != nil {
 		return "", err
 	}
@@ -28,16 +28,16 @@ func List(ctx context.Context, c *config.ChartsRelease, branch, chart string) (s
 	return response, nil
 }
 
-func runChartsBuildScripts(chartsRepoPath string, args ...string) ([]byte, error) {
+func runChartsBuild(chartsRepoPath string, args ...string) ([]byte, error) {
 	// save current working dir
 	ecmWorkDir, err := os.Getwd()
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	// change working dir to the charts repo
 	if err := os.Chdir(chartsRepoPath); err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	bin := strings.Join([]string{chartsRepoPath, "bin", "charts-build-scripts"}, string(os.PathSeparator))
@@ -45,12 +45,12 @@ func runChartsBuildScripts(chartsRepoPath string, args ...string) ([]byte, error
 	cmd := exec.Command(bin, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	// Change back working dir for the caller
 	if err := os.Chdir(ecmWorkDir); err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return output, nil


### PR DESCRIPTION
#### Issue:

https://github.com/rancher/ecm-distro-tools/issues/445


#### Solution:

After implementing: https://github.com/rancher/charts-build-scripts/pull/144

This is the integration between: 
- `charts-build-scripts` command `lifecycle-status`  
- `ecm-distro-tools` command `release list charts`

#### Result example:

The logs printed by `lifecycle-status` are printed to the terminal and the saved log files path is also printed in the terminal:
```
.
.
.

time=2024-07-26T18:11:33-03:00 level=info msg=Assets to be RELEASED

time=2024-07-26T18:11:33-03:00 level=info msg=rancher-istio

__________________________________________________________________
time=2024-07-26T18:11:33-03:00 level=info msg=Assets to be FORWARD-PORTED

time=2024-07-26T18:11:33-03:00 level=info msg=rancher-istio
time=2024-07-26T18:11:33-03:00 level=info msg=saving app state to state.json file
time=2024-07-26T18:11:33-03:00 level=info msg=saved state file successfully

generated log files for inspection at: 
/home/nick/WORK/SOFTWARE/go/src/github.com/release-work/charts/logs/
```