### PR TITLE
publish-image: Ensure fully qualified image name

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -193,7 +193,7 @@ runs:
       export IID_FILE_FLAG="--iidfile ${IID_FILE}"
       
       make ${{ inputs.make-target }}
-      IMG_NAME="${REPO}/${{ inputs.image }}@$(head -n 1 ${IID_FILE})"
+      IMG_NAME="${REPO}/${{ inputs.image }}:${TAG}@$(head -n 1 ${IID_FILE})"
 
       IDENTITY_REGISTRY=${IDENTITY_REGISTRY:-"$REGISTRY"}
       IDENTITY="$IDENTITY_REGISTRY/${{ inputs.prime-repo }}/${{ inputs.image }}"


### PR DESCRIPTION
The verification process that takes places during the slsav1 provenance generation requires a tag to correctly ascertain the signing subject. This ensures that alongside the digest which is required for the cosign sign command, a tag is added to the image, so that later on in the process it can be used by slsactl.