### PR TITLE
Ignore upstream tags with '-dev' suffix and retrieve all upstream tags

### DIFF
--- a/actions/sync-upstream-release/action.yml
+++ b/actions/sync-upstream-release/action.yml
@@ -66,7 +66,7 @@ runs:
   using: 'composite'
   steps:
     - name: setup ecm-distro-tools
-      uses: rancher/ecm-distro-tools@v0.58.3
+      uses: rancher/ecm-distro-tools@v0.58.4
 
     - name: 'Generate config file'
       shell: bash


### PR DESCRIPTION
We now fetch **all** upstream tags, not just the first page. This fixes an issue where newer tags were sometimes missed due to Git's lexicographical sorting. Our existing safeguard that ignores tags older than two days prevents us from creating releases from old tags that are now being fetched.

Also the upstream tag validation has been improved to only process stable releases. We now use `semver.Prerelease()` to filter out any tags with suffixes, for example:
- `v3.21.1` will be created
- `v3.21.1-typha` skipped
- `v3.21.1-pod2daemon`  skipped
- `v3.24.2-0.dev` skipped
