### PR TITLE
Fix k3s anchors and add project toggle

### DIFF
--- a/release/prime/artifacts.go
+++ b/release/prime/artifacts.go
@@ -369,32 +369,32 @@ const artifactsIndexTemplate = `{{ define "release-artifacts-index" }}
 				</div>
 			</div>
 		</main>
-	<script>
-	hideFiles()
-	function toggleProject(project) {
-		const projectId = "project-" + project + "-releases"
-		const expandButtonId = "project-" + project + "-expand"
-		toggleSection(projectId, expandButtonId)
-	}
-	function toggleFiles(tag) {
-		const filesId = "release-" + tag + "-files"
-		const expandButtonId = "release-" + tag + "-expand"
-		toggleSection(filesId, expandButtonId)
-	}
-	function toggleSection(sectionId, buttonId) {
-		const button = document.getElementById(buttonId)
-		document.getElementById(sectionId).classList.toggle("hidden")
-		button.classList.toggle("expand-active")
-
-		button.innerText == "hide" ? button.innerText = "show" : button.innerText = "hide"
-	}
-	function hideFiles() {
-		const files = document.getElementsByClassName('files')
-		for (let i = 0; i < files.length; i++) {
-		files[i].classList.add('hidden')
+		<script>
+		hideFiles()
+		function toggleProject(project) {
+			const projectId = "project-" + project + "-releases"
+			const expandButtonId = "project-" + project + "-expand"
+			toggleSection(projectId, expandButtonId)
 		}
-	}
-	</script>
+		function toggleFiles(tag) {
+			const filesId = "release-" + tag + "-files"
+			const expandButtonId = "release-" + tag + "-expand"
+			toggleSection(filesId, expandButtonId)
+		}
+		function toggleSection(sectionId, buttonId) {
+			const button = document.getElementById(buttonId)
+			document.getElementById(sectionId).classList.toggle("hidden")
+			button.classList.toggle("expand-active")
+
+			button.innerText == "hide" ? button.innerText = "show" : button.innerText = "hide"
+		}
+		function hideFiles() {
+			const files = document.getElementsByClassName('files')
+			for (let i = 0; i < files.length; i++) {
+			files[i].classList.add('hidden')
+			}
+		}
+		</script>
 	</body>
 </html>
 {{end}}`


### PR DESCRIPTION
Closes: #769 

1. Add anchors to `k3s`
    <img width="789" height="392" alt="image" src="https://github.com/user-attachments/assets/f0404800-c77b-4c83-9d39-f375b4f09190" />
2. Add `hide/show` button to projects and rename buttons from `expand` to `hide/show`
<img width="789" height="392" alt="image" src="https://github.com/user-attachments/assets/22096d95-0443-4f2f-b73b-b36127d3cb5f" />
<img width="789" height="392" alt="image" src="https://github.com/user-attachments/assets/1670419f-f9d3-4c8a-87eb-c5ad6a1ac8d2" />
Projects are visible by default, and files are still hidden by default.
3. Fix code indentation.
