### PR TITLE
add a custom install script version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,15 @@ inputs:
   version:
     description: 'The tag of the ecm-distro-tools release to install.'
     required: true
+  install-script-version:
+    description: 'The version of the install script to use.'
+    required: false
+    default: ${{ github.action_ref }}
 runs:
   using: 'composite'
   steps:
   - env:
-      INSTALL_SCRIPT_TAG: ${{ github.action_ref }} 
+      INSTALL_SCRIPT_TAG: ${{ inputs.install-script-version }} 
     shell: bash
     run: |
       INSTALL_SCRIPT_PATH="${RUNNER_TEMP}/install.sh"


### PR DESCRIPTION
When using this composite action inside another composite action, `github.action_ref` can be empty. In these situations, we can use the input to use a custom version.