### PR TITLE
Add max-retries field

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -207,7 +207,7 @@ runs:
     shell: bash
     if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
     run: |
-      max_retries=3
+      max_retries=10
       retry_delay=5
       i=0
 


### PR DESCRIPTION
Add optional field `max-retries` that may increase the number of `max-retries` in Attest Provenance step in `publish-image`  workflow.