### PR TITLE
General K3s release code improvements

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -451,7 +451,7 @@ func runTagScript(r *ecmConfig.K3sRelease, gitConfigFile, wrapperImageTag string
 		"-e", "GOCACHE=" + containerGoCachePath,
 		"-w", containerK8sPath,
 		wrapperImageTag,
-		"./tag.sh", r.NewK8sVersion + "-k3s1",
+		"./tag.sh", r.NewK8sVersion + "-" + r.NewSuffix,
 	}
 
 	fmt.Println("running tag script")


### PR DESCRIPTION
- Add `K8sBuildDependencies` struct to unmarshal k8s/k8s dependencies
- Switch hardcoded `-k3s1` suffix to dynamic `NewSuffix` value that is retrieved from `.ecm-distro-tools/config.json`
- Add `[release-1.X]` prefix to K3s PRs titles 