### PR TITLE
remove status check from rancher tag and shellcheck action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,18 +6,6 @@ on:
       - master
 
 jobs:
-  shellcheck:
-    name: Shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          severity: info
-          scandir: 'bin/'
-        env:
-          SHELLCHECK_OPTS: -s sh -e SC1091 -e SC2034 -e SC2317
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -27,5 +15,4 @@ jobs:
         run: |
           make all
           make test
-
 

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -23,10 +23,7 @@ type tagRKE2CmdFlags struct {
 	RPMVersion     *int
 }
 
-var (
-	tagRKE2Flags              tagRKE2CmdFlags
-	tagRancherSkipStatusCheck bool
-)
+var tagRKE2Flags              tagRKE2CmdFlags
 
 // tagCmd represents the tag command.
 var tagCmd = &cobra.Command{
@@ -178,7 +175,7 @@ var rancherTagSubCmd = &cobra.Command{
 			fmt.Println("dry run, skipping creating release")
 			return nil
 		}
-		releaseURL, err := rancher.CreateRelease(ctx, ghClient, &rancherRelease, opts, preRelease, tagRancherSkipStatusCheck, releaseType)
+		releaseURL, err := rancher.CreateRelease(ctx, ghClient, &rancherRelease, opts, preRelease, releaseType)
 		if err != nil {
 			return err
 		}
@@ -292,9 +289,6 @@ func init() {
 	tagRKE2Flags.ReleaseVersion = rke2TagSubCmd.Flags().StringP("release-version", "r", "r1", "Release version")
 	tagRKE2Flags.RCVersion = rke2TagSubCmd.Flags().String("rc", "", "RC version")
 	tagRKE2Flags.RPMVersion = rke2TagSubCmd.Flags().Int("rpm-version", 0, "RPM version")
-
-	// rancher
-	rancherTagSubCmd.Flags().BoolVarP(&tagRancherSkipStatusCheck, "skip-status-check", "s", false, "skip checking if CI is passing when creating a tag")
 }
 
 func releaseTypePreRelease(releaseType string) (bool, error) {

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -23,7 +23,7 @@ type tagRKE2CmdFlags struct {
 	RPMVersion     *int
 }
 
-var tagRKE2Flags              tagRKE2CmdFlags
+var tagRKE2Flags tagRKE2CmdFlags
 
 // tagCmd represents the tag command.
 var tagCmd = &cobra.Command{


### PR DESCRIPTION
A change to how GH actions are configured made this status check to always fail. Removing it for now until we find an alternative.

Remove shellcheck since it is not allowed anymore