### PR TITLE
Add sign container identity option to publish image action

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -195,7 +195,7 @@ runs:
       IMG_NAME="${REPO}/${{ inputs.image }}@$(head -n 1 ${IID_FILE})"
 
       IDENTITY_REGISTRY=${IDENTITY_REGISTRY:-"$REGISTRY"}
-      IDENTITY="$IDENTITY_REGISTRY/$PRIME_REPO/$IMAGE:$TAG"
+      IDENTITY="$IDENTITY_REGISTRY/${{ inputs.prime-repo }}/${{ inputs.image }}:$TAG"
 
       cosign sign \
         --oidc-provider=github-actions \
@@ -210,8 +210,6 @@ runs:
       TARGET_PLATFORMS: ${{ inputs.platforms }}
       REPO: ${{ inputs.prime-registry }}/${{ inputs.prime-repo }}
       REGISTRY: ${{ inputs.prime-registry }}
-      PRIME_REPO: ${{ inputs.prime-repo }}
-      IMAGE: ${{ inputs.image }}
 
   - name: Build and push image [Public]
     shell: bash


### PR DESCRIPTION
This PR adds the `identity-registry` input to support the new scenario of images that will first be pushed and signed in the staging registry and later transferred to the prime registry.

Tested in tashima42/tcp-chat:
v0.0.3-alpha4 (without): https://github.com/tashima42/tcp-chat/blob/v0.0.3-alpha4/.github/workflows/release.yml
```
[{"critical":{"identity":{"docker-reference":"quay.io/tashima42/tcp-chat:v0.0.3-alpha4"},
```
v0.0.3-alpha5 (with): https://github.com/tashima42/tcp-chat/blob/v0.0.3-alpha5/.github/workflows/release.yml
```
[{"critical":{"identity":{"docker-reference":"ghcr.io/tashima42/tcp-chat:v0.0.3-alpha5"},
```