### PR TITLE
Update `goVersion(...)` to look for `.go-version`

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -23,7 +24,6 @@ import (
 	"github.com/rancher/ecm-distro-tools/repository"
 	ssh2 "golang.org/x/crypto/ssh"
 	"golang.org/x/mod/semver"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -341,8 +341,10 @@ type K8sBuildDependencies struct {
 	} `yaml:"dependencies"`
 }
 
+var reGoVersion = regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+
 func goVersion(r *ecmConfig.K3sRelease) (string, error) {
-	url := "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/" + r.NewK8sVersion + "/build/dependencies.yaml"
+	url := "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/" + r.NewK8sVersion + "/.go-version"
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -351,7 +353,7 @@ func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch dependencies.yaml, unexpected status code: %d %s (URL: %s)", resp.StatusCode, resp.Status, url)
+		return "", fmt.Errorf("failed to fetch '.go-version', unexpected status code: %d %s (URL: %s)", resp.StatusCode, resp.Status, url)
 	}
 
 	dat, err := io.ReadAll(resp.Body)
@@ -359,19 +361,11 @@ func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 		return "", err
 	}
 
-	var deps K8sBuildDependencies
-
-	if err := yaml.Unmarshal(dat, &deps); err != nil {
-		return "", err
+	if reGoVersion.Match(dat) {
+		return strings.TrimSpace(string(dat)), nil
 	}
 
-	for _, dep := range deps.Dependencies {
-		if dep.Name == "golang: upstream version" {
-			return dep.Version, nil
-		}
-	}
-
-	return "", errors.New("can not find Go dependency")
+	return "", errors.New("invalid '.go-version' content: " + string(dat))
 }
 
 func buildGoWrapper(r *ecmConfig.K3sRelease) (string, error) {

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -23,7 +23,6 @@ import (
 	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/repository"
 	ssh2 "golang.org/x/crypto/ssh"
-	"golang.org/x/mod/semver"
 )
 
 const (
@@ -334,15 +333,6 @@ func previousK3sReleaseTag(ctx context.Context, ghClient *github.Client, r *ecmC
 	return "", errors.New("no Git ref found with k8s version: " + r.OldK8sVersion)
 }
 
-type K8sBuildDependencies struct {
-	Dependencies []struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
-	} `yaml:"dependencies"`
-}
-
-var reGoVersion = regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
-
 func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 	url := "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/" + r.NewK8sVersion + "/.go-version"
 
@@ -360,12 +350,12 @@ func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	if reGoVersion.Match(dat) {
-		return strings.TrimSpace(string(dat)), nil
+	ver, err := semver.NewVersion(string(dat))
+	if err != nil {
+		return "", errors.New("invalid '.go-version' content: " + string(dat))
 	}
 
-	return "", errors.New("invalid '.go-version' content: " + string(dat))
+	return ver.String(), nil
 }
 
 func buildGoWrapper(r *ecmConfig.K3sRelease) (string, error) {
@@ -743,9 +733,11 @@ func cleanGitRepo(dir string) error {
 
 func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sRelease, opts *repository.CreateReleaseOpts, rc bool) error {
 	fmt.Println("validating tag")
-	if !semver.IsValid(opts.Tag) {
+	_, err := semver.NewVersion(opts.Tag)
+	if err != nil {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
+
 	name := r.NewK8sVersion + "+" + r.NewSuffix
 	oldName := r.OldK8sVersion + "+" + r.OldSuffix
 


### PR DESCRIPTION
In this month's patch, upstream has moved away from setting the Go version in `build/dependencies.yaml`, and now their source of truth is the `.go-version` file.

Example:
- At K8s v1.35.1 you can still see the Go version: https://github.com/kubernetes/kubernetes/blob/v1.35.1/build/dependencies.yaml#L117-L124
- For K8s v1.35.3 there's no more the Go upstream entry: https://github.com/kubernetes/kubernetes/blob/v1.35.3/build/dependencies.yaml#L110-L116