### PR TITLE
`publish-image` Add conditional for Windows runners

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -175,14 +175,19 @@ runs:
       password: ${{ inputs.prime-password }}
 
   - name: Setup QEMU
+    if: runner.os != 'Windows'
     uses: docker/setup-qemu-action@v3
     with:
       image: tonistiigi/binfmt:qemu-v8.1.5
       cache-image: false
+
   - name: Setup Docker Buildx
+    if: runner.os != 'Windows'
     uses: docker/setup-buildx-action@v3
+
   - name: Install Cosign
     uses: sigstore/cosign-installer@v3.5.0
+
   - uses: rancherlabs/slsactl/actions/install-slsactl@5dabfd2b8590a8c90d6f64b1c6ee215e24ed3bfd # v0.0.6
 
   - name: Build and push image [Prime]


### PR DESCRIPTION
Basically if we try to install QEMU on a Windows runners it will fail, and we are able to use the context `runner.os` to check the current runner's OS. https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#runner-context