### PR TITLE
Add `rancher/cli` automation commands

### DIFF
--- a/cmd/release/cmd/errors.go
+++ b/cmd/release/cmd/errors.go
@@ -1,13 +1,11 @@
 package cmd
 
-import "fmt"
-
 type VersionNotFoundError struct {
 	Version string
 }
 
 func (e *VersionNotFoundError) Error() string {
-	return fmt.Sprintf("verify your config file, version not found: %s", e.Version)
+	return "verify your config file, version not found: " + e.Version
 }
 
 func NewVersionNotFoundError(version string) error {

--- a/cmd/release/cmd/errors.go
+++ b/cmd/release/cmd/errors.go
@@ -1,15 +1,15 @@
 package cmd
 
-type VersionNotFoundError struct {
+type ErrVersionNotFound struct {
 	Version string
 }
 
-func (e *VersionNotFoundError) Error() string {
+func (e *ErrVersionNotFound) Error() string {
 	return "verify your config file, version not found: " + e.Version
 }
 
 func NewVersionNotFoundError(version string) error {
-	return &VersionNotFoundError{
+	return &ErrVersionNotFound{
 		Version: version,
 	}
 }

--- a/cmd/release/cmd/errors.go
+++ b/cmd/release/cmd/errors.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "fmt"
+
+type VersionNotFoundError struct {
+	Version string
+}
+
+func (e *VersionNotFoundError) Error() string {
+	return fmt.Sprintf("verify your config file, version not found: %s", e.Version)
+}
+
+func NewVersionNotFoundError(version string) error {
+	return &VersionNotFoundError{
+		Version: version,
+	}
+}

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -90,7 +90,7 @@ var k3sGenerateTagsSubCmd = &cobra.Command{
 		version := args[0]
 		k3sRelease, found := rootConfig.K3s.Versions[version]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)

--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -27,6 +27,9 @@ var (
 	dashboardPrevMilestone string
 	dashboardMilestone     string
 
+	cliPrevMilestone string
+	cliMilestone     string
+
 	concurrencyLimit                      int
 	imagesListURL                         string
 	ignoreImages                          []string
@@ -284,25 +287,53 @@ var dashboardGenerateReleaseNotesSubCmd = &cobra.Command{
 	},
 }
 
+var cliGenerateSubCmd = &cobra.Command{
+	Use:   "cli",
+	Short: "Generate rancher/cli related artifacts",
+}
+
+var cliGenerateReleaseNotesSubCmd = &cobra.Command{
+	Use:   "release-notes",
+	Short: "Generate cli release notes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "cli", cliMilestone, cliPrevMilestone, client)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(notes.String())
+
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
 	k3sGenerateSubCmd.AddCommand(k3sGenerateReleaseNotesSubCmd)
 	k3sGenerateSubCmd.AddCommand(k3sGenerateTagsSubCmd)
+
 	rke2GenerateSubCmd.AddCommand(rke2GenerateReleaseNotesSubCmd)
+
 	rancherGenerateSubCmd.AddCommand(rancherGenerateArtifactsIndexSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateMissingImagesListSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateDockerImagesDigestsSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateImagesSyncConfigSubCmd)
 	rancherGenerateSubCmd.AddCommand(rancherGenerateMetricsSubCmd)
+
 	uiGenerateSubCmd.AddCommand(uiGenerateReleaseNotesSubCmd)
 	dashboardGenerateSubCmd.AddCommand(dashboardGenerateReleaseNotesSubCmd)
+	cliGenerateSubCmd.AddCommand(cliGenerateReleaseNotesSubCmd)
 
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
 	generateCmd.AddCommand(rancherGenerateSubCmd)
 	generateCmd.AddCommand(uiGenerateSubCmd)
 	generateCmd.AddCommand(dashboardGenerateSubCmd)
+	generateCmd.AddCommand(cliGenerateSubCmd)
 
 	// k3s release notes
 	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
@@ -348,6 +379,18 @@ func init() {
 		os.Exit(1)
 	}
 	if err := dashboardGenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// cli release notes
+	cliGenerateReleaseNotesSubCmd.Flags().StringVarP(&cliPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	cliGenerateReleaseNotesSubCmd.Flags().StringVarP(&cliMilestone, "milestone", "m", "", "Milestone")
+	if err := cliGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := cliGenerateReleaseNotesSubCmd.MarkFlagRequired("milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/release/cmd/push.go
+++ b/cmd/release/cmd/push.go
@@ -32,7 +32,7 @@ var pushK3sTagsCmd = &cobra.Command{
 		version := args[0]
 		k3sRelease, found := rootConfig.K3s.Versions[version]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -48,7 +48,7 @@ var k3sTagSubCmd = &cobra.Command{
 		tag := args[1]
 		k3sRelease, found := rootConfig.K3s.Versions[tag]
 		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
+			return NewVersionNotFoundError(tag)
 		}
 
 		ctx := context.Background()
@@ -162,7 +162,7 @@ var rancherTagSubCmd = &cobra.Command{
 		tag := args[1]
 		rancherRelease, found := rootConfig.Rancher.Versions[tag]
 		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
+			return NewVersionNotFoundError(tag)
 		}
 
 		ctx := context.Background()
@@ -206,7 +206,7 @@ var systemAgentInstallerK3sTagSubCmd = &cobra.Command{
 
 		k3sRelease, found := rootConfig.K3s.Versions[tag]
 		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
+			return NewVersionNotFoundError(tag)
 		}
 
 		ctx := context.Background()
@@ -233,7 +233,7 @@ var dashboardTagSubCmd = &cobra.Command{
 
 		version := args[1]
 		if _, found := rootConfig.Dashboard.Versions[version]; !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 		return nil
 	},
@@ -251,7 +251,7 @@ var dashboardTagSubCmd = &cobra.Command{
 
 		dashboardRelease, found := rootConfig.Dashboard.Versions[tag]
 		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
+			return NewVersionNotFoundError(tag)
 		}
 		dashboardRelease.DryRun = dryRun
 
@@ -281,16 +281,16 @@ var dashboardTagSubCmd = &cobra.Command{
 }
 
 var cliTagSubCmd = &cobra.Command{
-	Use:   "cli [ga,rc,alpha,test] [version]",
+	Use:   "cli [ga,rc] [version]",
 	Short: "Tag dashboard releases",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return errors.New("expected at least two arguments: [ga,rc,alpha,etc] [version]")
+			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
 
 		version := args[1]
 		if _, found := rootConfig.CLI.Versions[version]; !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 		return nil
 	},
@@ -308,7 +308,7 @@ var cliTagSubCmd = &cobra.Command{
 
 		cliRelease, found := rootConfig.CLI.Versions[tag]
 		if !found {
-			return errors.New("verify your config file, version not found: " + tag)
+			return NewVersionNotFoundError(tag)
 		}
 		cliRelease.DryRun = dryRun
 

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -341,7 +341,7 @@ func init() {
 }
 
 func releaseTypePreRelease(releaseType string) (bool, error) {
-	if releaseType == "rc" || releaseType == "alpha" || releaseType == "test" {
+	if releaseType == "rc" || releaseType == "alpha" {
 		return true, nil
 	}
 
@@ -349,5 +349,5 @@ func releaseTypePreRelease(releaseType string) (bool, error) {
 		return false, nil
 	}
 
-	return false, errors.New("release type must be either 'ga', 'test', 'alpha' or 'rc', instead got: " + releaseType)
+	return false, errors.New("release type must be either 'ga', 'alpha' or 'rc', instead got: " + releaseType)
 }

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -38,7 +38,7 @@ var updateK3sReferencesCmd = &cobra.Command{
 
 		k3sRelease, found := rootConfig.K3s.Versions[version]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 
 		ctx := context.Background()
@@ -162,7 +162,7 @@ var updateRancherDashboardCmd = &cobra.Command{
 
 		dashboardRelease, found := rootConfig.Dashboard.Versions[versionTrimmed]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 
 		dashboardRelease.Tag = version
@@ -199,7 +199,7 @@ var updateRancherCLICmd = &cobra.Command{
 
 		cliRelease, found := rootConfig.CLI.Versions[versionTrimmed]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 
 		cliRelease.Tag = version
@@ -241,7 +241,7 @@ var updateCLICmd = &cobra.Command{
 
 		cliRelease, found := rootConfig.CLI.Versions[versionTrimmed]
 		if !found {
-			return errors.New("verify your config file, version not found: " + version)
+			return NewVersionNotFoundError(version)
 		}
 
 		cliRelease.Tag = version

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -188,8 +188,7 @@ var updateRancherCLICmd = &cobra.Command{
 		version := args[0]
 
 		// checking if the provided version is valid
-		_, err := semver.NewVersion(version)
-		if err != nil {
+		if _, err := semver.NewVersion(version); err != nil {
 			return err
 		}
 

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/ecm-distro-tools/release/charts"
+	"github.com/rancher/ecm-distro-tools/release/cli"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/rancher/ecm-distro-tools/repository"
@@ -211,6 +212,50 @@ var updateRancherCLICmd = &cobra.Command{
 	},
 }
 
+var updateCLICmd = &cobra.Command{
+	Use:   "cli [version] [rancher_tag]",
+	Short: "Update CLI references and create a PR",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("expected at least one argument: [version]")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := args[0]
+		rancherTag := args[1]
+
+		// checking if the provided version is valid
+		if _, err := semver.NewVersion(version); err != nil {
+			return fmt.Errorf("cli version not semver valid: %v", err)
+		}
+
+		// checking if the provided version is valid
+		if _, err := semver.NewVersion(rancherTag); err != nil {
+			return fmt.Errorf("rancher version not semver valid: %v", err)
+		}
+
+		versionTrimmed, _, _ := strings.Cut(version, "-rc")
+		versionTrimmed, _, _ = strings.Cut(versionTrimmed, "-alpha")
+		versionTrimmed, _, _ = strings.Cut(versionTrimmed, "-test")
+
+		cliRelease, found := rootConfig.CLI.Versions[versionTrimmed]
+		if !found {
+			return errors.New("verify your config file, version not found: " + version)
+		}
+
+		cliRelease.Tag = version
+		cliRelease.RancherTag = rancherTag
+		cliRelease.CLIUpstreamURL = fmt.Sprintf("git@github.com:%s/%s.git", rootConfig.CLI.RepoOwner, rootConfig.CLI.RepoName)
+
+		ctx := context.Background()
+
+		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		return cli.UpdateRancherReferences(ctx, rootConfig.CLI, ghClient, &cliRelease, rootConfig.User)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(updateCmd)
 	updateCmd.AddCommand(updateChartsCmd)
@@ -219,6 +264,7 @@ func init() {
 	updateCmd.AddCommand(updateRancherCmd)
 	updateRancherCmd.AddCommand(updateRancherDashboardCmd)
 	updateRancherCmd.AddCommand(updateRancherCLICmd)
+	updateCmd.AddCommand(updateCLICmd)
 }
 
 func validateChartConfig() error {

--- a/cmd/release/cmd/update.go
+++ b/cmd/release/cmd/update.go
@@ -236,8 +236,6 @@ var updateCLICmd = &cobra.Command{
 		}
 
 		versionTrimmed, _, _ := strings.Cut(version, "-rc")
-		versionTrimmed, _, _ = strings.Cut(versionTrimmed, "-alpha")
-		versionTrimmed, _, _ = strings.Cut(versionTrimmed, "-test")
 
 		cliRelease, found := rootConfig.CLI.Versions[versionTrimmed]
 		if !found {

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -57,10 +57,10 @@ type DashboardRelease struct {
 type CLIRelease struct {
 	PreviousTag          string `json:"previous_tag" validate:"required"`
 	ReleaseBranch        string `json:"release_branch" validate:"required"`
-	Tag                  string
+	Tag                  string `json:"-"`
 	CLIUpstreamURL       string `json:"-"`
 	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
-	RancherUpstreamURL   string
+	RancherUpstreamURL   string `json:"rancher_upstream_url"`
 	RancherCommitSHA     string `json:"-"`
 	RancherTag           string `json:"-"`
 	DryRun               bool   `json:"dry_run"`

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -58,9 +58,12 @@ type CLIRelease struct {
 	PreviousTag          string `json:"previous_tag" validate:"required"`
 	ReleaseBranch        string `json:"release_branch" validate:"required"`
 	Tag                  string
+	CLIUpstreamURL       string `json:"-"`
 	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
 	RancherUpstreamURL   string
-	DryRun               bool `json:"dry_run"`
+	RancherCommitSHA     string `json:"-"`
+	RancherTag           string `json:"-"`
+	DryRun               bool   `json:"dry_run"`
 }
 
 // RKE2

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -54,6 +54,15 @@ type DashboardRelease struct {
 	DryRun               bool `json:"dry_run"`
 }
 
+type CLIRelease struct {
+	PreviousTag          string `json:"previous_tag" validate:"required"`
+	ReleaseBranch        string `json:"release_branch" validate:"required"`
+	Tag                  string
+	RancherReleaseBranch string `json:"rancher_release_branch" validate:"required"`
+	RancherUpstreamURL   string
+	DryRun               bool `json:"dry_run"`
+}
+
 // RKE2
 type RKE2 struct {
 	Versions []string `json:"versions"`
@@ -95,6 +104,15 @@ type Dashboard struct {
 	RancherUpstreamURL string                      `json:"rancher_upstream_url" validate:"required"`
 }
 
+type CLI struct {
+	Versions           map[string]CLIRelease `json:"versions" validate:"dive"`
+	RepoOwner          string                `json:"repo_owner" validate:"required"`
+	RepoName           string                `json:"repo_name" validate:"required"`
+	RancherRepoOwner   string                `json:"rancher_repo_owner" validate:"required"`
+	RancherRepoName    string                `json:"rancher_repo_name" validate:"required"`
+	RancherUpstreamURL string                `json:"rancher_upstream_url" validate:"required"`
+}
+
 // Auth
 type Auth struct {
 	GithubToken        string `json:"github_token"`
@@ -114,6 +132,7 @@ type Config struct {
 	Charts        *ChartsRelease `json:"charts" validate:"omitempty"`
 	Auth          *Auth          `json:"auth"`
 	Dashboard     *Dashboard     `json:"dashboard"`
+	CLI           *CLI           `json:"cli"`
 	PrimeRegistry string         `json:"prime_registry"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 
 require (
 	github.com/MetalBlueberry/go-plotly v0.4.0
+	github.com/aws/aws-sdk-go-v2 v1.30.4
 	github.com/aws/aws-sdk-go-v2/config v1.27.29
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.29
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.60.1
 	github.com/briandowns/spinner v1.23.1
 	github.com/go-playground/validator/v10 v10.22.0
@@ -33,8 +33,8 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.30.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.4 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.29 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.12 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.16 // indirect

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -133,7 +133,7 @@ func updateRancherReferencesAndPush(r *ecmConfig.CLIRelease, _ *ecmConfig.User) 
 
 func createCLIReferencesPR(ctx context.Context, cfg *config.CLI, ghClient *github.Client, r *ecmConfig.CLIRelease, u *ecmConfig.User) error {
 	pull := &github.NewPullRequest{
-		Title:               github.String(fmt.Sprintf("Bump Rancher CLI version to `%s`", r.RancherTag)),
+		Title:               github.String(fmt.Sprintf("[%s] Bump Rancher CLI version to `%s`", r.ReleaseBranch, r.RancherTag)),
 		Base:                github.String(r.ReleaseBranch),
 		Head:                github.String(u.GithubUsername + ":update-cli-build-refs-" + r.Tag),
 		MaintainerCanModify: github.Bool(true),

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v39/github"
+	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/rancher/ecm-distro-tools/release"
+	"github.com/rancher/ecm-distro-tools/repository"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	cliOrg           = "rancher"
+	cliRepo          = "cli"
+	cliImagesBaseURL = "https://github.com/" + cliOrg + "/" + cliRepo + "/releases"
+)
+
+// CreateRelease will create a new tag and a new release with given params.
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.CLIRelease, opts *repository.CreateReleaseOpts, rc bool, releaseType string) error {
+	if !semver.IsValid(opts.Tag) {
+		return errors.New("tag isn't a valid semver: " + opts.Tag)
+	}
+
+	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
+	if err != nil {
+		return err
+	}
+
+	if rc {
+		latestRCNumber := 1
+		if latestPreRelease != nil {
+			// v2.9.0-rc.N / -alpha.N
+			_, trimmedRCNumber, found := strings.Cut(*latestPreRelease, "-"+releaseType+".")
+			if !found {
+				return errors.New("failed to parse rc number from " + *latestPreRelease)
+			}
+			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
+			if err != nil {
+				return err
+			}
+			latestRCNumber = currentRCNumber + 1
+		}
+		opts.Tag = fmt.Sprintf("%s-%s.%d", opts.Tag, releaseType, latestRCNumber)
+	}
+
+	opts.Name = opts.Tag
+	opts.Prerelease = true
+	opts.Draft = !rc
+	opts.ReleaseNotes = ""
+
+	if !rc {
+		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, r.PreviousTag)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, r.PreviousTag, client)
+		if err != nil {
+			return err
+		}
+		opts.ReleaseNotes = buff.String()
+	}
+
+	fmt.Printf("create release options: %+v\n", *opts)
+
+	if r.DryRun {
+		fmt.Println("dry run, skipping creating release")
+		return nil
+	}
+
+	createdRelease, err := repository.CreateRelease(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("release created: " + *createdRelease.HTMLURL)
+	return nil
+}

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -34,6 +34,11 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.CLIR
 		return err
 	}
 
+	opts.Name = opts.Tag
+	opts.Prerelease = true
+	opts.Draft = !rc
+	opts.ReleaseNotes = ""
+
 	if rc {
 		latestRCNumber := 1
 		if latestPreRelease != nil {
@@ -49,14 +54,7 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.CLIR
 			latestRCNumber = currentRCNumber + 1
 		}
 		opts.Tag = fmt.Sprintf("%s-%s.%d", opts.Tag, releaseType, latestRCNumber)
-	}
-
-	opts.Name = opts.Tag
-	opts.Prerelease = true
-	opts.Draft = !rc
-	opts.ReleaseNotes = ""
-
-	if !rc {
+	} else {
 		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, r.PreviousTag)
 		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, r.PreviousTag, client)
 		if err != nil {

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/google/go-github/v39/github"
+	"github.com/rancher/ecm-distro-tools/cmd/release/config"
 	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
+	ecmExec "github.com/rancher/ecm-distro-tools/exec"
 	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"golang.org/x/mod/semver"
@@ -77,3 +80,127 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.CLIR
 	fmt.Println("release created: " + *createdRelease.HTMLURL)
 	return nil
 }
+
+func UpdateRancherReferences(ctx context.Context, cfg *config.CLI, ghClient *github.Client, r *config.CLIRelease, u *config.User) error {
+	r.RancherUpstreamURL = cfg.RancherUpstreamURL
+
+	commitSHA, err := getRancherPkgSHA(ctx, ghClient, cfg.RancherRepoOwner, cfg.RancherRepoName, r.RancherTag)
+	if err != nil {
+		return err
+	}
+
+	r.RancherCommitSHA = commitSHA
+
+	if err := updateRancherReferencesAndPush(r, u); err != nil {
+		return err
+	}
+
+	return createCLIReferencesPR(ctx, cfg, ghClient, r, u)
+}
+
+func getRancherPkgSHA(ctx context.Context, ghClient *github.Client, owner, repo, tag string) (string, error) {
+	ref, _, err := ghClient.Git.GetRef(ctx, owner, repo, "tags/"+tag)
+	if err != nil {
+		return "", fmt.Errorf("error getting tag reference: %v", err)
+	}
+
+	if ref.Object.GetType() == "commit" {
+		return ref.Object.GetSHA(), nil
+	}
+
+	if ref.Object.GetType() == "tag" {
+		tagObj, _, err := ghClient.Git.GetTag(ctx, owner, repo, ref.Object.GetSHA())
+		if err != nil {
+			return "", fmt.Errorf("error getting tag object: %v", err)
+		}
+		return tagObj.Object.GetSHA(), nil
+	}
+
+	return "", fmt.Errorf("unexpected reference type: %s", ref.Object.GetType())
+}
+
+func updateRancherReferencesAndPush(r *ecmConfig.CLIRelease, _ *ecmConfig.User) error {
+	funcMap := template.FuncMap{"replaceAll": strings.ReplaceAll}
+	fmt.Println("creating update cli references script template")
+	updateScriptOut, err := ecmExec.RunTemplatedScript("./", "replace_cli_ref.sh", updateRancherReferencesScript, funcMap, r)
+	if err != nil {
+		fmt.Println("error executing script")
+		return err
+	}
+	fmt.Println(updateScriptOut)
+	return nil
+}
+
+func createCLIReferencesPR(ctx context.Context, cfg *config.CLI, ghClient *github.Client, r *ecmConfig.CLIRelease, u *ecmConfig.User) error {
+	pull := &github.NewPullRequest{
+		Title:               github.String(fmt.Sprintf("Bump Rancher CLI version to `%s`", r.RancherTag)),
+		Base:                github.String(r.ReleaseBranch),
+		Head:                github.String(u.GithubUsername + ":update-cli-build-refs-" + r.Tag),
+		MaintainerCanModify: github.Bool(true),
+	}
+
+	// creating a pr from your fork branch
+	pr, _, err := ghClient.PullRequests.Create(ctx, cfg.RepoOwner, cfg.RepoName, pull)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Pull Request created successfully:", pr.GetHTMLURL())
+
+	return nil
+}
+
+const updateRancherReferencesScript = `#!/bin/sh
+# Enable verbose mode and exit on any error
+set -ex
+
+# Determine the operating system
+OS=$(uname -s)
+
+# Set variables (these are populated by Go's template engine)
+DRY_RUN={{ .DryRun }}
+BRANCH_NAME=update-cli-build-refs-{{ .Tag }}
+RANCHER_VERSION={{ .RancherTag }}
+RANCHER_COMMIT_SHA={{ .RancherCommitSHA }}
+
+# Add upstream remote if it doesn't exist
+# Note: Using ls | grep is not recommended for general use, but it's okay here
+# since we're only checking for 'rancher'
+git remote -v | grep -w upstream || git remote add upstream {{ .CLIUpstreamURL }}
+git fetch upstream
+git stash
+
+# Delete the branch if it exists, then create a new one based on upstream
+git branch -D "${BRANCH_NAME}" > /dev/null 2>&1 || true
+git checkout -B "${BRANCH_NAME}" upstream/{{.ReleaseBranch}}
+# git clean -xfd
+
+# Function to update the file
+update_go_mod() {
+	echo "Updating pkg/apis module..."
+	go get github.com/rancher/rancher/pkg/apis@$RANCHER_COMMIT_SHA
+	sleep 2
+
+	echo "Updating pkg/client module..."
+	go get github.com/rancher/rancher/pkg/client@$RANCHER_COMMIT_SHA
+
+	sleep 2
+	go mod tidy
+}
+
+# Run the update function
+update_go_mod
+
+git add go.mod go.sum
+
+# Cleaning temp files/scripts
+git clean -f
+
+git commit --signoff -m "Update Rancher refs to ${RANCHER_VERSION}"
+
+# Push the changes if not a dry run
+if [ "${DRY_RUN}" = false ]; then
+	git push --set-upstream origin "${BRANCH_NAME}" # run git remote -v for your origin
+fi
+
+`

--- a/release/release.go
+++ b/release/release.go
@@ -52,15 +52,12 @@ type changeLogData struct {
 }
 
 type rke2ReleaseNoteData struct {
-	Milestone                             string
 	K8sVersion                            string
-	MajorMinor                            string
 	EtcdVersion                           string
 	ContainerdVersion                     string
 	RuncVersion                           string
 	MetricsServerVersion                  string
 	CoreDNSVersion                        string
-	ChangeLogVersion                      string
 	IngressNginxVersion                   string
 	HelmControllerVersion                 string
 	FlannelVersion                        string
@@ -70,7 +67,6 @@ type rke2ReleaseNoteData struct {
 	CalicoURL                             string
 	CiliumVersion                         string
 	MultusVersion                         string
-	ChangeLogData                         changeLogData
 	CiliumChartVersion                    string
 	CanalChartVersion                     string
 	CalicoChartVersion                    string
@@ -85,14 +81,12 @@ type rke2ReleaseNoteData struct {
 	SnapshotControllerChartVersion        string
 	SnapshotControllerCRDChartVersion     string
 	SnapshotValidationWebhookChartVersion string
+	releaseNoteData
 }
 
 type k3sReleaseNoteData struct {
-	Milestone                   string
 	K8sVersion                  string
-	MajorMinor                  string
 	ChangeLogSince              string
-	ChangeLogVersion            string
 	KineVersion                 string
 	SQLiteVersion               string
 	SQLiteVersionReplaced       string
@@ -105,24 +99,22 @@ type k3sReleaseNoteData struct {
 	CoreDNSVersion              string
 	HelmControllerVersion       string
 	LocalPathProvisionerVersion string
-	ChangeLogData               changeLogData
+	releaseNoteData
 }
 
 type uiReleaseNoteData struct {
-	Milestone        string
-	MajorMinor       string
-	ChangeLogVersion string
-	ChangeLogData    changeLogData
+	releaseNoteData
 }
 
 type dashboardReleaseNoteData struct {
-	Milestone        string
-	MajorMinor       string
-	ChangeLogVersion string
-	ChangeLogData    changeLogData
+	releaseNoteData
 }
 
 type cliReleaseNoteData struct {
+	releaseNoteData
+}
+
+type releaseNoteData struct {
 	Milestone        string
 	MajorMinor       string
 	ChangeLogVersion string
@@ -210,15 +202,17 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 			tmpl,
 			milestone,
 			k3sReleaseNoteData{
-				Milestone:             milestoneNoRC,
-				MajorMinor:            majorMinor,
+				releaseNoteData: releaseNoteData{
+					Milestone:        milestoneNoRC,
+					MajorMinor:       majorMinor,
+					ChangeLogVersion: markdownVersion,
+					ChangeLogData:    cgData,
+				},
 				K8sVersion:            k8sVersion,
-				ChangeLogVersion:      markdownVersion,
 				ChangeLogSince:        changeLogSince,
 				SQLiteVersion:         sqliteVersionBinding,
 				SQLiteVersionReplaced: strings.ReplaceAll(sqliteVersionBinding, ".", "_"),
 				HelmControllerVersion: helmControllerVersion,
-				ChangeLogData:         cgData,
 				CoreDNSVersion:        coreDNSVersion,
 			},
 		)
@@ -228,13 +222,15 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 			tmpl,
 			milestone,
 			rke2ReleaseNoteData{
-				MajorMinor:            majorMinor,
-				Milestone:             milestoneNoRC,
-				ChangeLogVersion:      markdownVersion,
+				releaseNoteData: releaseNoteData{
+					Milestone:        milestoneNoRC,
+					MajorMinor:       majorMinor,
+					ChangeLogVersion: markdownVersion,
+					ChangeLogData:    cgData,
+				},
 				K8sVersion:            k8sVersion,
 				HelmControllerVersion: helmControllerVersion,
 				CoreDNSVersion:        coreDNSVersion,
-				ChangeLogData:         cgData,
 			},
 		)
 	}
@@ -244,10 +240,12 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 			tmpl,
 			milestone,
 			uiReleaseNoteData{
-				MajorMinor:       majorMinor,
-				Milestone:        milestoneNoRC,
-				ChangeLogVersion: markdownVersion,
-				ChangeLogData:    cgData,
+				releaseNoteData: releaseNoteData{
+					Milestone:        milestoneNoRC,
+					MajorMinor:       majorMinor,
+					ChangeLogVersion: markdownVersion,
+					ChangeLogData:    cgData,
+				},
 			},
 		)
 	}
@@ -257,10 +255,12 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 			tmpl,
 			milestone,
 			dashboardReleaseNoteData{
-				MajorMinor:       majorMinor,
-				Milestone:        milestoneNoRC,
-				ChangeLogVersion: markdownVersion,
-				ChangeLogData:    cgData,
+				releaseNoteData: releaseNoteData{
+					Milestone:        milestoneNoRC,
+					MajorMinor:       majorMinor,
+					ChangeLogVersion: markdownVersion,
+					ChangeLogData:    cgData,
+				},
 			},
 		)
 	}
@@ -270,10 +270,12 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 			tmpl,
 			milestone,
 			cliReleaseNoteData{
-				MajorMinor:       majorMinor,
-				Milestone:        milestoneNoRC,
-				ChangeLogVersion: markdownVersion,
-				ChangeLogData:    cgData,
+				releaseNoteData: releaseNoteData{
+					Milestone:        milestoneNoRC,
+					MajorMinor:       majorMinor,
+					ChangeLogVersion: markdownVersion,
+					ChangeLogData:    cgData,
+				},
 			},
 		)
 	}

--- a/release/release.go
+++ b/release/release.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -204,7 +205,7 @@ type uiReleaseNoteData struct {
 }
 
 func (_ *uiReleaseNoteData) Fill(_ string) error { return nil }
-func (_ *uiReleaseNoteData) Template() string    { return defaultReleaseNoteTemplate }
+func (_ *uiReleaseNoteData) Template() string    { return fmt.Sprintf(defaultReleaseNoteTemplate, uiRepo) }
 func (_ *uiReleaseNoteData) Repo() string        { return uiRepo }
 
 type dashboardReleaseNoteData struct {
@@ -212,16 +213,20 @@ type dashboardReleaseNoteData struct {
 }
 
 func (_ *dashboardReleaseNoteData) Fill(_ string) error { return nil }
-func (_ *dashboardReleaseNoteData) Template() string    { return defaultReleaseNoteTemplate }
-func (_ *dashboardReleaseNoteData) Repo() string        { return dashboardRepo }
+func (_ *dashboardReleaseNoteData) Template() string {
+	return fmt.Sprintf(defaultReleaseNoteTemplate, dashboardRepo)
+}
+func (_ *dashboardReleaseNoteData) Repo() string { return dashboardRepo }
 
 type cliReleaseNoteData struct {
 	releaseNoteData
 }
 
 func (_ *cliReleaseNoteData) Fill(_ string) error { return nil }
-func (_ *cliReleaseNoteData) Template() string    { return defaultReleaseNoteTemplate }
-func (_ *cliReleaseNoteData) Repo() string        { return cliRepo }
+func (_ *cliReleaseNoteData) Template() string {
+	return fmt.Sprintf(defaultReleaseNoteTemplate, cliRepo)
+}
+func (_ *cliReleaseNoteData) Repo() string { return cliRepo }
 
 func majMin(v string) (string, error) {
 	majMin := semver.MajorMinor(v)


### PR DESCRIPTION
Commands added:
- `release update rancher cli [version]`
    - Updates `CATTLE_CLI_VERSION` in `rancher/rancher`'s `package/Dockerfile`
- `release update cli [version] [rancher_tag]`
    - This will update the `rancher/rancher/pkg/apis` and `rancher/rancher/pkg/client` modules in `go.mod` based on `[rancher_tag]`. (the code will get the commit SHA from the provided Rancher tag.
- `release tag cli [release_type] [version]`
    - Command that will create the releases in `rancher/cli`
    - The `release_type` supports: `rc` and `ga`.
- `release generate k3s release-notes --milestone [version] --prev-milestone [version]`
    - This will generate the release notes for `rancher/cli` releases.

Closes #555 
