### PR TITLE
Switch Image Build logic from Releases to Tags

### DIFF
--- a/actions/sync-upstream-release/action.yml
+++ b/actions/sync-upstream-release/action.yml
@@ -66,7 +66,7 @@ runs:
   using: 'composite'
   steps:
     - name: setup ecm-distro-tools
-      uses: rancher/ecm-distro-tools@v0.58.1
+      uses: rancher/ecm-distro-tools@v0.58.3
 
     - name: 'Generate config file'
       shell: bash

--- a/release/imagebuild/image_build.go
+++ b/release/imagebuild/image_build.go
@@ -2,6 +2,7 @@ package imagebuild
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -146,7 +147,7 @@ func isTagOlderThanCutoff(ctx context.Context, client *github.Client, owner, rep
 		tagDate = commit.Committer.GetDate()
 
 	default:
-		return false, fmt.Errorf("unknown object type '%s' for tag '%s'", ref.Object.GetType(), tagName)
+		return false, errors.New("unknown object type '" + ref.Object.GetType() + "' for tag '" + tagName + "'")
 	}
 
 	// Compare the fetched date with the cutoff and return the result.


### PR DESCRIPTION
Switched to tags because there're a couple of upstream repos that don't do releases, just tags, and because the returned tags are in lexicographical order we need to increase the number of returned tags to make sure that it will

Also added a logic to ignore releases that are older than two day, because in some local tests the logic was trying to create releases of pretty old upstream releases.