### PR TITLE
Fix error return and improve rebase tag retrieval

### DIFF
--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -15,7 +15,8 @@ const (
 	RancherGithubOrganization = "rancher"
 	RancherRepositoryName     = "rancher"
 	K3sGithubOrganization     = "k3s-io"
-	K3sRepostitoryName        = "k3s"
+	K3sRepositoryName         = "k3s"
+	K3sK8sRepositoryName      = "kubernetes"
 )
 
 const (

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -112,7 +113,7 @@ func GenerateTags(ctx context.Context, ghClient *github.Client, r *ecmConfig.K3s
 
 	fmt.Println("rebasing and tagging")
 
-	tags, err := rebaseAndTag(r, u)
+	tags, err := rebaseAndTag(ghClient, r, u)
 	if err != nil {
 		return errors.New("failed to rebase and tag: " + err.Error())
 	}
@@ -226,8 +227,8 @@ func setupK8sRemotes(r *ecmConfig.K3sRelease, u *ecmConfig.User, sshKeyPath stri
 	return nil
 }
 
-func rebaseAndTag(r *ecmConfig.K3sRelease, u *ecmConfig.User) ([]string, error) {
-	rebaseOut, err := gitRebaseOnto(r)
+func rebaseAndTag(ghClient *github.Client, r *ecmConfig.K3sRelease, u *ecmConfig.User) ([]string, error) {
+	rebaseOut, err := gitRebaseOnto(ghClient, r)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +287,7 @@ func getAuth(privateKey string) (ssh.AuthMethod, error) {
 	return publicKeys, nil
 }
 
-func gitRebaseOnto(r *ecmConfig.K3sRelease) (string, error) {
+func gitRebaseOnto(ghClient *github.Client, r *ecmConfig.K3sRelease) (string, error) {
 	dir := filepath.Join(r.Workspace, "kubernetes")
 
 	// clean kubernetes directory before rebase
@@ -295,13 +296,41 @@ func gitRebaseOnto(r *ecmConfig.K3sRelease) (string, error) {
 		return "", err
 	}
 
-	commandArgs := strings.Split(fmt.Sprintf("rebase --onto %s %s %s-k3s1~1",
+	prevK3sTag, err := previousK3sReleaseTag(ghClient, r)
+	if err != nil {
+		return "", err
+	}
+
+	commandArgs := strings.Split(fmt.Sprintf("rebase --onto %s %s %s~1",
 		r.NewK8sVersion,
 		r.OldK8sVersion,
-		r.OldK8sVersion), " ")
+		prevK3sTag), " ")
 
 	fmt.Println("git ", commandArgs)
 	return ecmExec.RunCommand(dir, "git", commandArgs...)
+}
+
+func previousK3sReleaseTag(ghClient *github.Client, r *ecmConfig.K3sRelease) (string, error) {
+	ctx := context.Background()
+
+	maxIterations := 10
+
+	var latestRelease string
+
+	for i := 1; i < maxIterations; i++ {
+		releaseTag := fmt.Sprintf("%s-k3s%d", r.OldK8sVersion, i)
+		_, _, err := ghClient.Git.GetRef(ctx, ecmConfig.K3sGithubOrganization, ecmConfig.K3sK8sRepositoryName, "tags/"+releaseTag)
+		if err != nil {
+			if ghErr, ok := err.(*github.ErrorResponse); ok && ghErr.Response.StatusCode == http.StatusNotFound {
+				return latestRelease, nil
+			}
+			return "", fmt.Errorf("error getting Git ref for tag '%s': %w", releaseTag, err)
+		}
+
+		latestRelease = releaseTag
+	}
+
+	return "", errors.New("no Git ref found with k8s version: " + r.OldK8sVersion)
 }
 
 func goVersion(r *ecmConfig.K3sRelease) (string, error) {
@@ -317,14 +346,20 @@ func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 		return "", err
 	}
 
-	depList := dep["dependencies"].([]interface{})
+	depList := dep["dependencies"].([]any)
 
 	for _, v := range depList {
-		item := v.(map[interface{}]interface{})
-		itemName := item["name"]
+		var itemName, version string
+		switch item := v.(type) {
+		case map[string]any:
+			itemName = fmt.Sprintf("%v", item["name"])
+			version = fmt.Sprintf("%v", item["version"])
+		case map[any]any:
+			itemName = fmt.Sprintf("%v", item["name"])
+			version = fmt.Sprintf("%v", item["version"])
+		}
 		if itemName == "golang: upstream version" {
-			version := item["version"]
-			return version.(string), nil
+			return version, nil
 		}
 	}
 

--- a/release/kdm/create_nodes.go
+++ b/release/kdm/create_nodes.go
@@ -73,6 +73,14 @@ func createChartEntryNode(repo, version string) *yaml.Node {
 	}
 }
 
+// createAliasNode creates a new alias node that points to an anchor.
+func createAliasNode(anchorName string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.AliasNode,
+		Value: anchorName,
+	}
+}
+
 // strictlyAlphanumeric sanitizes a string to be purely alphanumeric.
 func strictlyAlphanumeric(input string) string {
 	var sb strings.Builder

--- a/release/kdm/rke2.go
+++ b/release/kdm/rke2.go
@@ -89,12 +89,12 @@ func UpdateRKE2Channels(versions []string) error {
 func (u *RKE2ChannelsUpdater) parseYaml(filename string) error {
 	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var rke2channels RKE2Channels
 	if err = yaml.Unmarshal(yamlBytes, &rke2channels); err != nil {
-		return nil
+		return err
 	}
 
 	u.channels = rke2channels
@@ -102,7 +102,7 @@ func (u *RKE2ChannelsUpdater) parseYaml(filename string) error {
 	var rootNode yaml.Node
 	err = yaml.Unmarshal(yamlBytes, &rootNode)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if rootNode.Kind != yaml.DocumentNode || len(rootNode.Content) == 0 {
@@ -305,7 +305,7 @@ func (u *RKE2ChannelsUpdater) addRelease(release Release) error {
 	// defining featureVersions
 	sanitizedFeatureVersionsAnchor := strictlyAlphanumeric(prevRelease.featureVersionsAnchor) // e.g., "v1216rke2r1"
 	u.tagReplacements[sanitizedFeatureVersionsAnchor] = prevRelease.featureVersionsAnchor
-	newReleaseContent = append(newReleaseContent, createScalarNode("featureVersions"), createScalarNode(sanitizedFeatureVersionsAnchor))
+	newReleaseContent = append(newReleaseContent, createScalarNode("featureVersions"), createAliasNode(sanitizedFeatureVersionsAnchor))
 
 	newReleaseNode := &yaml.Node{
 		Kind:    yaml.MappingNode,


### PR DESCRIPTION
This PR addresses:
- the K3s rebase from `release generate k3s tags v1.32.4`
    - It was hardcoded to use `k3s1` suffix, now there's an implementation to retrieve the latest release for that K8s release.
- `goVersion(...)` error, it was complaining a type mismatch, fixed by adding a switch case to handle both `map[any]any` and `map[string]any`
- The way `featureVersions` field was being populated when generating RKE2 KDM Charts, from value to anchor.
- Fixed small typos.