### PR TITLE
add the generate release announcement message command

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -189,7 +189,7 @@ var rancherGenerateReleaseMessageSubCmd = &cobra.Command{
 
 		rancherRelease, found := rootConfig.Rancher.Versions[versionKey]
 		if !found {
-			return errors.New("verify your config file, version not found: " + rancherReleaseAnnouncementTag)
+			return errors.New("verify your config file, version not found: " + versionKey)
 		}
 
 		ctx := context.Background()
@@ -199,7 +199,7 @@ var rancherGenerateReleaseMessageSubCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Print(message)
+		fmt.Println(message)
 		return nil
 	},
 }
@@ -298,7 +298,7 @@ func init() {
 	rancherGenerateReleaseMessageSubCmd.Flags().StringVarP(&rancherReleaseAnnouncementTag, "tag", "t", "", "Tag that will be announced")
 	rancherGenerateReleaseMessageSubCmd.Flags().StringVarP(&rancherReleaseAnnouncementPreviousTag, "previous-tag", "p", "", "Last tag before the current one")
 	rancherGenerateReleaseMessageSubCmd.Flags().StringVarP(&rancherReleaseAnnouncementActionRunID, "action-run-id", "a", "", "Run ID for the latest push-release.yml action")
-	rancherGenerateReleaseMessageSubCmd.Flags().BoolVarP(&rancherReleaseAnnouncementPrimeOnly, "prime-only", "p", false, "Version is prime-only and the artifacts are at prime.ribs.rancher.io")
+	rancherGenerateReleaseMessageSubCmd.Flags().BoolVarP(&rancherReleaseAnnouncementPrimeOnly, "prime-only", "o", false, "Version is prime-only and the artifacts are at prime.ribs.rancher.io")
 	if err := rancherGenerateReleaseMessageSubCmd.MarkFlagRequired("tag"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -43,6 +43,7 @@ var (
 	rancherReleaseAnnouncementPreviousTag string
 	rancherReleaseAnnouncementActionRunID string
 	rancherReleaseAnnouncementPrimeOnly   bool
+	rancherReleaseAnnouncementFinalRC     bool
 )
 
 // generateCmd represents the generate command
@@ -195,7 +196,7 @@ var rancherGenerateReleaseMessageSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		message, err := rancher.GenerateAnnounceReleaseMessage(ctx, client, rancherReleaseAnnouncementTag, rancherReleaseAnnouncementPreviousTag, rancherRelease.RancherRepoOwner, rancherReleaseAnnouncementActionRunID, rancherReleaseAnnouncementPrimeOnly)
+		message, err := rancher.GenerateAnnounceReleaseMessage(ctx, client, rancherReleaseAnnouncementTag, rancherReleaseAnnouncementPreviousTag, rancherRelease.RancherRepoOwner, rancherReleaseAnnouncementActionRunID, rancherReleaseAnnouncementPrimeOnly, rancherReleaseAnnouncementFinalRC)
 		if err != nil {
 			return err
 		}
@@ -299,6 +300,7 @@ func init() {
 	rancherGenerateReleaseMessageSubCmd.Flags().StringVarP(&rancherReleaseAnnouncementPreviousTag, "previous-tag", "p", "", "Last tag before the current one")
 	rancherGenerateReleaseMessageSubCmd.Flags().StringVarP(&rancherReleaseAnnouncementActionRunID, "action-run-id", "a", "", "Run ID for the latest push-release.yml action")
 	rancherGenerateReleaseMessageSubCmd.Flags().BoolVarP(&rancherReleaseAnnouncementPrimeOnly, "prime-only", "o", false, "Version is prime-only and the artifacts are at prime.ribs.rancher.io")
+	rancherGenerateReleaseMessageSubCmd.Flags().BoolVarP(&rancherReleaseAnnouncementFinalRC, "final-rc", "f", false, "Version is the final RC, the announce message won't contain images or components with RC")
 	if err := rancherGenerateReleaseMessageSubCmd.MarkFlagRequired("tag"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -727,7 +727,7 @@ func GenerateAnnounceReleaseMessage(ctx context.Context, ghClient *github.Client
 	return buff.String(), nil
 }
 
-// rancherUICLIVersions scans a dockerfile line by line and retruns the ui and cli versions, or an error if any of them are not found
+// rancherUICLIVersions scans a dockerfile line by line and returns the ui and cli versions, or an error if any of them are not found
 func rancherUICLIVersions(dockerfile []string) (string, string, error) {
 	var uiVersion string
 	var cliVersion string

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -701,7 +701,7 @@ func GenerateAnnounceReleaseMessage(ctx context.Context, ghClient *github.Client
 		}
 		r.ImagesWithRC = imagesWithRC
 		r.ComponentsWithRC = componentsWithRC
-	} else {
+	} else { // GA Version
 		dockerfileURL := "https://raw.githubusercontent.com/" + rancherRepoOwner + "/rancher/" + *release.TargetCommitish + "/package/Dockerfile"
 		dockerfile, err := remoteTextFileToSlice(dockerfileURL)
 		if err != nil {
@@ -715,7 +715,6 @@ func GenerateAnnounceReleaseMessage(ctx context.Context, ghClient *github.Client
 		r.CLIVersion = cliVersion
 	}
 
-	// only pre release versions contain a suffix that starts with "-" (v2.9.2-alpha1)
 	tmpl := template.New("announce-release")
 	tmpl, err = tmpl.Parse(announceTemplate)
 	if err != nil {
@@ -768,10 +767,10 @@ func rancherImagesComponentsWithRC(rancherComponents []string) ([]string, []stri
 
 		// if a line contains # it is a header for a section
 		isHeader := strings.Contains(line, "#")
-		imagesHeader := strings.Contains(line, "Images")
-		componentsHeader := strings.Contains(line, "Components")
 
 		if isHeader {
+			imagesHeader := strings.Contains(line, "Images")
+			componentsHeader := strings.Contains(line, "Components")
 			// if it's a header, but not for images or components, ignore it and everything else after it
 			if !imagesHeader && !componentsHeader {
 				break

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -983,10 +983,11 @@ func remoteTextFileToSlice(url string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode != 200 {
+  defer res.Body.Close()
+
+  if res.StatusCode != 200 {
 		return nil, errors.New("expected status code to be 200, got: " + res.Status)
 	}
-	defer res.Body.Close()
 
 	var file []string
 	scanner := bufio.NewScanner(res.Body)


### PR DESCRIPTION
command to generate the rancher release announcement messages:
```
release generate rancher release-message --tag v2.8.8-alpha2 --previous-tag v2.8.8-alpha1 --prime-only --action-run-id 10857046301
  ```
```
`v2.8.8-alpha2` is available based on this commit ([link](https://github.com/rancher/rancher/commit/release/v2.8))!
* Link of commits between last 2 RCs. ([link](https://github.com/rancher/rancher/compare/v2.8.8-alpha1...v2.8.8-alpha2))
* Completed GHA build ([link](https://github.com/rancher/rancher/actions/runs/10857046301)).
* Images with -rc:
    * rancher/aks-operator v1.2.5-rc.1
    * rancher/cis-operator v1.0.15-rc.2
    * rancher/eks-operator v1.3.5-rc.1
    * rancher/gke-operator v1.2.5-rc.1
    * rancher/rancher-webhook v0.4.11-rc.2
    * rancher/security-scan v0.2.17-rc14
    * rancher/system-agent v0.3.9-rc.4-suc
    * rancher/wins v0.4.18-rc2
* Components with -rc:
    * SYSTEM_AGENT_VERSION v0.3.9-rc.4
    * WINS_AGENT_VERSION v0.4.18-rc2
    * AKS-OPERATOR v1.2.5-rc.1
    * EKS-OPERATOR v1.3.5-rc.1
    * GKE-OPERATOR v1.2.5-rc.1
    * RKE v1.5.13-rc.2
```