### PR TITLE
fix: use qemu 8.1.5 instead of latest

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -167,6 +167,8 @@ runs:
 
   - name: Setup QEMU
     uses: docker/setup-qemu-action@v3
+    with:
+      image: tonistiigi/binfmt:qemu-v8.1.5
   - name: Setup Docker Buildx
     uses: docker/setup-buildx-action@v3
   - name: Install Cosign


### PR DESCRIPTION
We noticed recently that our release build would fail when building using emulated arm64 environment.  When it happens, it can fail in zypper, gcc or other commands.  For example:

```
#63 127.6 # github.com/mattn/go-sqlite3
#63 127.6 gcc: internal compiler error: Segmentation fault signal terminated program cc1
#63 127.6 Please submit a full bug report, with preprocessed source (by using -freport-bug).
#63 127.6 See <https://bugs.opensuse.org/> for instructions.
```

And https://github.com/neuvector/scanner/actions/runs/13068955842/attempts/1

After invesitation, this is because `tonistiigi/binfmt:latest` is not up-to-date, and it might get accidentally broken when GitHub migrate to Ubuntu 24.04 runners.

This PR fixes the issue by specifying `qemu-v8.1.5` to be used in publish-image action.

More discussions and affected software can be found in this upstream issue: https://github.com/tonistiigi/binfmt/issues/215