### PR TITLE
Don't cache the tonistiigi image

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -178,6 +178,7 @@ runs:
     uses: docker/setup-qemu-action@v3
     with:
       image: tonistiigi/binfmt:qemu-v8.1.5
+      cache-image: false
   - name: Setup Docker Buildx
     uses: docker/setup-buildx-action@v3
   - name: Install Cosign


### PR DESCRIPTION
Leads to wasted cache space in repos like RKE2 for releases. Since tags are unique, the image cannot be reused by other tags, resulting in a cache entry that never gets hit. 
![image](https://github.com/user-attachments/assets/9659357f-633c-4d0e-88d5-a830be337d16)

Signed-off-by: Derek Nola <derek.nola@suse.com>