### PR TITLE
Specify `slsactl` version to avoid `null`

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -183,7 +183,12 @@ runs:
     uses: docker/setup-buildx-action@v3
   - name: Install Cosign
     uses: sigstore/cosign-installer@v3.5.0
-  - uses: rancherlabs/slsactl/actions/install-slsactl@5dabfd2b8590a8c90d6f64b1c6ee215e24ed3bfd # v0.0.6
+  - name: Install slsactl
+    env:
+      SLSACTL_VERSION: v0.0.14
+    uses: rancherlabs/slsactl/actions/install-slsactl@${SLSACTL_VERSION}
+    with:
+      version: ${SLSACTL_VERSION}
 
   - name: Build and push image [Prime]
     shell: bash


### PR DESCRIPTION
Resolves #620.

When installing `slsactl`, the `latest` version is obtained with the following command, but this frequently returns `null`.
```
VERSION=$(curl -s 'https://api.github.com/repos/rancherlabs/slsactl/releases/latest' | jq -r '.tag_name')
```

Therefore, specify the version to avoid `null`.