### PR TITLE
Update slsactl to v0.1.22

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -201,7 +201,7 @@ runs:
     uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
   - name: Install Cosign
     uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-  - uses: rancherlabs/slsactl/actions/install-slsactl@5a6d9061ca13fea58294b8b2f839e2665b581499 # v0.1.21
+  - uses: rancherlabs/slsactl/actions/install-slsactl@a5177a3699b7cabfa4797e883314dde7e40523cc # v0.1.22
 
   - name: Build and push image [Prime]
     shell: bash


### PR DESCRIPTION
The slsactl new version v0.1.22 supports the full BuildKitV1 spec.
https://github.com/rancherlabs/slsactl/releases/tag/v0.1.22