### PR TITLE
`generate kdm rke2` generation now supports latest releases (rke2rN)

### DIFF
--- a/release/kdm/rke2.go
+++ b/release/kdm/rke2.go
@@ -214,7 +214,7 @@ func (u *RKE2ChannelsUpdater) getPreviousVersion(version string) (string, error)
 		v := fmt.Sprintf(rke2VersionTemplate, major, minor, patch-1, i)
 		if _, err := u.previousReleasePos(v); err != nil {
 			if prevVersion == "" {
-				return "", errors.New("previous release not found for: " + version)
+				return "", err
 			}
 		} else {
 			prevVersion = v


### PR DESCRIPTION
This PR adjusts the `generate kdm rke2` command to support adding new patches when the previous release is jumped (for example from `v1.32.11+rke2r1` to `v1.32.11+rke2r3`).

Also improves how insertion of new `rke2rN` (where N > 1) releases are handled.