### PR TITLE
Add support for releases that skipped the previous one

### DIFF
--- a/release/kdm/rke2.go
+++ b/release/kdm/rke2.go
@@ -180,9 +180,17 @@ func (u *RKE2ChannelsUpdater) getPreviousVersion(version string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	if release > 1 {
-		// for releases higher than 1, we can just return the previous one.
-		return fmt.Sprintf(rke2VersionTemplate, major, minor, patch, release-1), nil
+
+	for i := release; i > 1; i-- {
+		prevVersion := fmt.Sprintf(rke2VersionTemplate, major, minor, patch, i)
+		_, err := u.previousReleasePos(prevVersion)
+		if err != nil {
+			if i == 1 {
+				return "", err
+			}
+			continue
+		}
+		return prevVersion, nil
 	}
 
 	// when the patch number is 0, e.g "v1.33.0+rke2r1" we need


### PR DESCRIPTION
This fixes a bug where the `release generate kdm rke2` command would crash if we skipped a revision number (like going from `r1` straight to `r3`).

Previously, the code specifically looked for the release right before the current one (rN-1) and failed if it wasn't there. I changed the logic to check backwards (rN, rN-1, ... r1) until it finds the latest release that actually exists in `channels-rke2.yaml`.