### PR TITLE
Add `generate kdm rke2-charts` cmd

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-github/v39/github"
 	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/release/k3s"
+	"github.com/rancher/ecm-distro-tools/release/kdm"
 	"github.com/rancher/ecm-distro-tools/release/metrics"
 	"github.com/rancher/ecm-distro-tools/release/rancher"
 	"github.com/rancher/ecm-distro-tools/repository"
@@ -310,6 +311,26 @@ var cliGenerateReleaseNotesSubCmd = &cobra.Command{
 	},
 }
 
+var kdmGenerateSubCmd = &cobra.Command{
+	Use:   "kdm",
+	Short: "Generate kdm related artifacts",
+}
+
+var kdmGenerateRKE2ChartsSubCmd = &cobra.Command{
+	Use:   "rke2-charts",
+	Short: "Generate rke2 charts updated charts in YAML",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		charts, err := kdm.GetUpdatedCharts(rke2Milestone, rke2PrevMilestone)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(charts)
+
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
@@ -328,12 +349,15 @@ func init() {
 	dashboardGenerateSubCmd.AddCommand(dashboardGenerateReleaseNotesSubCmd)
 	cliGenerateSubCmd.AddCommand(cliGenerateReleaseNotesSubCmd)
 
+	kdmGenerateSubCmd.AddCommand(kdmGenerateRKE2ChartsSubCmd)
+
 	generateCmd.AddCommand(k3sGenerateSubCmd)
 	generateCmd.AddCommand(rke2GenerateSubCmd)
 	generateCmd.AddCommand(rancherGenerateSubCmd)
 	generateCmd.AddCommand(uiGenerateSubCmd)
 	generateCmd.AddCommand(dashboardGenerateSubCmd)
 	generateCmd.AddCommand(cliGenerateSubCmd)
+	generateCmd.AddCommand(kdmGenerateSubCmd)
 
 	// k3s release notes
 	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
@@ -462,6 +486,18 @@ func init() {
 		os.Exit(1)
 	}
 	if err := rancherGenerateMetricsSubCmd.MarkFlagRequired("prime-releases-file"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// k3s release notes
+	kdmGenerateRKE2ChartsSubCmd.Flags().StringVarP(&rke2PrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
+	kdmGenerateRKE2ChartsSubCmd.Flags().StringVarP(&rke2Milestone, "milestone", "m", "", "Milestone")
+	if err := kdmGenerateRKE2ChartsSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := kdmGenerateRKE2ChartsSubCmd.MarkFlagRequired("milestone"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/release/kdm/rke2_charts.go
+++ b/release/kdm/rke2_charts.go
@@ -1,0 +1,103 @@
+package kdm
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type (
+	ChartsFile struct {
+		Charts []Chart `yaml:"charts"`
+	}
+
+	Chart struct {
+		Repo     string `yaml:"repo,omitempty"`
+		Version  string `yaml:"version,omitempty"`
+		Filename string `yaml:"filename,omitempty"`
+	}
+)
+
+const (
+	chartsURLFormat = "https://raw.githubusercontent.com/rancher/rke2/%s/charts/chart_versions.yaml"
+)
+
+func getChartsFromVersion(version string) (map[string]Chart, error) {
+	chartsURL := fmt.Sprintf(chartsURLFormat, version)
+
+	resp, err := http.Get(chartsURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errorBodyBytes []byte
+		errorBodyBytes, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("received an error from GitHub API: %s", string(errorBodyBytes))
+	}
+
+	chartsFileContent, err := io.ReadAll(resp.Body) // io.ReadAll is preferred over ioutil.ReadAll since Go 1.16
+	if err != nil {
+		return nil, err
+	}
+
+	var chartFile ChartsFile
+	if err = yaml.Unmarshal(chartsFileContent, &chartFile); err != nil {
+		return nil, err
+	}
+
+	charts := map[string]Chart{}
+
+	for _, chart := range chartFile.Charts {
+		chartName := strings.TrimSuffix(chart.Filename, ".yaml")
+		chartName = strings.TrimPrefix(chartName, "/charts/")
+		charts[chartName] = Chart{
+			Repo:    "rancher-rke2-charts",
+			Version: chart.Version,
+		}
+	}
+
+	return charts, nil
+}
+
+func GetUpdatedCharts(milestone, prevMilestone string) (string, error) {
+	currentCharts, err := getChartsFromVersion(milestone)
+	if err != nil {
+		return "", err
+	}
+
+	previousCharts, err := getChartsFromVersion(prevMilestone)
+	if err != nil {
+		return "", err
+	}
+
+	updatedCharts := map[string]Chart{}
+
+	for name, details := range currentCharts {
+		prevChart, ok := previousCharts[name]
+		// if a new chart was added in the current release,
+		// it won't be found in the previous release's charts.
+		if !ok {
+			updatedCharts[name] = details
+			continue
+		}
+		if prevChart.Version != details.Version {
+			updatedCharts[name] = details
+			continue
+		}
+	}
+
+	b, err := yaml.Marshal(updatedCharts)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}


### PR DESCRIPTION
This command is basically a helper to the list of updated charts from RKE2 repository, it will return the list of updated charts in yaml format:

The command looks like this:
> release generate kdm rke2-charts --milestone v1.30.13+rke2r1 --prev-milestone v1.30.12+rke2r1

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/ffb31690-680b-4131-8b66-ab7ea594320d" />
