### PR TITLE
Ensure step conditions are respected

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -131,7 +131,7 @@ runs:
   # Short-circuit if either fails. This should decrease the likelihood
   # of only one registry getting updated while the other fails.
   - name: Login to registry [Public]
-    if: ${{ inputs.push-to-public }}
+    if: ${{ inputs.push-to-public == true || inputs.push-to-public == 'true' }}
     uses: docker/login-action@v3
     with:
       registry: ${{ inputs.public-registry }}
@@ -139,7 +139,7 @@ runs:
       password: ${{ inputs.public-password }}
 
   - name: Login to registry [Prime]
-    if: ${{ inputs.push-to-prime }}
+    if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
     uses: docker/login-action@v3
     with:
       registry: ${{ inputs.prime-registry }}
@@ -155,7 +155,7 @@ runs:
 
   - name: Build and push image [Public]
     shell: bash
-    if: ${{ inputs.push-to-public }}
+    if: ${{ inputs.push-to-public == true || inputs.push-to-public == 'true' }}
     run: |
       make ${{ inputs.make-target }}
     env:
@@ -165,7 +165,7 @@ runs:
 
   - name: Build and push image [Prime]
     shell: bash
-    if: ${{ inputs.push-to-prime }}
+    if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
     run: |
       IID_FILE=$(mktemp)
       export IID_FILE_FLAG="--iidfile ${IID_FILE}"


### PR DESCRIPTION
Yesterday I was having issues using this and I believe it's due to inconsistency in how input types are handled. Even though they are set to be booleans, the value passed is always a string. I found other GH issues with details on this: https://github.com/actions/runner/issues/1483

I have even encountered the same issue and needed to make similar changes, seen here: https://github.com/rancher/shell/blob/2106e32b5fb1651ff3523a356830fd1aec79294a/.github/workflows/port-pr.yaml#L48