### PR TITLE
publish-image: Add validation and lift soft failure

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -176,16 +176,6 @@ runs:
     run: |
       go install github.com/rancherlabs/slsactl@latest
 
-  - name: Build and push image [Public]
-    shell: bash
-    if: ${{ inputs.push-to-public == true || inputs.push-to-public == 'true' }}
-    run: |
-      make ${{ inputs.make-target }}
-    env:
-      TAG: ${{ inputs.tag }}
-      TARGET_PLATFORMS: ${{ inputs.platforms }}
-      REPO: ${{ inputs.public-registry }}/${{ inputs.public-repo }}
-
   - name: Build and push image [Prime]
     shell: bash
     if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
@@ -209,3 +199,13 @@ runs:
       TAG: ${{ inputs.tag }}
       TARGET_PLATFORMS: ${{ inputs.platforms }}
       REPO: ${{ inputs.prime-registry }}/${{ inputs.prime-repo }}
+
+  - name: Build and push image [Public]
+    shell: bash
+    if: ${{ inputs.push-to-public == true || inputs.push-to-public == 'true' }}
+    run: |
+      make ${{ inputs.make-target }}
+    env:
+      TAG: ${{ inputs.tag }}
+      TARGET_PLATFORMS: ${{ inputs.platforms }}
+      REPO: ${{ inputs.public-registry }}/${{ inputs.public-repo }}

--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -127,6 +127,22 @@ runs:
   using: composite
 
   steps:
+  - name: Validate Prime Registry
+    shell: bash
+    if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
+    run: |
+      if [[ -z "${REGISTRY}" ]]; then
+        echo "Prime registry cannot be empty"
+        exit 1
+      fi
+
+      if [[ "${REGISTRY}" == "docker.io" ]]; then
+        echo "Prime registry cannot be docker.io"
+        exit 2
+      fi
+    env:
+      REGISTRY: ${{ inputs.prime-registry }}
+
   # Login to all registries before starting the pushing process.
   # Short-circuit if either fails. This should decrease the likelihood
   # of only one registry getting updated while the other fails.
@@ -186,7 +202,8 @@ runs:
         cat provenance-slsav1.json
         cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${IMG_NAME}"
       else
-        echo "ERROR: Failed to generate slsav1 provenance"
+        echo "ERROR: Failed to generate slsav1 provenance. Check whether the image is present in the Prime registry."
+        exit 3
       fi
     env:
       TAG: ${{ inputs.tag }}


### PR DESCRIPTION
- Ensure the Prime registry information is provided, when a push to Prime is required.
- Move order of image pushes to start with Prime, this way if there is an issue that can be found before the public image is released.
- The soft failure was removed as it was in fact a sign that the image was not properly pushed to the Prime Registry.