### PR TITLE
Release charts push

### DIFF
--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -18,7 +18,7 @@ release -h
 * All commands require a Github token (classic) with the following permissions:
   * Be generated on behalf of an account with access to the `k3s-io/k3s` repo
   * `repo`
-  * `write:packages`    
+  * `write:packages`
 * An SSH key, follow the Github [Documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) to generate one.
 * A valid config file at `~/.ecm-distro-tools/config.json`
 
@@ -37,7 +37,7 @@ release tag system-agent-installer-k3s ga v1.29.2
 ```bash
 $ release generate k3s tags v1.26.12
 > failed to rebase and create tags: chown: changing ownership of '/home/go/.cache': Operation not permitted
-failed to initialize build cache at /home/go/.cache: mkdir /home/go/.cache/00: permission denied 
+failed to initialize build cache at /home/go/.cache: mkdir /home/go/.cache/00: permission denied
 ```
 Verify if the `$GOPATH/.cache` directory is owned by the same user that is running the command. If not, change the ownership of the directory:
 ```bash
@@ -54,6 +54,37 @@ Git ref can be a tag, branch, or commit hash.
 release list rancher rc-deps release/v2.7
 release list rancher rc-deps 8c7bbcaabcfabb00b1c89e55ed4f68117f938262
 release list rancher rc-deps v2.7.12-rc1
+```
+
+### Charts Release
+#### Examples
+##### Default workflow
+
+```bash
+release list charts 2.9
+release update charts 2.9 rancher-vsphere-csi 104.0.1+up3.3.0-rancher2
+release push charts 2.9
+
+# to inspect before pushing
+release push charts 2.9 debug
+```
+
+Configure your autocompletion on `zsh` or `bash` for `release chart` commands.
+
+#### `zsh` configuration example:
+```
+./release completion zsh > completion.zsh
+mv completion.zsh ~/.zsh/completion/completion.zsh
+chmod +x ~/.zsh/completion/completion.zsh
+```
+
+Your `.zshrc` file must have something like the following:
+```
+# ECM-DISTRO-TOOLS
+export PATH=$PATH:/<home_path>/.local/bin/ecm-distro-tools
+source ~/.zsh/completion/completion.zsh
+fpath=(~/.zsh/completion $fpath)
+autoload -Uz compinit && compinit
 ```
 
 ## Contributions

--- a/cmd/release/cmd/list.go
+++ b/cmd/release/cmd/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/rancher/ecm-distro-tools/release/charts"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
@@ -45,13 +46,26 @@ var rancherListRCDepsSubCmd = &cobra.Command{
 }
 
 var chartsListSubCmd = &cobra.Command{
-	Use:   "charts [branch] [charts](optional)",
-	Short: "List Charts assets versions state for release process",
+	Use:     "charts [branch-line] [charts](optional)",
+	Short:   "List Charts assets versions state for release process",
+	Example: "release list charts 2.9",
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if err := validateChartConfig(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(args) == 0 {
+			return rootConfig.Charts.BranchLines, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var branch, chart string
 
 		if len(args) < 1 {
-			return errors.New("expected at least one argument: [branch]")
+			return errors.New("expected at least one argument: [branch-line]")
 		}
 		branch = args[0]
 

--- a/cmd/release/cmd/push.go
+++ b/cmd/release/cmd/push.go
@@ -83,7 +83,6 @@ var pushChartsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
 			releaseBranch string // given release branch
-			debug         bool   // debug mode
 
 			ctx context.Context // background context
 			t   string          // token
@@ -92,10 +91,9 @@ var pushChartsCmd = &cobra.Command{
 
 		// arguments
 		releaseBranch = charts.MountReleaseBranch(args[0])
-		if len(args) > 1 {
-			if args[1] == "debug" || args[1] == "d" {
-				debug = true
-			}
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
 		}
 
 		ctx = context.Background()

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,7 +65,8 @@ func UserInput(title string) bool {
 
 	input, err = reader.ReadString('\n')
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 	input = strings.TrimSpace(input)
 	input = strings.ToLower(input)

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -1,11 +1,15 @@
 package exec
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"text/template"
 )
 
@@ -48,4 +52,35 @@ func RunTemplatedScript(dir, fileName, scriptTemplate string, funcMap template.F
 		return "", err
 	}
 	return output, nil
+}
+
+// UserInput will ask for user input with a given title
+func UserInput(title string) bool {
+	var input string
+	var err error
+
+	fmt.Println(title)
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("([Y]es/[N]o/[A]bort) Enter: ")
+
+	input, err = reader.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+	input = strings.TrimSpace(input)
+	input = strings.ToLower(input)
+
+	// Check user input
+	if input == "yes" || input == "y" {
+		fmt.Printf("Continue...\n___\n\n")
+		return true
+	}
+
+	if input == "a" || input == "abort" {
+		os.Exit(0)
+	}
+
+	fmt.Println("Stop.")
+	return false
 }

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -55,15 +55,12 @@ func RunTemplatedScript(dir, fileName, scriptTemplate string, funcMap template.F
 
 // UserInput will ask for user input with a given title
 func UserInput(title string) bool {
-	var input string
-	var err error
-
 	fmt.Println(title)
 
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("([Y]es/[N]o/[A]bort) Enter: ")
 
-	input, err = reader.ReadString('\n')
+	input, err := reader.ReadString('\n')
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/release/charts/chart_management.go
+++ b/release/charts/chart_management.go
@@ -76,6 +76,11 @@ func VersionArgs(ctx context.Context, c *config.ChartsRelease, ch string) ([]str
 	return versions, nil
 }
 
+// MountReleaseBranch will mount the release branch name from the line provided
+func MountReleaseBranch(line string) string {
+	return "release-v" + line
+}
+
 // IsBranchAvailable will check if the branch line exists
 func IsBranchAvailable(branch string, availableBranches []string) bool {
 	for _, b := range availableBranches {

--- a/release/charts/chart_management.go
+++ b/release/charts/chart_management.go
@@ -21,16 +21,11 @@ type asset struct {
 
 // ChartArgs will return the list of available charts in the current branch
 func ChartArgs(ctx context.Context, c *config.ChartsRelease) ([]string, error) {
-	var (
-		assets string
-		files  []os.DirEntry
-		dirs   []string
-		err    error
-	)
+	var dirs []string
 
-	assets = filepath.Join(c.Workspace, "assets")
+	assets := filepath.Join(c.Workspace, "assets")
 
-	files, err = os.ReadDir(assets)
+	files, err := os.ReadDir(assets)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +43,7 @@ func ChartArgs(ctx context.Context, c *config.ChartsRelease) ([]string, error) {
 
 // VersionArgs will return the list of available versions for the target chart
 func VersionArgs(ctx context.Context, c *config.ChartsRelease, ch string) ([]string, error) {
-	var (
-		status *status
-		err    error
-	)
-
-	status, err = loadState(filepath.Join(c.Workspace, "state.json"))
+	status, err := loadState(filepath.Join(c.Workspace, "state.json"))
 	if err != nil {
 		return nil, err
 	}
@@ -109,14 +99,14 @@ func IsChartAvailable(ctx context.Context, conf *config.ChartsRelease, ch string
 }
 
 // IsVersionAvailable exists to be released or forward ported
-func IsVersionAvailable(ctx context.Context, conf *config.ChartsRelease, ch, v string) (bool, error) {
+func IsVersionAvailable(ctx context.Context, conf *config.ChartsRelease, ch, version string) (bool, error) {
 	availableVersions, err := VersionArgs(ctx, conf, ch)
 	if err != nil {
 		return false, err
 	}
 
 	for _, c := range availableVersions {
-		if c == v {
+		if c == version {
 			return true, nil
 		}
 	}

--- a/release/charts/chart_management.go
+++ b/release/charts/chart_management.go
@@ -21,15 +21,20 @@ type asset struct {
 
 // ChartArgs will return the list of available charts in the current branch
 func ChartArgs(ctx context.Context, c *config.ChartsRelease) ([]string, error) {
-	assets := filepath.Join(c.Workspace, "assets")
+	var (
+		assets string
+		files  []os.DirEntry
+		dirs   []string
+		err    error
+	)
 
-	// Read the directory assets contents
-	files, err := os.ReadDir(assets)
+	assets = filepath.Join(c.Workspace, "assets")
+
+	files, err = os.ReadDir(assets)
 	if err != nil {
 		return nil, err
 	}
 
-	var dirs []string
 	for _, file := range files {
 		if file.IsDir() {
 			dirs = append(dirs, file.Name())
@@ -43,7 +48,12 @@ func ChartArgs(ctx context.Context, c *config.ChartsRelease) ([]string, error) {
 
 // VersionArgs will return the list of available versions for the target chart
 func VersionArgs(ctx context.Context, c *config.ChartsRelease, ch string) ([]string, error) {
-	status, err := loadState(filepath.Join(c.Workspace, "state.json"))
+	var (
+		status *status
+		err    error
+	)
+
+	status, err = loadState(filepath.Join(c.Workspace, "state.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -102,7 +102,14 @@ func Update(ctx context.Context, c *config.ChartsRelease, br, ch, vr string) (st
 	return string(output), nil
 }
 
-// Push will push the charts updates to the remote upstream charts repository
+// Push will push the charts updates to the remote upstream charts repository and create a PR.
+//   - ctx: background context.
+//   - c: charts release configuration.
+//   - u: user configuration with username and email.
+//   - ghc: github client, to be used to interact with github API.
+//   - b: release branch name.
+//   - t: token from github.
+//   - d: debug mode.
 func Push(ctx context.Context, c *config.ChartsRelease, u *config.User, ghc *github.Client, b, t string, d bool) (string, error) {
 	const repoOwner = "rancher"
 	const repoName = "charts"

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -4,13 +4,50 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/google/go-github/v39/github"
+
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
+	ecmExec "github.com/rancher/ecm-distro-tools/exec"
+	"github.com/rancher/ecm-distro-tools/repository"
 )
+
+// body is the default PR body for the charts release PR
+const body string = `
+## Charts Checklist (built for v0.9.5 charts-build-scripts)
+
+### Checkpoint 0: Validate **release.yaml**
+
+Validation steps:
+- [ ] Each chart version in **release.yaml** DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
+- [ ] Each chart version in **release.yaml** IS exactly 1 more patch version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.
+
+### Checkpoint 1: Compare contents of assets/ to charts/
+
+Validation steps:
+- [ ] Running **make unzip** to regenerate the **charts/** from scratch, then **git diff** to check differences between **assets/** and **charts/** yields NO differences or innocuous differences.
+
+IMPORTANT: Do not undo these changes for future steps since we want to keep the charts/ that match the current contents of assets!
+
+### Checkpoint 2: Compare assets against index.yaml
+
+Validation steps:
+- [ ] The **index.yaml** file has an entry for each chart version.
+- [ ] The **index.yaml** entries for each chart matches the **Chart.yaml** for each chart.
+- [ ] Each chart has ALL required annotations
+- kube-version annotation
+- rancher-version annotation
+- permits-os annotation (indicates Windows and/or Linux)
+`
 
 // List prints the lifecycle status of the charts
 func List(ctx context.Context, c *config.ChartsRelease, branch, chart string) (string, error) {
@@ -92,4 +129,104 @@ func runChartsBuild(chartsRepoPath string, args ...string) ([]byte, error) {
 	}
 
 	return output, nil
+}
+
+// Push will push the charts updates to the remote upstream charts repository
+func Push(ctx context.Context, c *config.ChartsRelease, u *config.User, ghc *github.Client, b, t string, d bool) (string, error) {
+	const repoOwner = "rancher"
+	const repoName = "charts"
+
+	var (
+		r      *git.Repository     // local opened repository
+		h      *plumbing.Reference // local head reference
+		remote string              // remote repository name
+		err    error
+	)
+
+	r, err = git.PlainOpen(c.Workspace)
+	if err != nil {
+		return "", err
+	}
+
+	remote, err = repository.GetUpstreamRemote(r, c.ChartsRepoURL)
+	if err != nil {
+		return "", err
+	}
+
+	h, err = r.Head()
+	if err != nil {
+		return "", err
+	}
+
+	// create a new PR
+	pr := &github.NewPullRequest{
+		Title:               github.String(fmt.Sprintf("[%s] batch release", b)),
+		Base:                github.String(b),
+		Head:                github.String(h.Name().Short()),
+		Body:                github.String(body),
+		MaintainerCanModify: github.Bool(true),
+	}
+
+	// debug mode
+	if d {
+		if err := debugPullRequest(r, remote, b); err != nil {
+			return "", err
+		}
+	}
+
+	if err := repository.PushRemoteBranch(r, remote, u.GithubUsername, t, d); err != nil {
+		return "", err
+	}
+
+	prResp, _, err := ghc.PullRequests.Create(ctx, repoOwner, repoName, pr)
+	if err != nil {
+		return "", err
+	}
+
+	return prResp.GetHTMLURL(), nil
+}
+
+// debugPullRequest will prompt the user to check the files and commits that will be pushed to the remote repository
+func debugPullRequest(r *git.Repository, remote, b string) error {
+	var (
+		execute bool
+		iter    object.CommitIter
+		err     error
+	)
+
+	if execute = ecmExec.UserInput("Check files that will be pushed?"); execute {
+		// commit history
+		iter, err = r.Log(&git.LogOptions{})
+		if err != nil {
+			return err
+		}
+
+		err = iter.ForEach(func(c *object.Commit) error {
+			fileStats, err := c.Stats()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(c)
+			fmt.Println(fileStats)
+
+			if execute = ecmExec.UserInput("Check next files that will be pushed?"); !execute {
+				return storer.ErrStop
+			}
+
+			return nil
+		})
+	}
+
+	if execute = ecmExec.UserInput("Check commits that will be pushed?"); execute {
+		if err := repository.DiffLocalToRemote(r, remote, b); err != nil {
+			return err
+		}
+	}
+
+	if execute = ecmExec.UserInput("Push and Create PR to the remote repository?"); !execute {
+		return errors.New("user aborted the push")
+	}
+
+	return nil
 }

--- a/release/charts/charts.go
+++ b/release/charts/charts.go
@@ -22,7 +22,7 @@ import (
 
 // body is the default PR body for the charts release PR
 const body string = `
-## Charts Checklist (built for v0.9.5 charts-build-scripts)
+## Charts Checklist (built for v0.9.X charts-build-scripts)
 
 ### Checkpoint 0: Validate **release.yaml**
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -624,10 +625,20 @@ func getCommits(r *git.Repository, h plumbing.Hash) ([]*object.Commit, error) {
 
 	iter = object.NewCommitPreorderIter(firstCommit, nil, nil)
 
+	limit := 100
+	count := 0
 	err = iter.ForEach(func(c *object.Commit) error {
+		if count >= limit {
+			return io.EOF
+		}
 		commits = append(commits, c)
+		count++
 		return nil
 	})
+
+	if err == io.EOF {
+		err = nil // Reset error if it was forced by the limit
+	}
 
 	return commits, err
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -545,10 +545,9 @@ func PushRemoteBranch(r *git.Repository, remote, u, t string, debug bool) error 
 	var (
 		branchRef string
 		h         *plumbing.Reference
-		err       error
 	)
 
-	h, err = r.Head()
+	h, err := r.Head()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Issue:

https://github.com/rancher/ecm-distro-tools/issues/447


#### Solution:

After: https://github.com/rancher/ecm-distro-tools/pull/464

This command (`release push charts <some_release_branch>`), 
will push the changes on the local branch, 
and create a Pull Request against the given release branch. 


#### Debug mode 

Since it is a critical operation, 
I implemented the debug mode which will guide the user on:
- inspecting the commits that will be pushed.
- inspecting the files that will be pushed.

#### Result example:

Without debug mode, this is an example PR created: https://github.com/rancher/charts/pull/4333

The debug mode is too verbose to print here. 

