### PR TITLE
add prime make target input to publish image

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -169,8 +169,9 @@ runs:
       echo "MAKE_TARGET=${MAKE_TARGET}" >> "${GITHUB_ENV}"
 
       if [[ -z "${PRIME_MAKE_TARGET}" ]]; then
-        echo "PRIME_MAKE_TARGET=${MAKE_TARGET}" >> "${GITHUB_ENV}"
+        PRIME_MAKE_TARGET=${MAKE_TARGET}
       fi
+      echo "PRIME_MAKE_TARGET=${PRIME_MAKE_TARGET}" >> "${GITHUB_ENV}"
 
   # Login to all registries before starting the pushing process.
   # Short-circuit if either fails. This should decrease the likelihood


### PR DESCRIPTION
Add a `prime-make-target` input to the `publish-image` action with an optional value, using the `make-target` input as a fallback to not break existing uses of this action.

Issue: https://github.com/rancher/ecm-distro-tools/issues/801