### PR TITLE
fix update rancher ref on CLI commit message

### DIFF
--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -201,7 +201,7 @@ git add go.mod go.sum
 # Cleaning temp files/scripts
 git clean -f
 
-git commit --signoff -m "Update Rancher refs to ${RANCHER_VERSION}"
+git commit --signoff -m "Update Rancher refs to ${TAG}"
 
 # Push the changes if not a dry run
 if [ "${DRY_RUN}" = false ]; then


### PR DESCRIPTION
Issue: #793 

The commit message tried to use an environment variable that wasn't available. The `RANCHER_VERSION` variable was replaced by `TAG`