### PR TITLE
feat: add Harvester artifacts to artifacts index

### DIFF
--- a/release/prime/artifacts.go
+++ b/release/prime/artifacts.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	rancherArtifactsBucket  = "prime-artifacts"
-	rancherArtifactsPrefix  = "rancher/v"
-	rke2ArtifactsPrefix     = "rke2/v"
-	k3sArtifactsPrefix      = "k3s/v"
-	rancherArtifactsBaseURL = "https://prime.ribs.rancher.io"
+	rancherArtifactsBucket   = "prime-artifacts"
+	rancherArtifactsPrefix   = "rancher/v"
+	rke2ArtifactsPrefix      = "rke2/v"
+	k3sArtifactsPrefix       = "k3s/v"
+	harvesterArtifactsPrefix = "harvester/v"
+	rancherArtifactsBaseURL  = "https://prime.ribs.rancher.io"
 )
 
 type ArtifactsIndexContent struct {
@@ -32,14 +33,15 @@ type ArtifactsIndexVersions struct {
 }
 
 type ArtifactsIndexContentGroup struct {
-	Rancher ArtifactsIndexVersions
-	RKE2    ArtifactsIndexVersions
-	K3s     ArtifactsIndexVersions
-	BaseURL string
+	Rancher   ArtifactsIndexVersions
+	RKE2      ArtifactsIndexVersions
+	K3s       ArtifactsIndexVersions
+	Harvester ArtifactsIndexVersions
+	BaseURL   string
 }
 
 type ArtifactLister interface {
-	List(ctx context.Context) (rancherKeys []string, rke2Keys []string, k3sKeys []string, err error)
+	List(ctx context.Context) (rancherKeys []string, rke2Keys []string, k3sKeys []string, harvesterKeys []string, err error)
 }
 
 type ArtifactBucket struct {
@@ -54,20 +56,24 @@ func NewArtifactBucket(client *s3.Client) ArtifactBucket {
 	}
 }
 
-func (a ArtifactBucket) List(ctx context.Context) ([]string, []string, []string, error) {
+func (a ArtifactBucket) List(ctx context.Context) ([]string, []string, []string, []string, error) {
 	rancherKeys, err := listS3Objects(ctx, a.client, a.bucket, rancherArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	rke2Keys, err := listS3Objects(ctx, a.client, a.bucket, rke2ArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	k3sKeys, err := listS3Objects(ctx, a.client, a.bucket, k3sArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return rancherKeys, rke2Keys, k3sKeys, nil
+	harvesterKeys, err := listS3Objects(ctx, a.client, a.bucket, harvesterArtifactsPrefix)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return rancherKeys, rke2Keys, k3sKeys, harvesterKeys, nil
 }
 
 type ArtifactDir struct {
@@ -78,8 +84,8 @@ func NewArtifactDir(dir string) ArtifactDir {
 	return ArtifactDir{dir}
 }
 
-func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, error) {
-	var rancherKeys, rke2Keys, k3sKeys []string
+func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, []string, error) {
+	var rancherKeys, rke2Keys, k3sKeys, harvesterKeys []string
 	err := filepath.WalkDir(a.dir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -98,13 +104,15 @@ func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, er
 			rke2Keys = append(rke2Keys, rel)
 		} else if strings.HasPrefix(rel, "k3s/v") {
 			k3sKeys = append(k3sKeys, rel)
+		} else if strings.HasPrefix(rel, "harvester/v") {
+			harvesterKeys = append(harvesterKeys, rel)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return rancherKeys, rke2Keys, k3sKeys, nil
+	return rancherKeys, rke2Keys, k3sKeys, harvesterKeys, nil
 }
 
 // GenerateArtifactsIndex lists artifacts and writes index.html and index-prerelease.html
@@ -113,11 +121,11 @@ func GenerateArtifactsIndex(ctx context.Context, outPath string, ignoreVersions 
 	for _, v := range ignoreVersions {
 		ignore[v] = true
 	}
-	rancherKeys, rke2Keys, k3sKeys, err := lister.List(ctx)
+	rancherKeys, rke2Keys, k3sKeys, harvesterKeys, err := lister.List(ctx)
 	if err != nil {
 		return err
 	}
-	content := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, ignore)
+	content := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, harvesterKeys, ignore)
 	gaIndex, err := generateArtifactsHTML(content.GA)
 	if err != nil {
 		return err
@@ -132,7 +140,7 @@ func GenerateArtifactsIndex(ctx context.Context, outPath string, ignoreVersions 
 	return os.WriteFile(filepath.Join(outPath, "index-prerelease.html"), preReleaseIndex, 0o644)
 }
 
-func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, ignoreVersions map[string]bool) ArtifactsIndexContent {
+func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, harvesterKeys []string, ignoreVersions map[string]bool) ArtifactsIndexContent {
 	indexContent := ArtifactsIndexContent{
 		GA: ArtifactsIndexContentGroup{
 			Rancher: ArtifactsIndexVersions{
@@ -144,6 +152,10 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 				VersionsFiles: map[string][]string{},
 			},
 			K3s: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			Harvester: ArtifactsIndexVersions{
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
@@ -162,6 +174,10 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
+			Harvester: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
 			BaseURL: rancherArtifactsBaseURL,
 		},
 	}
@@ -169,6 +185,7 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 	indexContent.GA.Rancher, indexContent.PreRelease.Rancher = parseVersionsFromKeys(rancherKeys, "rancher/", ignoreVersions)
 	indexContent.GA.RKE2, indexContent.PreRelease.RKE2 = parseVersionsFromKeys(rke2Keys, "rke2/", ignoreVersions)
 	indexContent.GA.K3s, indexContent.PreRelease.K3s = parseVersionsFromKeys(k3sKeys, "k3s/", ignoreVersions)
+	indexContent.GA.Harvester, indexContent.PreRelease.Harvester = parseVersionsFromKeys(harvesterKeys, "harvester/", ignoreVersions)
 
 	return indexContent
 }
@@ -361,6 +378,30 @@ const artifactsIndexTemplate = `{{ define "release-artifacts-index" }}
 							<ul>
 							{{ range index $.K3s.VersionsFiles $version }}
 							<li><a href="{{ $.BaseURL }}/k3s/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/k3s/{{ $version }}/{{ . }}</a></li>
+							{{ end }}
+							</ul>
+						</div>
+					</div>
+					{{ end }}
+				</div>
+			</div>
+			<div class="project-harvester project">
+				<div class="flex-row">
+					<h2 id="harvester" class="project-title"><a class="anchor" href="#harvester">#</a>harvester</h2>
+					<button onclick="toggleProject('harvester')" id="project-harvester-expand" class="release-title-expand expand-active">hide</button>
+				</div>
+				<div id="project-harvester-releases">
+					{{ range $i, $version := .Harvester.Versions }}
+					<div id="harvester-{{ $version }}" class="release-{{ $version }} release">
+						<div class="flex-row">
+							<a class="anchor" href="#harvester-{{ $version }}">#</a>
+							<b class="release-title-tag">{{ $version }}</b>
+							<button onclick="toggleFiles('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">show</button>
+						</div>
+						<div class="files" id="release-{{ $version }}-files">
+							<ul>
+							{{ range index $.Harvester.VersionsFiles $version }}
+							<li><a href="{{ $.BaseURL }}/harvester/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/harvester/{{ $version }}/{{ . }}</a></li>
 							{{ end }}
 							</ul>
 						</div>

--- a/release/prime/artifacts_test.go
+++ b/release/prime/artifacts_test.go
@@ -9,7 +9,8 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	rancherKeys := []string{"rancher/v2.10.0/images.txt"}
 	rke2Keys := []string{"rke2/v1.30.1+rke2r1/images.txt"}
 	k3sKeys := []string{"k3s/v1.30.1+k3s1/images.txt"}
-	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, nil)
+	harvesterKeys := []string{"harvester/v1.8.1/harvester-v1.8.1-amd64.iso"}
+	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, harvesterKeys, nil)
 	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.10.0"}) {
 		t.Fatalf("unexpected GA rancher versions: %v", got.GA.Rancher.Versions)
 	}
@@ -28,6 +29,12 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	if len(got.PreRelease.K3s.Versions) != 0 {
 		t.Fatalf("expected no prerelease k3s versions, got %v", got.PreRelease.K3s.Versions)
 	}
+	if !slices.Equal(got.GA.Harvester.Versions, []string{"v1.8.1"}) {
+		t.Fatalf("unexpected GA harvester versions: %v", got.GA.Harvester.Versions)
+	}
+	if len(got.PreRelease.Harvester.Versions) != 0 {
+		t.Fatalf("expected no prerelease harvester versions, got %v", got.PreRelease.Harvester.Versions)
+	}
 }
 
 func TestGenerateArtifactsIndexContentPreRelease(t *testing.T) {
@@ -36,7 +43,7 @@ func TestGenerateArtifactsIndexContentPreRelease(t *testing.T) {
 		"rancher/v2.9.0-rc1/foo.txt",
 		"rancher/v2.9.0-hotfix-1/images.txt",
 	}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, nil)
 	wantPre := []string{"v2.9.0-rc1", "v2.9.0-hotfix-1"}
 	if !slices.Equal(got.PreRelease.Rancher.Versions, wantPre) {
 		t.Fatalf("unexpected prerelease versions: %v", got.PreRelease.Rancher.Versions)
@@ -56,7 +63,7 @@ func TestGenerateArtifactsIndexContentIgnoredVersions(t *testing.T) {
 		"rancher/v2.8.2/images.txt",
 	}
 	ignore := map[string]bool{"v2.8.1": true}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, ignore)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, ignore)
 	if len(got.GA.Rancher.Versions) != 1 || got.GA.Rancher.Versions[0] != "v2.8.2" {
 		t.Fatalf("expected only v2.8.2, got %v", got.GA.Rancher.Versions)
 	}
@@ -71,7 +78,7 @@ func TestGenerateArtifactsIndexContentSkipUnexpectedKeys(t *testing.T) {
 		"rancher/v2.11.0/",
 		"rancher/v2.11.0/file.txt",
 	}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, nil)
 	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.11.0"}) {
 		t.Fatalf("expected only valid version captured, got %v", got.GA.Rancher.Versions)
 	}


### PR DESCRIPTION
Add Harvester artifacts to the index page, following the k3s section.

Related issue: https://github.com/harvester/suse-virtualization-mgmt/issues/10

Test with the guidelines provided by @tashima42 (big thanks!).
```
# build
make release

# fake some files
mkdir -p dist/prime-artifacts/rancher/v2.13.1
mkdir -p dist/prime-artifacts/rke2/v1.35.2+rke2r1
mkdir -p dist/prime-artifacts/k3s/v1.35.2+k3s1
mkdir -p dist/prime-artifacts/harvester/v1.7.1

touch dist/prime-artifacts/rancher/v2.13.1/rancher-images.txt
touch dist/prime-artifacts/rke2/v1.35.2+rke2r1/rke2-images.txt
touch dist/prime-artifacts/k3s/v1.35.2+k3s1/k3s-images.txt
touch dist/prime-artifacts/harvester/v1.7.1/harvester-images.txt

# generate the page
./cmd/release/bin/release-darwin-arm64 generate rancher artifacts-index --config "{}" --dir ./dist/prime-artifacts --write-path ./dist/prime-artifacts
```


<img width="846" height="524" alt="Screenshot 2026-03-25 at 9 06 31 PM" src="https://github.com/user-attachments/assets/2d90f006-6e86-480e-94e4-aac0fa7114f9" />
