### PR TITLE
Small improvements in kdm generation and update nginx env name

### DIFF
--- a/release/kdm/rke2.go
+++ b/release/kdm/rke2.go
@@ -183,8 +183,9 @@ func (u *RKE2ChannelsUpdater) getPreviousVersion(version string) (string, error)
 
 	// for +rke2r2 and forward
 	if release > 1 {
-		for i := release; i > 1; i-- {
+		for i := release - 1; i > 0; i-- {
 			prevVersion := fmt.Sprintf(rke2VersionTemplate, major, minor, patch, i)
+			fmt.Println("checking for previous version: ", prevVersion)
 			_, err := u.previousReleasePos(prevVersion)
 			if err != nil {
 				if i == 1 {

--- a/release/release.go
+++ b/release/release.go
@@ -119,7 +119,7 @@ func (rd *rke2ReleaseNoteData) Fill(milestone string) error {
 	rd.CiliumVersion = imageTagVersion("cilium-cilium", rke2Repo, milestone)
 	rd.ContainerdVersion = containerdVersion
 	rd.MetricsServerVersion = imageTagVersion("metrics-server", rke2Repo, milestone)
-	rd.IngressNginxVersion = imageEnvVersion("INGRESS_NGINX_TAG", rke2Repo, milestone)
+	rd.IngressNginxVersion = imageEnvVersion("INGRESS_NGINX_HARDENED_TAG", rke2Repo, milestone)
 	rd.FlannelVersion = imageTagVersion("flannel", rke2Repo, milestone)
 	rd.MultusVersion = imageTagVersion("multus-cni", rke2Repo, milestone)
 	rd.CalicoVersion = imageTagVersion("calico-node", rke2Repo, milestone)
@@ -659,6 +659,10 @@ func imageEnvVersion(envName, repo, branchVersion string) string {
 
 	var regex = fmt.Sprintf(`^(%s)=.+$`, envName)
 	submatch := findInURL(imageListURL, regex, envName, true)
+	if len(submatch) == 0 {
+		logrus.Debugf("env %s not found in %s", envName, imageListURL)
+		return ""
+	}
 
 	return strings.Trim(submatch[0], envName+"=")
 }


### PR DESCRIPTION
- Updates Nginx env name from `INGRESS_NGINX_TAG` to `INGRESS_NGINX_HARDENED_TAG`.
- Fix a small bug in the `generate kdm` command, when it looks for previous releases for new entries +rke2rN, where N > 1;