### PR TITLE
publish-image: Disable landlock for slsactl

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -244,3 +244,5 @@ runs:
 
       cat provenance-slsav1.json
       cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${IMG_NAME}"
+    env:
+      LANDLOCK_MODE: DISABLED


### PR DESCRIPTION
Landlock was enabled by default recently and is failing to download provenance during the attestation process. This will be fixed as part of: https://github.com/rancherlabs/slsactl/pull/170.

In the mean time, disable landlock. This can be undone after slsactl is bumped to the next release.