### PR TITLE
add generate images-sync-config command

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -35,6 +35,10 @@ var (
 	rancherImagesDigestsOutputFile      string
 	rancherImagesDigestsRegistry        string
 	rancherImagesDigestsImagesURL       string
+	rancherSyncImages                   []string
+	rancherSourceRegistry               string
+	rancherTargetRegistry               string
+	rancherSyncConfigOutputPath         string
 )
 
 // generateCmd represents the generate command
@@ -160,6 +164,14 @@ var rancherGenerateDockerImagesDigestsSubCmd = &cobra.Command{
 	},
 }
 
+var rancherGenerateImagesSyncConfigSubCmd = &cobra.Command{
+	Use:   "images-sync-config",
+	Short: "Generate a regsync config file for images sync",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rancher.GenerateImagesSyncConfig(rancherSyncImages, rancherSourceRegistry, rancherTargetRegistry, rancherSyncConfigOutputPath)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
@@ -169,6 +181,7 @@ func init() {
 	rancherGenerateSubCmd.AddCommand(rancherGenerateArtifactsIndexSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateMissingImagesListSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateDockerImagesDigestsSubCmd)
+	rancherGenerateSubCmd.AddCommand(rancherGenerateImagesSyncConfigSubCmd)
 
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
@@ -227,6 +240,23 @@ func init() {
 	}
 	rancherGenerateDockerImagesDigestsSubCmd.Flags().StringVarP(&rancherImagesDigestsRegistry, "registry", "r", "", "Docker Registry e.g: docker.io")
 	if err := rancherGenerateDockerImagesDigestsSubCmd.MarkFlagRequired("registry"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	// rancher generate images-sync-config
+	rancherGenerateImagesSyncConfigSubCmd.Flags().StringSliceVarP(&rancherSyncImages, "images", "k", make([]string, 0), "List of images to sync to a registry")
+	rancherGenerateImagesSyncConfigSubCmd.Flags().StringVarP(&rancherSourceRegistry, "source-registry", "s", "", "Source registry, where the images are located")
+	rancherGenerateImagesSyncConfigSubCmd.Flags().StringVarP(&rancherTargetRegistry, "target-registry", "t", "", "Target registry, where the images should be synced to")
+	rancherGenerateImagesSyncConfigSubCmd.Flags().StringVarP(&rancherSyncConfigOutputPath, "output", "o", "./config.yaml", "Output path of the generated config file")
+	if err := rancherGenerateImagesSyncConfigSubCmd.MarkFlagRequired("images"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := rancherGenerateImagesSyncConfigSubCmd.MarkFlagRequired("source-registry"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := rancherGenerateImagesSyncConfigSubCmd.MarkFlagRequired("target-registry"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -590,7 +590,7 @@ func generateRegsyncConfig(images []string, sourceRegistry, targetRegistry strin
 			return nil, err
 		}
 		config.Sync[i] = regsyncSync{
-			Source: image,
+			Source: sourceRegistry + "/" + image,
 			Target: targetRegistry + "/" + image,
 			Type:   "repository",
 			Tags:   regsyncTags{Allow: []string{imageVersion}},

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -566,20 +566,20 @@ func GenerateImagesSyncConfig(images []string, sourceRegistry, targetRegistry, o
 			Parallel:   1,
 			MediaTypes: regsyncDefaultMediaTypes,
 		},
-		Sync: make([]regsyncSync, 0),
+		Sync: make([]regsyncSync, len(images)),
 	}
 
-	for _, imageAndVersion := range images {
+	for i, imageAndVersion := range images {
 		image, imageVersion, err := splitImageAndVersion(imageAndVersion)
 		if err != nil {
 			return err
 		}
-		config.Sync = append(config.Sync, regsyncSync{
+		config.Sync[i] = regsyncSync{
 			Source: image,
 			Target: targetRegistry + "/" + image,
 			Type:   "repository",
 			Tags:   regsyncTags{Allow: []string{imageVersion}},
-		})
+		}
 	}
 
 	f, err := os.Create(outputPath)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -66,22 +66,22 @@ var registriesInfo = map[string]registryInfo{
 		BaseURL:     rancherRegistryBaseURL,
 		AuthURL:     sccSUSEURL,
 		Service:     sccSUSEService,
-		UserEnv:     "{{env \"PRIME_REGISTRY_USERNAME\"}}",
-		PasswordEnv: "{{env \"PRIME_REGISTRY_PASSWORD\"}}",
+		UserEnv:     `{{env "PRIME_REGISTRY_USERNAME"}}`,
+		PasswordEnv: `{{env "PRIME_REGISTRY_PASSWORD"}}`,
 	},
 	"stgregistry.suse.com": {
 		BaseURL:     stagingRancherRegistryBaseURL,
 		AuthURL:     stagingSccSUSEURL,
 		Service:     sccSUSEService,
-		UserEnv:     "{{env \"STAGING_REGISTRY_USERNAME\"}}",
-		PasswordEnv: "{{env \"STAGING_REGISTRY_PASSWORD\"}}",
+		UserEnv:     `{{env "STAGING_REGISTRY_USERNAME"}}`,
+		PasswordEnv: `{{env "STAGING_REGISTRY_PASSWORD"}}`,
 	},
 	"docker.io": {
 		BaseURL:     dockerRegistryURL,
 		AuthURL:     dockerAuthURL,
 		Service:     dockerService,
-		UserEnv:     "{{env \"DOCKERIO_REGISTRY_USERNAME\"}}",
-		PasswordEnv: "{{env \"DOCKERIO_REGISTRY_PASSWORD\"}}",
+		UserEnv:     `{{env "DOCKERIO_REGISTRY_USERNAME"}}`,
+		PasswordEnv: `{{env "DOCKERIO_REGISTRY_PASSWORD"}}`,
 	},
 }
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -130,18 +130,22 @@ type regsyncConfig struct {
 	Defaults regsyncDefaults `yaml:"defaults"`
 	Sync     []regsyncSync   `yaml:"sync"`
 }
+
 type regsyncCreds struct {
 	Registry string `yaml:"registry"`
 	User     string `yaml:"user"`
 	Pass     string `yaml:"pass"`
 }
+
 type regsyncDefaults struct {
 	Parallel   int      `yaml:"parallel"`
 	MediaTypes []string `yaml:"mediaTypes"`
 }
+
 type regsyncTags struct {
 	Allow []string `yaml:"allow"`
 }
+
 type regsyncSync struct {
 	Source string      `yaml:"source"`
 	Target string      `yaml:"target"`

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -66,13 +66,15 @@ func TestGenerateRegsyncConfig(t *testing.T) {
 	images := []string{rancherImage + ":" + rancherVersion, rancherAgentImage + ":" + rancherVersion}
 	sourceRegistry := "docker.io"
 	targetRegistry := "registry.rancher.com"
+	sourceRancherImage := sourceRegistry + "/" + rancherImage
+	sourceRancherAgentImage := sourceRegistry + "/" + rancherAgentImage
 	targetRancherImage := targetRegistry + "/" + rancherImage
 	config, err := generateRegsyncConfig(images, sourceRegistry, targetRegistry)
 	if err != nil {
 		t.Error(err)
 	}
-	if config.Sync[0].Source != rancherImage {
-		t.Error("rancher image should be: '" + rancherImage + "' instead, got: '" + config.Sync[0].Source + "'")
+	if config.Sync[0].Source != sourceRancherImage {
+		t.Error("rancher image should be: '" + sourceRancherImage + "' instead, got: '" + config.Sync[0].Source + "'")
 	}
 	if config.Sync[0].Target != targetRancherImage {
 		t.Error("target rancher image should be: '" + targetRancherImage + "' instead, got: '" + config.Sync[0].Target + "'")
@@ -80,7 +82,7 @@ func TestGenerateRegsyncConfig(t *testing.T) {
 	if config.Sync[0].Tags.Allow[0] != rancherVersion {
 		t.Error("rancher version should be: '" + rancherVersion + "' instead, got: '" + config.Sync[0].Tags.Allow[0] + "'")
 	}
-	if config.Sync[1].Source != rancherAgentImage {
-		t.Error("rancher agent image should be: '" + rancherAgentImage + "' instead, got: '" + config.Sync[1].Source + "'")
+	if config.Sync[1].Source != sourceRancherAgentImage {
+		t.Error("rancher agent image should be: '" + sourceRancherAgentImage + "' instead, got: '" + config.Sync[1].Source + "'")
 	}
 }

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -58,3 +58,29 @@ func TestSplitImageAndVersion(t *testing.T) {
 		t.Error("expected to flag image without version as malformed " + imagesWithoutVersion[0])
 	}
 }
+
+func TestGenerateRegsyncConfig(t *testing.T) {
+	rancherImage := "rancher/rancher"
+	rancherAgentImage := "rancher/rancher-agent"
+	rancherVersion := "v2.9.0"
+	images := []string{rancherImage + ":" + rancherVersion, rancherAgentImage + ":" + rancherVersion}
+	sourceRegistry := "docker.io"
+	targetRegistry := "registry.rancher.com"
+	targetRancherImage := targetRegistry + "/" + rancherImage
+	config, err := generateRegsyncConfig(images, sourceRegistry, targetRegistry)
+	if err != nil {
+		t.Error(err)
+	}
+	if config.Sync[0].Source != rancherImage {
+		t.Error("rancher image should be: '" + rancherImage + "' instead, got: '" + config.Sync[0].Source + "'")
+	}
+	if config.Sync[0].Target != targetRancherImage {
+		t.Error("target rancher image should be: '" + targetRancherImage + "' instead, got: '" + config.Sync[0].Target + "'")
+	}
+	if config.Sync[0].Tags.Allow[0] != rancherVersion {
+		t.Error("rancher version should be: '" + rancherVersion + "' instead, got: '" + config.Sync[0].Tags.Allow[0] + "'")
+	}
+	if config.Sync[1].Source != rancherAgentImage {
+		t.Error("rancher agent image should be: '" + rancherAgentImage + "' instead, got: '" + config.Sync[1].Source + "'")
+	}
+}


### PR DESCRIPTION
Adds the `release generate rancher images-sync-config` command, which generates a regsync config file, used to sync images from one registry to another.

Example usage:
```
export DOCKERIO_REGISTRY_USERNAME=username
export DOCKERIO_REGISTRY_PASSWORD=password
export PRIME_REGISTRY_USERNAME=username
export PRIME_REGISTRY_PASSWORD=password

release generate rancher images-sync-config -k "tashima42/rancher:v2.9.0,tashima42/rancher-agent:v2.9.0" -s docker.io -t registry.rancher.com -o ./config.yaml

regsync check --config ./config.yaml
regsync once --config ./config.yaml
```