### PR TITLE
publish-image: Remove hard failure

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -186,8 +186,7 @@ runs:
         cat provenance-slsav1.json
         cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${IMG_NAME}"
       else
-        echo "Failed to generate provenance"
-        exit 1
+        echo "ERROR: Failed to generate slsav1 provenance"
       fi
     env:
       TAG: ${{ inputs.tag }}


### PR DESCRIPTION
The publishing of some images is failing due to not being able to generate slsav1 provenance. Removing hard failure while the issue is investigated.