### PR TITLE
add make target directory inputs to publish-image action

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -233,7 +233,7 @@ runs:
           cmd+=(--directory "$PRIME_MAKE_TARGET_DIRECTORY")
       fi
 
-      cmd=+=("${PRIME_MAKE_TARGET}")
+      cmd+=("${PRIME_MAKE_TARGET}")
 
       # execute the command
       "${cmd[@]}"


### PR DESCRIPTION
Issue: #814

Adds the `make-target-directory` and `prime-make-target-directory` inputs to the publish-image action. When the directory input is set, the `--directory` flag is appended to the make command allowing repos to use makefiles in different directories.

Also updates the documentation