### PR TITLE
add sync-upstream action

### DIFF
--- a/actions/publish-image/sync-upstream/action.yml
+++ b/actions/publish-image/sync-upstream/action.yml
@@ -1,0 +1,56 @@
+name: Sync Upstream
+
+on:
+  workflow_call:
+    inputs:
+      upstream-repo:
+        required: true
+        type: string
+        description: 'Upstream repository to sync from (format: owner/repo)'
+      branches:
+        required: true
+        type: string
+        description: 'JSON array of branches to sync'
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
+
+    strategy:
+      matrix:
+        branch: ${{ fromJSON(inputs.branches) }}
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote add upstream https://github.com/${{ inputs.upstream-repo }}.git
+          git fetch upstream ${{ matrix.branch }}
+
+      - name: Sync branch
+        run: |
+          git checkout -B ${{ matrix.branch }} upstream/${{ matrix.branch }}
+          git push -f origin ${{ matrix.branch }}
+
+      - name: Update branch status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          gh api \
+            --method POST \
+            /repos/${{ github.repository }}/statuses/$SHA \
+            -f state=success \
+            -f description="Branch synced with upstream" \
+            -f context="Branch Sync Status"


### PR DESCRIPTION
This PR adds a reusable action to sync a forked repo with any number of upstream branches
* maintains upstream history
* adds checks to branches

Intended workflow:
```mermaid
graph TB
    %% Upstream
    subgraph "Upstream"
        UP_Main["Main Branch"]
        UP_Release["Release Branch (1.2)"]
    end

    %% Fork
    subgraph "Fork"
        FORK_Main["Main Branch"]
        FORK_Release["Release Branch (1.2)"]
        FORK_CVE["CVE Patch Branch (release-1.2-cve1)"]
    end

    %% Sync Workflow (runs in main branch)
    subgraph "Sync Workflow"
        Sync_Action["GitHub Action: Sync Upstream Release"]
    end

    %% Security Patch Process
    subgraph "Security Patch Process"
        Step_Create["1. Create CVE Branch"]
        Step_PR["2. Open Pull Request"]
        Step_Merge["3. Squash & Merge"]
        Step_Tag["4. Tag Release"]
    end

    %% Sync Workflow Connections
    FORK_Main --> Sync_Action
    UP_Release -->|Sync| Sync_Action
    Sync_Action --> FORK_Release

    %% Security Patch Process Connections
    FORK_Release -->|Branch off to create| FORK_CVE
    Step_Create --> FORK_CVE
    FORK_CVE --> Step_PR
    Step_PR --> Step_Merge
    Step_Merge --> Step_Tag
```