### PR TITLE
refactor release generate rancher artifacts-index

### DIFF
--- a/release/prime/artifacts.go
+++ b/release/prime/artifacts.go
@@ -1,0 +1,337 @@
+package prime
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	rancherImagesBaseURL     = "https://github.com/rancher/rancher/releases/download/"
+	rancherImagesFileName    = "/rancher-images.txt"
+	rancherHelmRepositoryURL = "https://releases.rancher.com/server-charts/latest/index.yaml"
+	rancherArtifactsBucket   = "prime-artifacts"
+	rancherArtifactsPrefix   = "rancher/v"
+	rke2ArtifactsPrefix      = "rke2/v"
+	rancherArtifactsBaseURL  = "https://prime.ribs.rancher.io"
+)
+
+type ArtifactsIndexContent struct {
+	GA         ArtifactsIndexContentGroup `json:"ga"`
+	PreRelease ArtifactsIndexContentGroup `json:"preRelease"`
+}
+
+type ArtifactsIndexVersions struct {
+	Versions      []string            `json:"versions"`
+	VersionsFiles map[string][]string `json:"versionsFiles"`
+}
+
+type ArtifactsIndexContentGroup struct {
+	Rancher ArtifactsIndexVersions
+	RKE2    ArtifactsIndexVersions
+	BaseURL string `json:"baseUrl"`
+}
+
+type ArtifactLister interface {
+	List(ctx context.Context) (rancherKeys []string, rke2Keys []string, err error)
+}
+
+type ArtifactBucket struct {
+	bucket string
+	client *s3.Client
+}
+
+func NewArtifactBucket(client *s3.Client) ArtifactBucket {
+	return ArtifactBucket{
+		bucket: rancherArtifactsBucket,
+		client: client,
+	}
+}
+
+func (a ArtifactBucket) List(ctx context.Context) ([]string, []string, error) {
+	rancherKeys, err := listS3Objects(ctx, a.client, a.bucket, rancherArtifactsPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	rke2Keys, err := listS3Objects(ctx, a.client, a.bucket, rke2ArtifactsPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rancherKeys, rke2Keys, nil
+}
+
+type ArtifactDir struct {
+	dir string
+}
+
+func NewArtifactDir(dir string) ArtifactDir {
+	return ArtifactDir{dir}
+}
+
+func (a ArtifactDir) List(ctx context.Context) ([]string, []string, error) {
+	var rancherKeys, rke2Keys []string
+	err := filepath.WalkDir(a.dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(a.dir, p)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "rancher/v") {
+			rancherKeys = append(rancherKeys, rel)
+		} else if strings.HasPrefix(rel, "rke2/v") {
+			rke2Keys = append(rke2Keys, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return rancherKeys, rke2Keys, nil
+}
+
+// GenerateArtifactsIndex lists artifacts and writes index.html and index-prerelease.html
+func GenerateArtifactsIndex(ctx context.Context, outPath string, ignoreVersions []string, lister ArtifactLister) error {
+	ignore := make(map[string]bool, len(ignoreVersions))
+	for _, v := range ignoreVersions {
+		ignore[v] = true
+	}
+	rancherKeys, rke2Keys, err := lister.List(ctx)
+	if err != nil {
+		return err
+	}
+	content := generateArtifactsIndexContent(rancherKeys, rke2Keys, ignore)
+	gaIndex, err := generateArtifactsHTML(content.GA)
+	if err != nil {
+		return err
+	}
+	preReleaseIndex, err := generateArtifactsHTML(content.PreRelease)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outPath, "index.html"), gaIndex, 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outPath, "index-prerelease.html"), preReleaseIndex, 0644)
+}
+
+func generateArtifactsIndexContent(rancherKeys, rke2Keys []string, ignoreVersions map[string]bool) ArtifactsIndexContent {
+	indexContent := ArtifactsIndexContent{
+		GA: ArtifactsIndexContentGroup{
+			Rancher: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			RKE2: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			BaseURL: rancherArtifactsBaseURL,
+		},
+		PreRelease: ArtifactsIndexContentGroup{
+			Rancher: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			RKE2: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			BaseURL: rancherArtifactsBaseURL,
+		},
+	}
+
+	indexContent.GA.Rancher, indexContent.PreRelease.Rancher = parseVersionsFromKeys(rancherKeys, "rancher/", ignoreVersions)
+	indexContent.GA.RKE2, indexContent.PreRelease.RKE2 = parseVersionsFromKeys(rke2Keys, "rke2/", ignoreVersions)
+
+	return indexContent
+}
+
+// parseVersionsFromKeys extracts versions and files from keys and returns GA and pre-release version structs
+func parseVersionsFromKeys(keys []string, prefix string, ignoreVersions map[string]bool) (ArtifactsIndexVersions, ArtifactsIndexVersions) {
+	var versions []string
+	versionsFiles := make(map[string][]string)
+
+	gaVersions := ArtifactsIndexVersions{
+		Versions:      []string{},
+		VersionsFiles: map[string][]string{},
+	}
+
+	preReleaseVersions := ArtifactsIndexVersions{
+		Versions:      []string{},
+		VersionsFiles: map[string][]string{},
+	}
+
+	for _, key := range keys {
+		if !strings.Contains(key, prefix) {
+			continue
+		}
+		keyFile := strings.Split(strings.TrimPrefix(key, prefix), "/")
+		if len(keyFile) < 2 || keyFile[1] == "" {
+			continue
+		}
+		version := keyFile[0]
+		file := keyFile[1]
+
+		if _, ok := ignoreVersions[version]; ok {
+			continue
+		}
+
+		if _, ok := versionsFiles[version]; !ok {
+			versions = append(versions, version)
+		}
+		versionsFiles[version] = append(versionsFiles[version], file)
+	}
+
+	semver.Sort(versions)
+
+	// starting from the last index will result in a newest to oldest sorting
+	for i := len(versions) - 1; i >= 0; i-- {
+		version := versions[i]
+		// only non ga releases contains '-' e.g: -rc, -hotfix
+		if strings.Contains(version, "-") {
+			preReleaseVersions.Versions = append(preReleaseVersions.Versions, version)
+			preReleaseVersions.VersionsFiles[version] = versionsFiles[version]
+		} else {
+			gaVersions.Versions = append(gaVersions.Versions, version)
+			gaVersions.VersionsFiles[version] = versionsFiles[version]
+		}
+	}
+
+	return gaVersions, preReleaseVersions
+}
+
+func generateArtifactsHTML(content ArtifactsIndexContentGroup) ([]byte, error) {
+	tmpl, err := template.New("release-artifacts-index").Parse(artifactsIndexTemplate)
+	if err != nil {
+		return nil, err
+	}
+	buff := bytes.NewBuffer(nil)
+	if err := tmpl.ExecuteTemplate(buff, "release-artifacts-index", content); err != nil {
+		return nil, err
+	}
+
+	return buff.Bytes(), nil
+}
+
+func listS3Objects(ctx context.Context, s3Client *s3.Client, bucketName string, prefix string) ([]string, error) {
+	var keys []string
+	var continuationToken *string
+	isTruncated := true
+	for isTruncated {
+		objects, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            &bucketName,
+			Prefix:            &prefix,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, object := range objects.Contents {
+			keys = append(keys, *object.Key)
+		}
+		// used for pagination
+		continuationToken = objects.NextContinuationToken
+		// if the bucket has more keys
+		if objects.IsTruncated != nil && !*objects.IsTruncated {
+			isTruncated = false
+		}
+	}
+	return keys, nil
+}
+
+const artifactsIndexTemplate = `{{ define "release-artifacts-index" }}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Rancher Prime Artifacts</title>
+    <link rel="icon" type="image/png" href="https://prime.ribs.rancher.io/assets/img/favicon.png">
+    <style>
+    body { font-family: 'Courier New', monospace, Verdana, Geneneva; }
+    header { display: flex; flex-direction: row; justify-items: center; }
+    #rancher-logo { width: 200px; }
+    .project { margin-left: 20px; }
+    .release { margin-left: 40px; margin-bottom: 20px; }
+    .release h3 { margin-bottom: 0px; }
+    .files { margin-left: 60px; display: flex; flex-direction: column; }
+    .release-title { display: flex; flex-direction: row; }
+    .release-title-tag { margin-right: 20px; min-width: 70px; }
+    .release-title-expand { background-color: #2453ff; color: white; border-radius: 5px; border: none; }
+    .release-title-expand:hover, .expand-active{ background-color: white; color: #2453ff; border: 1px solid #2453ff; }
+    .hidden { display: none; overflow: hidden; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <img src="https://prime.ribs.rancher.io/assets/img/rancher-suse-logo-horizontal-color.svg" alt="rancher logo" id="rancher-logo" />
+      <h1>PRIME ARTIFACTS</h1>
+    </header>
+    <main>
+      <div class="project-rancher project">
+        <h2>rancher</h2>
+        {{ range $i, $version := .Rancher.Versions }}
+        <div class="release-{{ $version }} release">
+          <div class="release-title">
+						<b class="release-title-tag">{{ $version }}</b>
+            <button onclick="expand('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">expand</button>
+          </div>
+          <div class="files" id="release-{{ $version }}-files">
+            <ul>
+              {{ range index $.Rancher.VersionsFiles $version }}
+              <li><a href="{{ $.BaseURL }}/rancher/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/rancher/{{ $version }}/{{ . }}</a></li>
+              {{ end }}
+            </ul>
+          </div>
+        </div>
+				{{ end }}
+      </div>
+	  <div class="project-rke2 project">
+        <h2>rke2</h2>
+        {{ range $i, $version := .RKE2.Versions }}
+        <div class="release-{{ $version }} release">
+          <div class="release-title">
+						<b class="release-title-tag">{{ $version }}</b>
+            <button onclick="expand('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">expand</button>
+          </div>
+          <div class="files" id="release-{{ $version }}-files">
+            <ul>
+              {{ range index $.RKE2.VersionsFiles $version }}
+              <li><a href="{{ $.BaseURL }}/rke2/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/rke2/{{ $version }}/{{ . }}</a></li>
+              {{ end }}
+            </ul>
+          </div>
+        </div>
+		{{ end }}
+      </div>
+    </main>
+  <script>
+    hideFiles()
+    function expand(tag) {
+      const filesId = "release-" + tag + "-files"
+      const expandButtonId = "release-" + tag + "-expand"
+      document.getElementById(filesId).classList.toggle("hidden")
+      document.getElementById(expandButtonId).classList.toggle("expand-active")
+    }
+    function hideFiles() {
+        const fileDivs = document.querySelectorAll(".files")
+        fileDivs.forEach(f => f.classList.add("hidden"))
+    }
+  </script>
+  </body>
+</html>
+{{end}}`

--- a/release/prime/artifacts_test.go
+++ b/release/prime/artifacts_test.go
@@ -1,0 +1,74 @@
+package prime
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestGenerateArtifactsIndexContentGA(t *testing.T) {
+	rancherKeys := []string{"rancher/v2.10.0/images.txt"}
+	rke2Keys := []string{"rke2/v1.30.1+rke2r1/images.txt"}
+	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, nil)
+	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.10.0"}) {
+		t.Fatalf("unexpected GA rancher versions: %v", got.GA.Rancher.Versions)
+	}
+	if len(got.PreRelease.Rancher.Versions) != 0 {
+		t.Fatalf("expected no prerelease rancher versions, got %v", got.PreRelease.Rancher.Versions)
+	}
+	if !slices.Equal(got.GA.RKE2.Versions, []string{"v1.30.1+rke2r1"}) {
+		t.Fatalf("unexpected GA rke2 versions: %v", got.GA.RKE2.Versions)
+	}
+	if len(got.PreRelease.RKE2.Versions) != 0 {
+		t.Fatalf("expected no prerelease rke2 versions, got %v", got.PreRelease.RKE2.Versions)
+	}
+}
+
+func TestGenerateArtifactsIndexContentPreRelease(t *testing.T) {
+	rancherKeys := []string{
+		"rancher/v2.9.0-rc1/images.txt",
+		"rancher/v2.9.0-rc1/foo.txt",
+		"rancher/v2.9.0-hotfix-1/images.txt",
+	}
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil)
+	wantPre := []string{"v2.9.0-rc1", "v2.9.0-hotfix-1"}
+	if !slices.Equal(got.PreRelease.Rancher.Versions, wantPre) {
+		t.Fatalf("unexpected prerelease versions: %v", got.PreRelease.Rancher.Versions)
+	}
+	files := got.PreRelease.Rancher.VersionsFiles["v2.9.0-rc1"]
+	if !slices.Equal(files, []string{
+		"images.txt",
+		"foo.txt",
+	}) {
+		t.Fatalf("unexpected files for rc1: %v", files)
+	}
+}
+
+func TestGenerateArtifactsIndexContentIgnoredVersions(t *testing.T) {
+	rancherKeys := []string{
+		"rancher/v2.8.1/images.txt",
+		"rancher/v2.8.2/images.txt",
+	}
+	ignore := map[string]bool{"v2.8.1": true}
+	got := generateArtifactsIndexContent(rancherKeys, nil, ignore)
+	if len(got.GA.Rancher.Versions) != 1 || got.GA.Rancher.Versions[0] != "v2.8.2" {
+		t.Fatalf("expected only v2.8.2, got %v", got.GA.Rancher.Versions)
+	}
+	if _, ok := got.GA.Rancher.VersionsFiles["v2.8.1"]; ok {
+		t.Fatalf("ignored version present in files map")
+	}
+}
+
+func TestGenerateArtifactsIndexContentSkipUnexpectedKeys(t *testing.T) {
+	rancherKeys := []string{
+		"unexpected/v2.10.0/file.txt",
+		"rancher/v2.11.0/",
+		"rancher/v2.11.0/file.txt",
+	}
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil)
+	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.11.0"}) {
+		t.Fatalf("expected only valid version captured, got %v", got.GA.Rancher.Versions)
+	}
+	if files := got.GA.Rancher.VersionsFiles["v2.11.0"]; !slices.Equal(files, []string{"file.txt"}) {
+		t.Fatalf("unexpected files for v2.11.0: %v", files)
+	}
+}


### PR DESCRIPTION
This PR refactors artifacts-index generation to prevent errors when using the command in GitHub workflows, and to make it easier to test changes to the html.

- Moves GenerateArtifactsIndex from package `release/rancher` package to `release/prime` to reflect use by multiple projects.
- Hardcodes known versions that must be skipped.
- `--dir` will read artifacts from a local directory, rather than the production s3 bucket, for testing purposes;
- `--write-path` is now optional.
- Adds unit tests.

To verify that these changes produce no change in html output:

```sh
go run ./cmd/release generate rancher artifacts-index
curl https://prime.ribs.rancher.io/index-prerelease.html -o index-prerelease-orig.html
curl https://prime.ribs.rancher.io/index.html -o index-orig.html
diff -q index.html index-orig.html
diff -q index-prerelease.html index-prerelease-orig.html
```