### PR TITLE
add images locations cmd and deprecate missing images

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -502,7 +502,7 @@ func init() {
 	rancherGenerateImagesLocationsSubCmd.Flags().StringSliceVarP(&ignoreImages, "ignore-images", "g", make([]string, 0), "Images to ignore when checking for missing images without the version. e.g: rancher/rancher")
 	rancherGenerateImagesLocationsSubCmd.Flags().StringSliceVarP(&checkImages, "check-images", "k", make([]string, 0), "Images to check for when checking for missing images with the version. e.g: rancher/rancher-agent:v2.9.0")
 	rancherGenerateImagesLocationsSubCmd.Flags().StringSliceVarP(&registries, "registries", "r", make([]string, 0), "Registries where the images should be located at")
-	rancherGenerateImagesLocationsSubCmd.Flags().StringVarP(&registry, "target-registry", "t", "registry.rancher.com", "Registry to check images")
+	rancherGenerateImagesLocationsSubCmd.Flags().StringVarP(&registry, "target-registry", "t", "registry.rancher.com", "Registry where the images should be located at")
 	rancherGenerateImagesLocationsSubCmd.Flags().StringVarP(&username, "username", "u", "", "Docker registry username")
 	rancherGenerateImagesLocationsSubCmd.Flags().StringVarP(&password, "password", "p", "", "Docker registry password")
 
@@ -512,7 +512,7 @@ func init() {
 	rancherGenerateMissingImagesListSubCmd.Flags().StringVarP(&imagesListURL, "images-list-url", "i", "", "URL of the artifact containing all images for a given version 'rancher-images.txt' (required)")
 	rancherGenerateMissingImagesListSubCmd.Flags().StringSliceVarP(&ignoreImages, "ignore-images", "g", make([]string, 0), "Images to ignore when checking for missing images without the version. e.g: rancher/rancher")
 	rancherGenerateMissingImagesListSubCmd.Flags().StringSliceVarP(&checkImages, "check-images", "k", make([]string, 0), "Images to check for when checking for missing images with the version. e.g: rancher/rancher-agent:v2.9.0")
-	rancherGenerateMissingImagesListSubCmd.Flags().StringVarP(&registry, "registry", "r", "registry.rancher.com", "Registry to check images")
+	rancherGenerateMissingImagesListSubCmd.Flags().StringVarP(&registry, "registry", "r", "registry.rancher.com", "Registry where the images should be located at")
 	rancherGenerateMissingImagesListSubCmd.Flags().StringVarP(&username, "username", "u", "", "Docker registry username")
 	rancherGenerateMissingImagesListSubCmd.Flags().StringVarP(&password, "password", "p", "", "Docker registry password")
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -563,7 +563,7 @@ func imagesDiff(source, compare []string) ([]string, error) {
 	return diff, nil
 }
 
-// missingImagesFromRegistry receives registry information and a list of images and checks which images are missing from that registry
+// MissingImagesFromRegistry receives registry information and a list of images and checks which images are missing from that registry
 // it uses the docker http api v2 to check images concurrently
 func MissingImagesFromRegistry(username, password, registry string, concurrencyLimit int, checkImages, ignoreImages []string) ([]string, error) {
 	ignore, err := imageSliceToMap(ignoreImages, true)

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -514,6 +514,8 @@ func formatContentLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
+// ImagesLocationsMap searches for missing images in a registry and creates a map with the locations of the images, or if they are missing
+// this map can be used to identify where which image should be synced from
 func ImagesLocationsMap(username, password string, concurrencyLimit int, checkImages, ignoreImages []string, targetRegistry string, imagesRegiestries []string) (map[string][]string, error) {
 	syncImagesRegistries := make(map[string][]string)
 

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -515,19 +514,57 @@ func formatContentLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-func GenerateMissingImagesList(imagesListURL, registry, username, password string, concurrencyLimit int, checkImages, ignoreImages []string, verbose bool) ([]string, error) {
-	if len(checkImages) == 0 {
-		if imagesListURL == "" {
-			return nil, errors.New("if no images are provided, an images list URL must be provided")
-		}
-		rancherImages, err := rancherPrimeArtifact(imagesListURL)
-		if err != nil {
-			return nil, errors.New("failed to get rancher images: " + err.Error())
-		}
-		checkImages = append(checkImages, rancherImages...)
+func ImagesLocationsMap(username, password string, concurrencyLimit int, checkImages, ignoreImages []string, targetRegistry string, imagesRegiestries []string) (map[string][]string, error) {
+	syncImagesRegistries := make(map[string][]string)
+
+	var err error
+	missingFromTarget, err := MissingImagesFromRegistry(username, password, targetRegistry, concurrencyLimit, checkImages, ignoreImages)
+	if err != nil {
+		return nil, err
 	}
 
-	ignore, err := imageSliceToMap(ignoreImages)
+	lastMissingImages := missingFromTarget
+	for _, registry := range imagesRegiestries {
+		missingFromRegistry, err := MissingImagesFromRegistry(username, password, registry, concurrencyLimit, lastMissingImages, ignoreImages)
+		if err != nil {
+			return nil, err
+		}
+
+		syncImagesRegistries[registry], err = imagesDiff(lastMissingImages, missingFromRegistry)
+		if err != nil {
+			return nil, err
+		}
+
+		lastMissingImages = missingFromRegistry
+	}
+
+	syncImagesRegistries["missing"] = lastMissingImages
+
+	return syncImagesRegistries, nil
+}
+
+// imagesDiff compares two images slices and returns a slice with all images that are in the source slice, but not in the compare slice
+func imagesDiff(source, compare []string) ([]string, error) {
+	cm, err := imageSliceToMap(compare, false)
+	if err != nil {
+		return nil, err
+	}
+
+	diff := make([]string, 0)
+
+	for _, s := range source {
+		if _, ok := cm[s]; !ok {
+			diff = append(diff, s)
+		}
+	}
+
+	return diff, nil
+}
+
+// missingImagesFromRegistry receives registry information and a list of images and checks which images are missing from that registry
+// it uses the docker http api v2 to check images concurrently
+func MissingImagesFromRegistry(username, password, registry string, concurrencyLimit int, checkImages, ignoreImages []string) ([]string, error) {
+	ignore, err := imageSliceToMap(ignoreImages, true)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +599,7 @@ func GenerateMissingImagesList(imagesListURL, registry, username, password strin
 		func(ctx context.Context, missingImagesChan chan string, image, imageVersion, username, password string, repositoryAuths map[string]string, mu *sync.RWMutex) {
 			errGroup.Go(func() error {
 				// if any other check failed, stop running to prevent wasting resources
-				// this doesn't include 404's since it is expected it does include any other errors
+				// this doesn't include 404's since it is expected. Any other errors are included
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -678,11 +715,13 @@ func generateRegsyncConfig(images []string, sourceRegistry, targetRegistry strin
 	return &config, nil
 }
 
-func imageSliceToMap(images []string) (map[string]bool, error) {
+func imageSliceToMap(images []string, validate bool) (map[string]bool, error) {
 	imagesMap := make(map[string]bool, len(images))
 	for _, image := range images {
-		if err := validateRepoImage(image); err != nil {
-			return nil, err
+		if validate {
+			if err := validateRepoImage(image); err != nil {
+				return nil, err
+			}
 		}
 		imagesMap[image] = true
 	}
@@ -874,7 +913,6 @@ func dockerImageDigest(registryBaseURL, img, imgVersion, auth string) (string, i
 }
 
 func checkIfImageExists(registryBaseURL, img, imgVersion, auth string) (bool, error) {
-	log.Println("checking image: " + img + ":" + imgVersion)
 	_, statusCode, err := dockerImageDigest(registryBaseURL, img, imgVersion, auth)
 	if err != nil {
 		return false, err
@@ -917,7 +955,7 @@ func registryAuth(authURL, service, image, username, password string) (string, e
 	return auth.Token, nil
 }
 
-func rancherPrimeArtifact(url string) ([]string, error) {
+func ImagesListFromArtifact(url string) ([]string, error) {
 	httpClient := ecmHTTP.NewClient(time.Second * 15)
 	res, err := httpClient.Get(url)
 	if err != nil {

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -517,7 +517,7 @@ func formatContentLine(line string) string {
 // ImagesLocationsMap searches for missing images in a registry and creates a map with the locations of the images, or if they are missing
 // this map can be used to identify where which image should be synced from
 func ImagesLocationsMap(username, password string, concurrencyLimit int, checkImages, ignoreImages []string, targetRegistry string, imagesRegiestries []string) (map[string][]string, error) {
-	syncImagesRegistries := make(map[string][]string)
+	imagesLocations := make(map[string][]string)
 
 	var err error
 	missingFromTarget, err := MissingImagesFromRegistry(username, password, targetRegistry, concurrencyLimit, checkImages, ignoreImages)
@@ -532,7 +532,7 @@ func ImagesLocationsMap(username, password string, concurrencyLimit int, checkIm
 			return nil, err
 		}
 
-		syncImagesRegistries[registry], err = imagesDiff(lastMissingImages, missingFromRegistry)
+		imagesLocations[registry], err = imagesDiff(lastMissingImages, missingFromRegistry)
 		if err != nil {
 			return nil, err
 		}
@@ -540,9 +540,9 @@ func ImagesLocationsMap(username, password string, concurrencyLimit int, checkIm
 		lastMissingImages = missingFromRegistry
 	}
 
-	syncImagesRegistries["missing"] = lastMissingImages
+	imagesLocations["missing"] = lastMissingImages
 
-	return syncImagesRegistries, nil
+	return imagesLocations, nil
 }
 
 // imagesDiff compares two images slices and returns a slice with all images that are in the source slice, but not in the compare slice

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -34,7 +34,7 @@ func TestImageSliceToMap(t *testing.T) {
 	}
 	images, err = imageSliceToMap(imagesWithVersion, false)
 	if err != nil {
-		t.Error("didn't expected to flag image with version as malformed")
+		t.Error("didn't expect to flag image with version as malformed")
 	}
 }
 

--- a/release/rancher/rancher_test.go
+++ b/release/rancher/rancher_test.go
@@ -21,16 +21,20 @@ var (
 )
 
 func TestImageSliceToMap(t *testing.T) {
-	images, err := imageSliceToMap(imagesWithoutVersion)
+	images, err := imageSliceToMap(imagesWithoutVersion, true)
 	if err != nil {
 		t.Error(err)
 	}
 	if _, ok := images[imagesWithoutVersion[0]]; !ok {
 		t.Error("expected image not found on map " + imagesWithoutVersion[0])
 	}
-	images, err = imageSliceToMap(imagesWithVersion)
+	images, err = imageSliceToMap(imagesWithVersion, true)
 	if err == nil {
 		t.Error("expected to flag image with version as malformed")
+	}
+	images, err = imageSliceToMap(imagesWithVersion, false)
+	if err != nil {
+		t.Error("didn't expected to flag image with version as malformed")
 	}
 }
 


### PR DESCRIPTION
The generate images locations command will be used to find where to sync each image from, this is necessary to automate the sync process, especially now that different registries will require different tools to sync images.
```
release generate rancher images-locations \
    --registries "stgregistry.suse.com,docker.io" \
    -check-images "rancher/rancher:v2.11.1,rancher/rancher:v2.12.0-alpha7,rancher/rancher:v2.9.10-rc1,rancher/rancher:v2.12.1"
```