### PR TITLE
Install action use latest by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   install-script-version:
     description: 'The version of the install script to use.'
     required: false
-    default: "refs/heads/master"
+    default: ${{ github.action_ref }}
 runs:
   using: 'composite'
   steps:

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - env:
-      INSTALL_SCRIPT_TAG: ${{ inputs.install-script-version }}
-      TAG: ${{ inputs.version }}
+  - name: install ecm-distro-tools
     shell: bash
     run: |
+      INSTALL_SCRIPT_TAG=${{ inputs.install-script-version }}
       INSTALL_SCRIPT_PATH="${RUNNER_TEMP}/install.sh"
+      TAG=${{ inputs.version }}
       INSTALL_DIR=$HOME/.local/bin/ecm-distro-tools
+
       wget -O "${INSTALL_SCRIPT_PATH}" "https://raw.githubusercontent.com/rancher/ecm-distro-tools/${INSTALL_SCRIPT_TAG}/install.sh"
       chmod +x "${INSTALL_SCRIPT_PATH}" 
       ${INSTALL_SCRIPT_PATH} ${TAG}

--- a/action.yml
+++ b/action.yml
@@ -4,20 +4,19 @@ inputs:
   version:
     description: 'The tag of the ecm-distro-tools release to install.'
     required: false
-    default: ${{ github.action_ref }}
   install-script-version:
     description: 'The version of the install script to use.'
     required: false
-    default: ${{ github.action_ref }}
+    default: "refs/heads/master"
 runs:
   using: 'composite'
   steps:
   - env:
-      INSTALL_SCRIPT_TAG: ${{ inputs.install-script-version }} 
+      INSTALL_SCRIPT_TAG: ${{ inputs.install-script-version }}
+      TAG: ${{ inputs.version }}
     shell: bash
     run: |
       INSTALL_SCRIPT_PATH="${RUNNER_TEMP}/install.sh"
-      TAG="${{ inputs.version }}"
       INSTALL_DIR=$HOME/.local/bin/ecm-distro-tools
       wget -O "${INSTALL_SCRIPT_PATH}" "https://raw.githubusercontent.com/rancher/ecm-distro-tools/${INSTALL_SCRIPT_TAG}/install.sh"
       chmod +x "${INSTALL_SCRIPT_PATH}" 


### PR DESCRIPTION
The new renovate policy by the security team uses commits instead of tags to pin dependencies on workflows. This breaks the current usages of ecm-distro-tools because by default, the action uses the ref defined when the workflow is called.