### PR TITLE
fix registry urls on generate missing images list and adds registry info to digests

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -124,7 +124,7 @@ var rancherGenerateMissingImagesListSubCmd = &cobra.Command{
 		if len(checkImages) == 0 && imagesListURL == "" {
 			return errors.New("either --images-list-url or --check-images must be provided")
 		}
-		missingImages, err := rancher.GenerateMissingImagesList(imagesListURL, registry, concurrencyLimit, checkImages, ignoreImages)
+		missingImages, err := rancher.GenerateMissingImagesList(imagesListURL, registry, concurrencyLimit, checkImages, ignoreImages, verbose)
 		if err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ var rancherGenerateDockerImagesDigestsSubCmd = &cobra.Command{
 	Use:   "docker-images-digests",
 	Short: "Generate a file with images digests from an images list",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return rancher.GenerateDockerImageDigests(rancherImagesDigestsOutputFile, rancherImagesDigestsImagesURL, rancherImagesDigestsRegistry)
+		return rancher.GenerateDockerImageDigests(rancherImagesDigestsOutputFile, rancherImagesDigestsImagesURL, rancherImagesDigestsRegistry, verbose)
 	},
 }
 

--- a/cmd/release/cmd/root.go
+++ b/cmd/release/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	dryRun         bool
 	ignoreValidate bool
 	rootConfig     *config.Config
+	verbose        bool
 	configFile     string
 	stringConfig   string
 )
@@ -44,6 +45,7 @@ func SetVersion(version string) {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "Debug")
 	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "R", false, "Dry Run")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&ignoreValidate, "ignore-validate", "I", false, "Ignore the validate config step")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config-file", "c", "$HOME/.ecm-distro-tools/config.json", "Path for the config.json file")
 	rootCmd.PersistentFlags().StringVarP(&stringConfig, "config", "C", "", "JSON config string")

--- a/cmd/release/cmd/root.go
+++ b/cmd/release/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func initConfig() {
 		configFile = os.ExpandEnv(configFile)
 		conf, err = config.Load(configFile)
 		if err != nil {
-			log.Println("failed to load config, use 'release config gen' to create a new one at: " + configFile)
+			fmt.Println("failed to load config, use 'release config gen' to create a new one at: " + configFile)
 			fmt.Println(err)
 			os.Exit(1)
 		}

--- a/log/log.go
+++ b/log/log.go
@@ -10,23 +10,23 @@ func NewLogger(verbose bool) Logger {
 	return Logger{verbose: verbose}
 }
 
-func (l Logger) Print(a ...any) (n int, err error) {
+func (l Logger) Print(a ...any) (int, error) {
 	if l.verbose {
 		return fmt.Print(a...)
 	}
-	return
+	return 0, nil
 }
 
-func (l Logger) Printf(format string, a ...any) (n int, err error) {
+func (l Logger) Printf(format string, a ...any) (int, error) {
 	if l.verbose {
 		return fmt.Printf(format, a...)
 	}
-	return
+	return 0, nil
 }
 
-func (l Logger) Println(a ...any) (n int, err error) {
+func (l Logger) Println(a ...any) (int, error) {
 	if l.verbose {
 		return fmt.Println(a...)
 	}
-	return
+	return 0, nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,32 @@
+package log
+
+import "fmt"
+
+type Logger struct {
+	verbose bool
+}
+
+func NewLogger(verbose bool) Logger {
+	return Logger{verbose: verbose}
+}
+
+func (l Logger) Print(a ...any) (n int, err error) {
+	if l.verbose {
+		return fmt.Print(a...)
+	}
+	return
+}
+
+func (l Logger) Printf(format string, a ...any) (n int, err error) {
+	if l.verbose {
+		return fmt.Printf(format, a...)
+	}
+	return
+}
+
+func (l Logger) Println(a ...any) (n int, err error) {
+	if l.verbose {
+		return fmt.Println(a...)
+	}
+	return
+}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -24,11 +24,10 @@ import (
 	"text/template"
 	"time"
 
-	ecmLog "github.com/rancher/ecm-distro-tools/log"
-
 	"github.com/google/go-github/v39/github"
 	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
 	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
+	ecmLog "github.com/rancher/ecm-distro-tools/log"
 	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"golang.org/x/mod/semver"

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -528,15 +528,14 @@ func validateRepoImage(repoImage string) error {
 }
 
 func GenerateDockerImageDigests(outputFile, imagesFileURL, registry string, verbose bool) error {
-	imagesDigests, err := dockerImagesDigests(imagesFileURL, registry, verbose)
+	imagesDigests, err := dockerImagesDigests(imagesFileURL, registry)
 	if err != nil {
 		return err
 	}
 	return createAssetFile(outputFile, imagesDigests)
 }
 
-func dockerImagesDigests(imagesFileURL, registry string, verbose bool) (imageDigest, error) {
-	log := ecmLog.NewLogger(verbose)
+func dockerImagesDigests(imagesFileURL, registry string) (imageDigest, error) {
 	imagesList, err := artifactImageList(imagesFileURL, registry)
 	if err != nil {
 		return nil, err
@@ -554,7 +553,6 @@ func dockerImagesDigests(imagesFileURL, registry string, verbose bool) (imageDig
 		if imageAndVersion == "" || imageAndVersion == " " {
 			continue
 		}
-		log.Println("image: " + imageAndVersion)
 		if !strings.Contains(imageAndVersion, ":") {
 			return nil, errors.New("malformed image name: , missing ':'")
 		}
@@ -569,8 +567,7 @@ func dockerImagesDigests(imagesFileURL, registry string, verbose bool) (imageDig
 			}
 			repositoryAuths[image] = auth
 		}
-		digest, statusCode, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, repositoryAuths[image])
-		log.Println("status code: " + strconv.Itoa(statusCode))
+		digest, _, err := dockerImageDigest(rgInfo.BaseURL, image, imageVersion, repositoryAuths[image])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Problem: The `--registry` flag wasn't working because the registry URL was hardcoded in a function
Solution: Use the registry info to get the correct registry information

Other updates:
* Adds the registry information to docker digests
* Adds the verbose flag `--verbose`, `-V`
* Adds the ecm log package which only prints info to sdout if verbose is enabled.