### PR TITLE
increase releases per page for pre-release versions

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -751,7 +751,10 @@ func LatestRC(ctx context.Context, owner, repo, k8sVersion, projectSuffix string
 func LatestPreRelease(ctx context.Context, client *github.Client, owner, repo, version, preReleaseSuffix string) (*string, error) {
 	var versions []*github.RepositoryRelease
 
-	allReleases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
+	allReleases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{
+		Page:    0,
+		PerPage: 40,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With the default page size, sometimes the latest pre-release for a version is not found. Increasing it to 40 doesn't guarantee, but it has worked with rcs.