### PR TITLE
[feature] Rancher UI dashboard commands

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -22,9 +22,6 @@ var (
 	k3sPrevMilestone string
 	k3sMilestone     string
 
-	uiPrevMilestone string
-	uiMilestone     string
-
 	dashboardPrevMilestone string
 	dashboardMilestone     string
 
@@ -190,7 +187,7 @@ var uiGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "ui", uiMilestone, uiPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "ui", dashboardMilestone, dashboardPrevMilestone, client)
 		if err != nil {
 			return err
 		}
@@ -268,8 +265,8 @@ func init() {
 	}
 
 	// ui release notes
-	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&uiPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
-	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&uiMilestone, "milestone", "m", "", "Milestone")
+	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&dashboardPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&dashboardMilestone, "milestone", "m", "", "Milestone")
 	if err := uiGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -22,6 +22,12 @@ var (
 	k3sPrevMilestone string
 	k3sMilestone     string
 
+	uiPrevMilestone string
+	uiMilestone     string
+
+	dashboardPrevMilestone string
+	dashboardMilestone     string
+
 	concurrencyLimit                    int
 	imagesListURL                       string
 	ignoreImages                        []string
@@ -172,6 +178,52 @@ var rancherGenerateImagesSyncConfigSubCmd = &cobra.Command{
 	},
 }
 
+var uiGenerateSubCmd = &cobra.Command{
+	Use:   "ui",
+	Short: "Generate ui related artifacts",
+}
+
+var uiGenerateReleaseNotesSubCmd = &cobra.Command{
+	Use:   "release-notes",
+	Short: "Generate ui release notes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "ui", uiMilestone, uiPrevMilestone, client)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(notes.String())
+
+		return nil
+	},
+}
+
+var dashboardGenerateSubCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Generate dashboard related artifacts",
+}
+
+var dashboardGenerateReleaseNotesSubCmd = &cobra.Command{
+	Use:   "release-notes",
+	Short: "Generate dashboard release notes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "dashboard", dashboardMilestone, dashboardPrevMilestone, client)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(notes.String())
+
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
@@ -182,10 +234,14 @@ func init() {
 	rancherGenerateSubCmd.AddCommand(rancherGenerateMissingImagesListSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateDockerImagesDigestsSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateImagesSyncConfigSubCmd)
+	uiGenerateSubCmd.AddCommand(uiGenerateReleaseNotesSubCmd)
+	dashboardGenerateSubCmd.AddCommand(dashboardGenerateReleaseNotesSubCmd)
 
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
 	generateCmd.AddCommand(rancherGenerateSubCmd)
+	generateCmd.AddCommand(uiGenerateSubCmd)
+	generateCmd.AddCommand(dashboardGenerateSubCmd)
 
 	// k3s release notes
 	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
@@ -207,6 +263,30 @@ func init() {
 		os.Exit(1)
 	}
 	if err := rke2GenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// ui release notes
+	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&uiPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	uiGenerateReleaseNotesSubCmd.Flags().StringVarP(&uiMilestone, "milestone", "m", "", "Milestone")
+	if err := uiGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := uiGenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// dashboard release notes
+	dashboardGenerateReleaseNotesSubCmd.Flags().StringVarP(&dashboardPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	dashboardGenerateReleaseNotesSubCmd.Flags().StringVarP(&dashboardMilestone, "milestone", "m", "", "Milestone")
+	if err := dashboardGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := dashboardGenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -148,11 +148,13 @@ var rancherTagSubCmd = &cobra.Command{
 		if len(args) < 2 {
 			return errors.New("expected at least two arguments: [ga,rc,debug,alpha] [version]")
 		}
+
 		releaseType := args[0]
 		preRelease, err := releaseTypePreRelease(releaseType)
 		if err != nil {
 			return err
 		}
+
 		tag := args[1]
 		rancherRelease, found := rootConfig.Rancher.Versions[tag]
 		if !found {
@@ -213,15 +215,18 @@ var uiTagSubCmd = &cobra.Command{
 		if len(args) < 2 {
 			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
+
 		rc, err := releaseTypePreRelease(args[0])
 		if err != nil {
 			return err
 		}
+
 		tag := args[1]
 		uiRelease, found := rootConfig.UI.Versions[tag]
 		if !found {
 			return errors.New("verify your config file, version not found: " + tag)
 		}
+
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 		opts := &repository.CreateReleaseOpts{
@@ -230,6 +235,7 @@ var uiTagSubCmd = &cobra.Command{
 			Owner:  uiRelease.UIRepoOwner,
 			Branch: uiRelease.ReleaseBranch,
 		}
+
 		return ui.CreateRelease(ctx, ghClient, &uiRelease, opts, rc)
 	},
 }
@@ -241,15 +247,18 @@ var dashboardTagSubCmd = &cobra.Command{
 		if len(args) < 2 {
 			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
+
 		rc, err := releaseTypePreRelease(args[0])
 		if err != nil {
 			return err
 		}
+
 		tag := args[1]
 		dashboardRelease, found := rootConfig.Dashboard.Versions[tag]
 		if !found {
 			return errors.New("verify your config file, version not found: " + tag)
 		}
+
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 		opts := &repository.CreateReleaseOpts{
@@ -258,6 +267,7 @@ var dashboardTagSubCmd = &cobra.Command{
 			Owner:  dashboardRelease.DashboardRepoOwner,
 			Branch: dashboardRelease.ReleaseBranch,
 		}
+
 		return dashboard.CreateRelease(ctx, ghClient, &dashboardRelease, opts, rc)
 	},
 }

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
 	"github.com/rancher/ecm-distro-tools/release/dashboard"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
@@ -210,45 +209,6 @@ var systemAgentInstallerK3sTagSubCmd = &cobra.Command{
 	},
 }
 
-var uiTagSubCmd = &cobra.Command{
-	Use:   "ui [ga,rc] [version]",
-	Short: "Tag ui releases",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
-			return errors.New("expected at least two arguments: [ga,rc] [version]")
-		}
-
-		releaseType := args[0]
-
-		rc, err := releaseTypePreRelease(releaseType)
-		if err != nil {
-			return err
-		}
-
-		tag := args[1]
-		_, err = semver.NewVersion(tag)
-		if err != nil {
-			return err
-		}
-
-		uiRelease, found := rootConfig.UI.Versions[tag]
-		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
-		}
-
-		ctx := context.Background()
-		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
-		opts := &repository.CreateReleaseOpts{
-			Tag:    tag,
-			Repo:   "ui",
-			Owner:  uiRelease.UIRepoOwner,
-			Branch: uiRelease.ReleaseBranch,
-		}
-
-		return ui.CreateRelease(ctx, ghClient, &uiRelease, opts, rc, releaseType)
-	},
-}
-
 var dashboardTagSubCmd = &cobra.Command{
 	Use:   "dashboard [ga,rc, alpha] [version]",
 	Short: "Tag dashboard releases",
@@ -305,7 +265,6 @@ func init() {
 	tagCmd.AddCommand(rke2TagSubCmd)
 	tagCmd.AddCommand(rancherTagSubCmd)
 	tagCmd.AddCommand(systemAgentInstallerK3sTagSubCmd)
-	tagCmd.AddCommand(uiTagSubCmd)
 	tagCmd.AddCommand(dashboardTagSubCmd)
 
 	// rke2

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/ecm-distro-tools/release/dashboard"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
@@ -222,6 +223,11 @@ var uiTagSubCmd = &cobra.Command{
 		}
 
 		tag := args[1]
+		_, err = semver.NewVersion(tag)
+		if err != nil {
+			return err
+		}
+
 		uiRelease, found := rootConfig.UI.Versions[tag]
 		if !found {
 			return errors.New("verify your config file, version not found: " + tag)
@@ -241,14 +247,16 @@ var uiTagSubCmd = &cobra.Command{
 }
 
 var dashboardTagSubCmd = &cobra.Command{
-	Use:   "dashboard [ga,rc] [version]",
+	Use:   "dashboard [ga,rc, alpha] [version]",
 	Short: "Tag dashboard releases",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
 
-		rc, err := releaseTypePreRelease(args[0])
+		releaseType := args[0]
+
+		rc, err := releaseTypePreRelease(releaseType)
 		if err != nil {
 			return err
 		}
@@ -268,7 +276,7 @@ var dashboardTagSubCmd = &cobra.Command{
 			Branch: dashboardRelease.ReleaseBranch,
 		}
 
-		return dashboard.CreateRelease(ctx, ghClient, &dashboardRelease, opts, rc)
+		return dashboard.CreateRelease(ctx, ghClient, &dashboardRelease, opts, rc, releaseType)
 	},
 }
 

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -210,11 +210,11 @@ var systemAgentInstallerK3sTagSubCmd = &cobra.Command{
 }
 
 var dashboardTagSubCmd = &cobra.Command{
-	Use:   "dashboard [ga,rc, alpha] [version]",
+	Use:   "dashboard [ga,rc,alpha] [version]",
 	Short: "Tag dashboard releases",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return errors.New("expected at least two arguments: [ga,rc] [version]")
+			return errors.New("expected at least two arguments: [ga,rc,alpha] [version]")
 		}
 
 		version := args[1]

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -217,7 +217,9 @@ var uiTagSubCmd = &cobra.Command{
 			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
 
-		rc, err := releaseTypePreRelease(args[0])
+		releaseType := args[0]
+
+		rc, err := releaseTypePreRelease(releaseType)
 		if err != nil {
 			return err
 		}
@@ -242,7 +244,7 @@ var uiTagSubCmd = &cobra.Command{
 			Branch: uiRelease.ReleaseBranch,
 		}
 
-		return ui.CreateRelease(ctx, ghClient, &uiRelease, opts, rc)
+		return ui.CreateRelease(ctx, ghClient, &uiRelease, opts, rc, releaseType)
 	},
 }
 

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -155,6 +155,7 @@ var updateRancherDashboardCmd = &cobra.Command{
 		}
 
 		versionTrimmed, _, _ := strings.Cut(version, "-rc")
+		versionTrimmed, _, _ = strings.Cut(versionTrimmed, "-alpha")
 
 		dashboardRelease, found := rootConfig.Dashboard.Versions[versionTrimmed]
 		if !found {

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rancher/ecm-distro-tools/release/charts"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
+	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"github.com/spf13/cobra"
 )
@@ -130,11 +132,44 @@ var updateChartsCmd = &cobra.Command{
 	},
 }
 
+var updateRancherCmd = &cobra.Command{
+	Use:   "rancher",
+	Short: "Update rancher files",
+}
+
+var updateRancherDashboardCmd = &cobra.Command{
+	Use:   "dashboard [version]",
+	Short: "Update Rancher's Dashboard and UI references and create a PR",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("expected at least one argument: [version]")
+		}
+
+		version := args[0]
+		versionTrimmed, _, _ := strings.Cut(version, "-rc")
+
+		dashboardRelease, found := rootConfig.Dashboard.Versions[versionTrimmed]
+		if !found {
+			return errors.New("verify your config file, version not found: " + version)
+		}
+
+		dashboardRelease.Tag = version
+
+		ctx := context.Background()
+
+		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		return rancher.UpdateDashboardReferences(ctx, ghClient, &dashboardRelease, rootConfig.User)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(updateCmd)
 	updateCmd.AddCommand(updateChartsCmd)
 	updateCmd.AddCommand(updateK3sCmd)
 	updateK3sCmd.AddCommand(updateK3sReferencesCmd)
+	updateCmd.AddCommand(updateRancherCmd)
+	updateRancherCmd.AddCommand(updateRancherDashboardCmd)
 }
 
 func validateChartConfig() error {

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/ecm-distro-tools/release/charts"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
@@ -146,6 +147,13 @@ var updateRancherDashboardCmd = &cobra.Command{
 		}
 
 		version := args[0]
+
+		// checking if the provided version is valid
+		_, err := semver.NewVersion(version)
+		if err != nil {
+			return err
+		}
+
 		versionTrimmed, _, _ := strings.Cut(version, "-rc")
 
 		dashboardRelease, found := rootConfig.Dashboard.Versions[versionTrimmed]

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -141,11 +141,13 @@ var updateRancherCmd = &cobra.Command{
 var updateRancherDashboardCmd = &cobra.Command{
 	Use:   "dashboard [version]",
 	Short: "Update Rancher's Dashboard and UI references and create a PR",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("expected at least one argument: [version]")
 		}
-
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		version := args[0]
 
 		// checking if the provided version is valid

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -168,7 +168,7 @@ var updateRancherDashboardCmd = &cobra.Command{
 
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		return rancher.UpdateDashboardReferences(ctx, ghClient, &dashboardRelease, rootConfig.User)
+		return rancher.UpdateDashboardReferences(ctx, rootConfig.Dashboard, ghClient, &dashboardRelease, rootConfig.User)
 	},
 }
 

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -56,6 +56,7 @@ type DashboardRelease struct {
 	ReleaseBranch        string `json:"release_branch" validate:"required"`
 	Tag                  string
 	RancherUpstreamURL   string `json:"rancher_upstream_url" validate:"required"`
+	RancherUpstreamRepo  string `json:"rancher_upstream_repo" validate:"required"`
 	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
 	DryRun               bool   `json:"dry_run"`
 }

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -216,10 +216,11 @@ func ExampleConfig() (string, error) {
 			RancherUpstreamURL: "git@github.com:rancher/rancher.git",
 			Versions: map[string]DashboardRelease{
 				"v2.x.y": {
-					PreviousTag:     "v2.x.y",
-					UIPreviousTag:   "v2.x.y",
-					ReleaseBranch:   "release-v2.x",
-					UIReleaseBranch: "release-v2.x",
+					PreviousTag:          "v2.x.y",
+					UIPreviousTag:        "v2.x.y",
+					ReleaseBranch:        "release-v2.x",
+					UIReleaseBranch:      "release-v2.x",
+					RancherReleaseBranch: "release/v2.x",
 				},
 			},
 		},

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -89,11 +89,6 @@ type Rancher struct {
 	Versions map[string]RancherRelease `json:"versions" validate:"dive,omitempty"`
 }
 
-// UI
-type UI struct {
-	Versions map[string]UIRelease `json:"versions" validate:"dive"`
-}
-
 // Dashboard
 type Dashboard struct {
 	Versions           map[string]DashboardRelease `json:"versions" validate:"dive"`
@@ -124,7 +119,6 @@ type Config struct {
 	RKE2      *RKE2          `json:"rke2" validate:"omitempty"`
 	Charts    *ChartsRelease `json:"charts" validate:"omitempty"`
 	Auth      *Auth          `json:"auth"`
-	UI        *UI            `json:"ui"`
 	Dashboard *Dashboard     `json:"dashboard"`
 }
 

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -41,6 +41,22 @@ type RancherRelease struct {
 	SkipStatusCheck      bool   `json:"skip_status_check"`
 }
 
+type UIRelease struct {
+	UIRepoOwner   string `json:"ui_repo_owner" validate:"required"`
+	UIRepoName    string `json:"ui_repo_name"`
+	PreviousTag   string `json:"previous_tag"`
+	ReleaseBranch string `json:"release_branch" validate:"required"`
+	DryRun        bool   `json:"dry_run"`
+}
+
+type DashboardRelease struct {
+	DashboardRepoOwner string `json:"dashboard_repo_owner" validate:"required"`
+	DashboardRepoName  string `json:"dashboard_repo_name"`
+	PreviousTag        string `json:"previous_tag"`
+	ReleaseBranch      string `json:"release_branch" validate:"required"`
+	DryRun             bool   `json:"dry_run"`
+}
+
 // RKE2
 type RKE2 struct {
 	Versions []string `json:"versions"`
@@ -70,6 +86,16 @@ type Rancher struct {
 	Versions map[string]RancherRelease `json:"versions" validate:"dive,omitempty"`
 }
 
+// UI
+type UI struct {
+	Versions map[string]UIRelease `json:"versions" validate:"dive"`
+}
+
+// Dashboard
+type Dashboard struct {
+	Versions map[string]DashboardRelease `json:"versions" validate:"dive"`
+}
+
 // Auth
 type Auth struct {
 	GithubToken        string `json:"github_token"`
@@ -82,12 +108,14 @@ type Auth struct {
 
 // Config
 type Config struct {
-	User    *User          `json:"user"`
-	K3s     *K3s           `json:"k3s" validate:"omitempty"`
-	Rancher *Rancher       `json:"rancher" validate:"omitempty"`
-	RKE2    *RKE2          `json:"rke2" validate:"omitempty"`
-	Charts  *ChartsRelease `json:"charts" validate:"omitempty"`
-	Auth    *Auth          `json:"auth"`
+	User      *User          `json:"user"`
+	K3s       *K3s           `json:"k3s" validate:"omitempty"`
+	Rancher   *Rancher       `json:"rancher" validate:"omitempty"`
+	RKE2      *RKE2          `json:"rke2" validate:"omitempty"`
+	Charts    *ChartsRelease `json:"charts" validate:"omitempty"`
+	Auth      *Auth          `json:"auth"`
+	UI        *UI            `json:"ui"`
+	Dashboard *Dashboard     `json:"dashboard"`
 }
 
 // OpenOnEditor opens the given config file on the user's default text editor.

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -50,11 +50,14 @@ type UIRelease struct {
 }
 
 type DashboardRelease struct {
-	DashboardRepoOwner string `json:"dashboard_repo_owner" validate:"required"`
-	DashboardRepoName  string `json:"dashboard_repo_name"`
-	PreviousTag        string `json:"previous_tag"`
-	ReleaseBranch      string `json:"release_branch" validate:"required"`
-	DryRun             bool   `json:"dry_run"`
+	DashboardRepoOwner   string `json:"dashboard_repo_owner" validate:"required"`
+	DashboardRepoName    string `json:"dashboard_repo_name"`
+	PreviousTag          string `json:"previous_tag"`
+	ReleaseBranch        string `json:"release_branch" validate:"required"`
+	Tag                  string
+	RancherUpstreamURL   string `json:"rancher_upstream_url" validate:"required"`
+	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
+	DryRun               bool   `json:"dry_run"`
 }
 
 // RKE2

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -206,6 +206,23 @@ func ExampleConfig() (string, error) {
 				},
 			},
 		},
+		Dashboard: &Dashboard{
+			RepoName:           "dashboard",
+			RepoOwner:          "rancher",
+			UIRepoName:         "ui",
+			UIRepoOwner:        "rancher",
+			RancherRepoName:    "rancher",
+			RancherRepoOwner:   "rancher",
+			RancherUpstreamURL: "git@github.com:rancher/rancher.git",
+			Versions: map[string]DashboardRelease{
+				"v2.x.y": {
+					PreviousTag:     "v2.x.y",
+					UIPreviousTag:   "v2.x.y",
+					ReleaseBranch:   "release-v2.x",
+					UIReleaseBranch: "release-v2.x",
+				},
+			},
+		},
 		Charts: &ChartsRelease{
 			Workspace:     filepath.Join(gopath, "src", "github.com", "rancher", "charts") + "/",
 			ChartsRepoURL: "https://github.com/rancher/charts",

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -50,13 +50,11 @@ type UIRelease struct {
 }
 
 type DashboardRelease struct {
-	DashboardRepoOwner   string `json:"dashboard_repo_owner" validate:"required"`
-	DashboardRepoName    string `json:"dashboard_repo_name"`
-	PreviousTag          string `json:"previous_tag"`
+	PreviousTag          string `json:"previous_tag" validate:"required"`
 	ReleaseBranch        string `json:"release_branch" validate:"required"`
+	UIReleaseBranch      string `json:"ui_release_branch" validate:"required"`
+	UIPreviousTag        string `json:"ui_previous_tag" validate:"required"`
 	Tag                  string
-	RancherUpstreamURL   string `json:"rancher_upstream_url" validate:"required"`
-	RancherUpstreamRepo  string `json:"rancher_upstream_repo" validate:"required"`
 	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
 	DryRun               bool   `json:"dry_run"`
 }
@@ -97,7 +95,14 @@ type UI struct {
 
 // Dashboard
 type Dashboard struct {
-	Versions map[string]DashboardRelease `json:"versions" validate:"dive"`
+	Versions           map[string]DashboardRelease `json:"versions" validate:"dive"`
+	RepoOwner          string                      `json:"repo_owner" validate:"required"`
+	RepoName           string                      `json:"repo_name" validate:"required"`
+	UIRepoOwner        string                      `json:"ui_repo_owner" validate:"required"`
+	UIRepoName         string                      `json:"ui_repo_name" validate:"required"`
+	RancherRepoOwner   string                      `json:"rancher_repo_owner" validate:"required"`
+	RancherRepoName    string                      `json:"rancher_repo_name" validate:"required"`
+	RancherUpstreamURL string                      `json:"rancher_upstream_url" validate:"required"`
 }
 
 // Auth

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -56,7 +56,8 @@ type DashboardRelease struct {
 	UIPreviousTag        string `json:"ui_previous_tag" validate:"required"`
 	Tag                  string
 	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
-	DryRun               bool   `json:"dry_run"`
+	RancherUpstreamURL   string
+	DryRun               bool `json:"dry_run"`
 }
 
 // RKE2

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -20,7 +20,7 @@ const (
 	dashboardImagesBaseURL = "https://github.com/" + dashboardOrg + "/" + dashboardRepo + "/releases"
 )
 
-func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.DashboardRelease, opts *repository.CreateReleaseOpts, rc bool) error {
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.DashboardRelease, opts *repository.CreateReleaseOpts, rc bool, releaseType string) error {
 	fmt.Println("validating tag")
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
@@ -53,7 +53,7 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.Dash
 			latestRC = new(string)
 			*latestRC = opts.Tag + "-rc1"
 		}
-		opts.Tag = fmt.Sprintf("%s-rc%d", opts.Tag, latestRCNumber)
+		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}
 
 	opts.Name = opts.Tag

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -28,18 +28,18 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.Dash
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
 
-	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
+	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
 	if err != nil {
 		return err
 	}
 
 	if rc {
 		latestRCNumber := 1
-		if latestRC != nil {
-			// v2.9.0-rcN
-			_, trimmedRCNumber, found := strings.Cut(*latestRC, "-rc")
+		if latestPreRelease != nil {
+			// v2.9.0-rcN / -alphaN
+			_, trimmedRCNumber, found := strings.Cut(*latestPreRelease, "-"+releaseType)
 			if !found {
-				return errors.New("failed to parse rc number from " + *latestRC)
+				return errors.New("failed to parse rc number from " + *latestPreRelease)
 			}
 			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
 			if err != nil {
@@ -48,8 +48,8 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.Dash
 			latestRCNumber = currentRCNumber + 1
 		} else {
 			// this means it would be the first RC tag
-			latestRC = new(string)
-			*latestRC = opts.Tag + "-rc1"
+			latestPreRelease = new(string)
+			*latestPreRelease = opts.Tag + "-rc1"
 		}
 		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -26,10 +26,6 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.Dash
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
 
-	if r.DashboardRepoName != "" {
-		opts.Repo = r.DashboardRepoName
-	}
-
 	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
 	if err != nil {
 		return err

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -46,10 +46,6 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.Dash
 				return err
 			}
 			latestRCNumber = currentRCNumber + 1
-		} else {
-			// this means it would be the first RC tag
-			latestPreRelease = new(string)
-			*latestPreRelease = opts.Tag + "-rc1"
 		}
 		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v39/github"
+	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/rancher/ecm-distro-tools/release"
+	"github.com/rancher/ecm-distro-tools/repository"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	dashboardOrg           = "rancher"
+	dashboardRepo          = "dashboard"
+	dashboardImagesBaseURL = "https://github.com/" + dashboardOrg + "/" + dashboardRepo + "/releases"
+)
+
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.DashboardRelease, opts *repository.CreateReleaseOpts, rc bool) error {
+	fmt.Println("validating tag")
+	if !semver.IsValid(opts.Tag) {
+		return errors.New("tag isn't a valid semver: " + opts.Tag)
+	}
+
+	if r.DashboardRepoName != "" {
+		opts.Repo = r.DashboardRepoName
+	}
+
+	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
+	if err != nil {
+		return err
+	}
+
+	if rc {
+		latestRCNumber := 1
+		if latestRC != nil {
+			// v2.9.0-rcN
+			_, trimmedRCNumber, found := strings.Cut(*latestRC, "-rc")
+			if !found {
+				return errors.New("failed to parse rc number from " + *latestRC)
+			}
+			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
+			if err != nil {
+				return err
+			}
+			latestRCNumber = currentRCNumber + 1
+		} else {
+			// this means it would be the first RC tag
+			latestRC = new(string)
+			*latestRC = opts.Tag + "-rc1"
+		}
+		opts.Tag = fmt.Sprintf("%s-rc%d", opts.Tag, latestRCNumber)
+	}
+
+	opts.Name = opts.Tag
+	opts.Prerelease = true
+	opts.Draft = !rc
+	opts.ReleaseNotes = ""
+
+	if !rc {
+		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, r.PreviousTag)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, r.PreviousTag, client)
+		if err != nil {
+			return err
+		}
+		opts.ReleaseNotes = buff.String()
+	}
+
+	fmt.Printf("create release options: %+v\n", *opts)
+
+	if r.DryRun {
+		fmt.Println("dry run, skipping creating release")
+		return nil
+	}
+
+	createdRelease, err := repository.CreateRelease(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("release created: " + *createdRelease.HTMLURL)
+	return nil
+}

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -17,11 +17,13 @@ import (
 const (
 	dashboardOrg           = "rancher"
 	dashboardRepo          = "dashboard"
+	uiOrg                  = "rancher"
+	uiRepo                 = "ui"
 	dashboardImagesBaseURL = "https://github.com/" + dashboardOrg + "/" + dashboardRepo + "/releases"
 )
 
+// CreateRelease will create a new tag and a new release with given params.
 func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.DashboardRelease, opts *repository.CreateReleaseOpts, rc bool, releaseType string) error {
-	fmt.Println("validating tag")
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -205,6 +205,8 @@ func GeneratePrimeArtifactsIndex(ctx context.Context, path string, ignoreVersion
 }
 
 func UpdateDashboardReferences(ctx context.Context, cfg *config.Dashboard, ghClient *github.Client, r *config.DashboardRelease, u *config.User) error {
+	r.RancherUpstreamURL = cfg.RancherUpstreamURL
+
 	if err := updateDashboardReferencesAndPush(r, u); err != nil {
 		return err
 	}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -227,13 +227,13 @@ func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, _ *ecmConfi
 func createDashboardReferencesPR(ctx context.Context, ghClient *github.Client, r *ecmConfig.DashboardRelease, u *ecmConfig.User) error {
 	pull := &github.NewPullRequest{
 		Title:               github.String(fmt.Sprintf("Bump Dashboard to `%s`", r.Tag)),
-		Base:                github.String(r.ReleaseBranch),
+		Base:                github.String(r.RancherReleaseBranch),
 		Head:                github.String(u.GithubUsername + ":update-build-refs-" + r.Tag),
 		MaintainerCanModify: github.Bool(true),
 	}
 
 	// creating a pr from your fork branch
-	_, _, err := ghClient.PullRequests.Create(ctx, r.DashboardRepoOwner, r.DashboardRepoName, pull)
+	_, _, err := ghClient.PullRequests.Create(ctx, r.DashboardRepoOwner, r.RancherUpstreamRepo, pull)
 
 	return err
 }
@@ -1053,4 +1053,7 @@ git commit --signoff -m "Update to Dashboard refs to ${VERSION}"
 # Push the changes if not a dry run
 if [ "${DRY_RUN}" = false ]; then
 	git push --set-upstream origin "${BRANCH_NAME}" # run git remote -v for your origin
-fi`
+fi
+
+# Cleaning temp files/scripts
+git clean -f`

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -204,12 +204,12 @@ func GeneratePrimeArtifactsIndex(ctx context.Context, path string, ignoreVersion
 	return os.WriteFile(filepath.Join(path, "index-prerelease.html"), preReleaseIndex, 0644)
 }
 
-func UpdateDashboardReferences(ctx context.Context, ghClient *github.Client, r *config.DashboardRelease, u *config.User) error {
+func UpdateDashboardReferences(ctx context.Context, cfg *config.Dashboard, ghClient *github.Client, r *config.DashboardRelease, u *config.User) error {
 	if err := updateDashboardReferencesAndPush(r, u); err != nil {
 		return err
 	}
 
-	return createDashboardReferencesPR(ctx, ghClient, r, u)
+	return createDashboardReferencesPR(ctx, cfg, ghClient, r, u)
 }
 
 func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, _ *ecmConfig.User) error {
@@ -224,7 +224,7 @@ func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, _ *ecmConfi
 	return nil
 }
 
-func createDashboardReferencesPR(ctx context.Context, ghClient *github.Client, r *ecmConfig.DashboardRelease, u *ecmConfig.User) error {
+func createDashboardReferencesPR(ctx context.Context, cfg *config.Dashboard, ghClient *github.Client, r *ecmConfig.DashboardRelease, u *ecmConfig.User) error {
 	pull := &github.NewPullRequest{
 		Title:               github.String(fmt.Sprintf("Bump Dashboard to `%s`", r.Tag)),
 		Base:                github.String(r.RancherReleaseBranch),
@@ -233,7 +233,7 @@ func createDashboardReferencesPR(ctx context.Context, ghClient *github.Client, r
 	}
 
 	// creating a pr from your fork branch
-	_, _, err := ghClient.PullRequests.Create(ctx, r.DashboardRepoOwner, r.RancherUpstreamRepo, pull)
+	_, _, err := ghClient.PullRequests.Create(ctx, cfg.RancherRepoOwner, cfg.RancherRepoName, pull)
 
 	return err
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -209,20 +209,15 @@ func UpdateDashboardReferences(ctx context.Context, ghClient *github.Client, r *
 		return err
 	}
 
-	if r.DryRun {
-		fmt.Println("dry run, skipping creating PR")
-		return nil
-	}
 	return createDashboardReferencesPR(ctx, ghClient, r, u)
 }
 
-func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, u *ecmConfig.User) error {
+func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, _ *ecmConfig.User) error {
 	fmt.Println("verifying if workspace dir exists")
 	funcMap := template.FuncMap{"replaceAll": strings.ReplaceAll}
 	fmt.Println("creating update dashboard references script template")
 	updateScriptOut, err := ecmExec.RunTemplatedScript("./", "replase_dash_ref.sh", updateDashboardReferencesScript, funcMap, r)
 	if err != nil {
-		fmt.Println("AAAAAAA")
 		return err
 	}
 	fmt.Println(updateScriptOut)
@@ -230,8 +225,6 @@ func updateDashboardReferencesAndPush(r *ecmConfig.DashboardRelease, u *ecmConfi
 }
 
 func createDashboardReferencesPR(ctx context.Context, ghClient *github.Client, r *ecmConfig.DashboardRelease, u *ecmConfig.User) error {
-	const repo = "rancher"
-
 	pull := &github.NewPullRequest{
 		Title:               github.String(fmt.Sprintf("Bump Dashboard to `%s`", r.Tag)),
 		Base:                github.String(r.ReleaseBranch),

--- a/release/release.go
+++ b/release/release.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -346,7 +347,8 @@ func genRKE2ReleaseNotes(tmpl *template.Template, milestone string, rd rke2Relea
 }
 
 func genUIReleaseNotes(tmpl *template.Template, _ string, rd uiReleaseNoteData) (*bytes.Buffer, error) {
-	tmpl = template.Must(tmpl.Parse(uiReleaseNoteTemplate))
+	uiTemplate := fmt.Sprintf(dashboardReleaseNoteTemplate, "ui")
+	tmpl = template.Must(tmpl.Parse(uiTemplate))
 	b := bytes.NewBuffer(nil)
 	if err := tmpl.ExecuteTemplate(b, uiRepo, rd); err != nil {
 		return nil, err
@@ -355,7 +357,8 @@ func genUIReleaseNotes(tmpl *template.Template, _ string, rd uiReleaseNoteData) 
 }
 
 func genDashboardReleaseNotes(tmpl *template.Template, _ string, rd dashboardReleaseNoteData) (*bytes.Buffer, error) {
-	tmpl = template.Must(tmpl.Parse(dashboardReleaseNoteTemplate))
+	dashboardTemplate := fmt.Sprintf(dashboardReleaseNoteTemplate, "dashboard")
+	tmpl = template.Must(tmpl.Parse(dashboardTemplate))
 	b := bytes.NewBuffer(nil)
 	if err := tmpl.ExecuteTemplate(b, dashboardRepo, rd); err != nil {
 		return nil, err
@@ -914,15 +917,8 @@ As always, we welcome and appreciate feedback from our community of users. Pleas
 - [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
 {{ end }}`
 
-const uiReleaseNoteTemplate = `
-{{- define "ui" -}}
-<!-- {{.Milestone}} -->
-
-{{ template "changelog" . }}
-{{ end }}`
-
 const dashboardReleaseNoteTemplate = `
-{{- define "dashboard" -}}
+{{- define "%s" -}}
 <!-- {{.Milestone}} -->
 
 {{ template "changelog" . }}

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -26,10 +26,6 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRe
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
 
-	if r.UIRepoName != "" {
-		opts.Repo = r.UIRepoName
-	}
-
 	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
 	if err != nil {
 		return err

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -20,8 +20,8 @@ const (
 	uiImagesBaseURL = "https://github.com/" + uiOrg + "/" + uiRepo + "/releases"
 )
 
+// CreateRelease will create a new tag and a new release with given params.
 func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRelease, opts *repository.CreateReleaseOpts, rc bool, releaseType string) error {
-	fmt.Println("validating tag")
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -44,10 +44,6 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRe
 				return err
 			}
 			latestRCNumber = currentRCNumber + 1
-		} else {
-			// this means it would be the first RC tag
-			latestPreRelease = new(string)
-			*latestPreRelease = opts.Tag + "-rc1"
 		}
 		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -20,7 +20,7 @@ const (
 	uiImagesBaseURL = "https://github.com/" + uiOrg + "/" + uiRepo + "/releases"
 )
 
-func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRelease, opts *repository.CreateReleaseOpts, rc bool) error {
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRelease, opts *repository.CreateReleaseOpts, rc bool, releaseType string) error {
 	fmt.Println("validating tag")
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
@@ -53,7 +53,7 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRe
 			latestRC = new(string)
 			*latestRC = opts.Tag + "-rc1"
 		}
-		opts.Tag = fmt.Sprintf("%s-rc%d", opts.Tag, latestRCNumber)
+		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}
 
 	opts.Name = opts.Tag

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v39/github"
+	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/rancher/ecm-distro-tools/release"
+	"github.com/rancher/ecm-distro-tools/repository"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	uiOrg           = "rancher"
+	uiRepo          = "ui"
+	uiImagesBaseURL = "https://github.com/" + uiOrg + "/" + uiRepo + "/releases"
+)
+
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRelease, opts *repository.CreateReleaseOpts, rc bool) error {
+	fmt.Println("validating tag")
+	if !semver.IsValid(opts.Tag) {
+		return errors.New("tag isn't a valid semver: " + opts.Tag)
+	}
+
+	if r.UIRepoName != "" {
+		opts.Repo = r.UIRepoName
+	}
+
+	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
+	if err != nil {
+		return err
+	}
+
+	if rc {
+		latestRCNumber := 1
+		if latestRC != nil {
+			// v2.9.0-rcN
+			_, trimmedRCNumber, found := strings.Cut(*latestRC, "-rc")
+			if !found {
+				return errors.New("failed to parse rc number from " + *latestRC)
+			}
+			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
+			if err != nil {
+				return err
+			}
+			latestRCNumber = currentRCNumber + 1
+		} else {
+			// this means it would be the first RC tag
+			latestRC = new(string)
+			*latestRC = opts.Tag + "-rc1"
+		}
+		opts.Tag = fmt.Sprintf("%s-rc%d", opts.Tag, latestRCNumber)
+	}
+
+	opts.Name = opts.Tag
+	opts.Prerelease = true
+	opts.Draft = !rc
+	opts.ReleaseNotes = ""
+
+	if !rc {
+		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, r.PreviousTag)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, r.PreviousTag, client)
+		if err != nil {
+			return err
+		}
+		opts.ReleaseNotes = buff.String()
+	}
+
+	fmt.Printf("create release options: %+v\n", *opts)
+
+	if r.DryRun {
+		fmt.Println("dry run, skipping creating release")
+		return nil
+	}
+
+	createdRelease, err := repository.CreateRelease(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("release created: " + *createdRelease.HTMLURL)
+	return nil
+}

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -26,18 +26,18 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRe
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
 
-	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, opts.Tag, opts.Tag, client)
+	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
 	if err != nil {
 		return err
 	}
 
 	if rc {
 		latestRCNumber := 1
-		if latestRC != nil {
-			// v2.9.0-rcN
-			_, trimmedRCNumber, found := strings.Cut(*latestRC, "-rc")
+		if latestPreRelease != nil {
+			// v2.9.0-rcN / -alphaN
+			_, trimmedRCNumber, found := strings.Cut(*latestPreRelease, "-"+releaseType)
 			if !found {
-				return errors.New("failed to parse rc number from " + *latestRC)
+				return errors.New("failed to parse rc number from " + *latestPreRelease)
 			}
 			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
 			if err != nil {
@@ -46,8 +46,8 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.UIRe
 			latestRCNumber = currentRCNumber + 1
 		} else {
 			// this means it would be the first RC tag
-			latestRC = new(string)
-			*latestRC = opts.Tag + "-rc1"
+			latestPreRelease = new(string)
+			*latestPreRelease = opts.Tag + "-rc1"
 		}
 		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
 	}


### PR DESCRIPTION
## Commands added

### `$ release [repo] release-notes ` 
Added support for `repo`:
- `ui`
- `dashboard`

Command examples: 
- `$ release generate ui release-notes --milestone v2.9.1 --prev-milestone v2.9.0`
- `$ release generate dashboard release-notes --milestone v2.9.1 --prev-milestone v2.9.0`

This command will generate and output the release notes, based on two milestones.

----------

### `$ release [repo] [ga,ra] [version]` 
Added support for `repo`:
- `ui`
- `dashboard`

- `$ release tag dashboard rc v2.9.1` tags https://github.com/rafaelbreno/rancher-dashboard/releases/tag/v2.9.1-rc1
- `$ release tag dashboard ga v2.9.1` tags https://github.com/rafaelbreno/rancher-dashboard/releases/tag/v2.9.0

----------

### `$ release update rancher dashboard [version]`
This command is ran in the `rancher/rancher` fork clone, where it will run a script that updates the two necessary fields, and opens a PR against `rancher/rancher`.

Command examples:
- `$ release update rancher dashboard v2.9.1-rc8` opens https://github.com/rancher/rancher/pull/46947
