### PR TITLE
Update `release tag rke2|k3s` commands to support Tag instead of Release

### DIFF
--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
@@ -65,80 +64,34 @@ var k3sTagSubCmd = &cobra.Command{
 }
 
 var rke2TagSubCmd = &cobra.Command{
-	Use:   "rke2",
+	Use:   "rke2 [ga,rc] [version]",
 	Short: "Tag rke2 releases",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
-
-		switch args[0] {
-		case "image-build-base":
-			if err := rke2.ImageBuildBaseRelease(ctx, client, dryRun); err != nil {
-				return err
-			}
-		case "image-build-kubernetes":
-			now := time.Now().UTC().Format("20060102")
-			suffix := "-rke2" + *tagRKE2Flags.ReleaseVersion + "-build" + now
-
-			if dryRun {
-				fmt.Println("dry-run:")
-				for _, version := range rootConfig.RKE2.Versions {
-					fmt.Println("\t" + version + suffix)
-				}
-			} else {
-				for _, version := range rootConfig.RKE2.Versions {
-					cro := repository.CreateReleaseOpts{
-						Owner:      "rancher",
-						Repo:       "image-build-kubernetes",
-						Branch:     "master",
-						Name:       version + suffix,
-						Prerelease: false,
-						Draft:      false,
-					}
-					if _, err := repository.CreateRelease(ctx, client, &cro); err != nil {
-						return err
-					}
-
-					fmt.Println("tag " + version + suffix + " created successfully")
-				}
-			}
-		case "rke2":
-			//
-		case "rpm":
-			if len(args) == 1 {
-				return errors.New("invalid rpm tag. expected {testinglatest|stable}")
-			}
-
-			rpmTag := fmt.Sprintf("+rke2%s.%s.%d", *tagRKE2Flags.ReleaseVersion, args[1], *tagRKE2Flags.RPMVersion)
-			if *tagRKE2Flags.RCVersion != "" {
-				rpmTag = fmt.Sprintf("+rke2%s-rc%s.%s.%d", *tagRKE2Flags.ReleaseVersion, *tagRKE2Flags.RCVersion, args[1], *tagRKE2Flags.RPMVersion)
-			}
-
-			if dryRun {
-				fmt.Print("(dry-run)\n\nTagging github.com/rancher/rke2-packaging:\n\n")
-				for _, version := range rootConfig.RKE2.Versions {
-					fmt.Println("\t" + version + rpmTag)
-				}
-			} else {
-				for _, version := range rootConfig.RKE2.Versions {
-					cro := repository.CreateReleaseOpts{
-						Owner:      "rancher",
-						Repo:       "rke2-packaging",
-						Branch:     "master",
-						Name:       version + rpmTag,
-						Tag:        version + rpmTag,
-						Prerelease: false,
-					}
-					if _, err := repository.CreateRelease(ctx, client, &cro); err != nil {
-						return err
-					}
-				}
-			}
-		default:
-			return errors.New("unrecognized resource")
+		if len(args) < 2 {
+			return errors.New("expected at least two arguments: [ga,rc] [version]")
 		}
 
-		return nil
+		rc, err := releaseTypePreRelease(args[0])
+		if err != nil {
+			return err
+		}
+
+		tag := args[1]
+		rke2Release, found := rootConfig.RKE2.Versions[tag]
+		if !found {
+			return NewVersionNotFoundError(tag, "rke2")
+		}
+
+		ctx := context.Background()
+		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+
+		opts := repository.CreateRefOpts{
+			Tag:    tag,
+			Repo:   rke2Release.RKE2RepoName,
+			Owner:  rke2Release.RKE2RepoOwner,
+			Branch: rke2Release.ReleaseBranch,
+		}
+		return rke2.CreateRef(ctx, ghClient, &rke2Release, &opts, rc)
 	},
 }
 

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -54,13 +54,13 @@ var k3sTagSubCmd = &cobra.Command{
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		opts := repository.CreateReleaseOpts{
+		opts := repository.CreateRefOpts{
 			Tag:    tag,
 			Repo:   "k3s",
 			Owner:  k3sRelease.K3sRepoOwner,
 			Branch: k3sRelease.ReleaseBranch,
 		}
-		return k3s.CreateRelease(ctx, ghClient, &k3sRelease, &opts, rc)
+		return k3s.CreateRef(ctx, ghClient, &k3sRelease, &opts, rc)
 	},
 }
 

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -88,6 +88,18 @@ type K3sRelease struct {
 	DryRun                        bool   `json:"dry_run"`
 }
 
+// RKE2Release
+type RKE2Release struct {
+	OldK8sVersion string `json:"old_k8s_version"`
+	NewK8sVersion string `json:"new_k8s_version"`
+	OldSuffix     string `json:"old_suffix"`
+	NewSuffix     string `json:"new_suffix"`
+	ReleaseBranch string `json:"release_branch"`
+	RKE2RepoOwner string `json:"rke2_repo_owner"`
+	RKE2RepoName  string `json:"rke2_repo_name"`
+	DryRun        bool   `json:"dry_run"`
+}
+
 // RancherRelease
 type RancherRelease struct {
 	ReleaseBranch string `json:"release_branch"`
@@ -105,7 +117,7 @@ type CLIRelease struct {
 
 // RKE2
 type RKE2 struct {
-	Versions []string `json:"versions"`
+	Versions map[string]RKE2Release `json:"versions"`
 }
 
 // ChartsRelease
@@ -223,7 +235,18 @@ func ExampleConfig() (string, error) {
 			},
 		},
 		RKE2: &RKE2{
-			Versions: []string{"v1.x.y"},
+			Versions: map[string]RKE2Release{
+				"v1.x.y": {
+					OldK8sVersion: "v1.x.z",
+					NewK8sVersion: "v1.x.y",
+					OldSuffix:     "k3s1",
+					NewSuffix:     "k3s1",
+					ReleaseBranch: "release-1.x",
+					DryRun:        false,
+					RKE2RepoOwner: "rancher",
+					RKE2RepoName:  "rke2",
+				},
+			},
 		},
 		Rancher: &Rancher{
 			Versions: map[string]RancherRelease{

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -792,3 +792,52 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sR
 	fmt.Println("release created: " + *createdRelease.HTMLURL)
 	return nil
 }
+
+func CreateRef(ctx context.Context, client *github.Client, r *ecmConfig.K3sRelease, opts *repository.CreateRefOpts, rc bool) error {
+	fmt.Println("validating tag")
+	_, err := semver.NewVersion(opts.Tag)
+	if err != nil {
+		return errors.New("tag isn't a valid semver: " + opts.Tag)
+	}
+
+	name := r.NewK8sVersion + "+" + r.NewSuffix
+
+	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, r.NewK8sVersion, r.NewSuffix, client)
+	if err != nil {
+		return err
+	}
+	if latestRC == nil && !rc {
+		return errors.New("couldn't find the latest RC")
+	}
+	if rc {
+		latestRCNumber := 1
+		if latestRC != nil {
+			trimmedRCNumber, _, found := strings.Cut(strings.TrimPrefix(*latestRC, r.NewK8sVersion+"-rc"), "+k3s")
+			if !found {
+				return errors.New("failed to parse rc number from " + *latestRC)
+			}
+			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
+			if err != nil {
+				return err
+			}
+			latestRCNumber = currentRCNumber + 1
+		}
+		name = r.NewK8sVersion + "-rc" + strconv.Itoa(latestRCNumber) + "+" + r.NewSuffix
+	}
+
+	opts.Tag = name
+
+	fmt.Printf("create ref options: %+v\n", *opts)
+
+	if r.DryRun {
+		fmt.Println("dry run, skipping creating tag")
+		return nil
+	}
+	createdRef, err := repository.CreateRef(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("ref created: " + *createdRef.URL)
+	return nil
+}

--- a/release/release.go
+++ b/release/release.go
@@ -756,9 +756,9 @@ func findInURL(url, regex, str string, checkStatusCode bool) []string {
 
 // LatestRC will get the latest rc created for the k8s version in either rke2 or k3s
 func LatestRC(ctx context.Context, owner, repo, k8sVersion, projectSuffix string, client *github.Client) (*string, error) {
-	var rcs []*github.RepositoryRelease
+	var rcs []*github.RepositoryTag
 
-	allReleases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{
+	allTags, _, err := client.Repositories.ListTags(ctx, owner, repo, &github.ListOptions{
 		Page:    0,
 		PerPage: 40,
 	})
@@ -766,13 +766,14 @@ func LatestRC(ctx context.Context, owner, repo, k8sVersion, projectSuffix string
 		return nil, err
 	}
 
-	for _, release := range allReleases {
-		if strings.Contains(*release.TagName, k8sVersion+"-rc") && strings.Contains(*release.TagName, projectSuffix) {
-			rcs = append(rcs, release)
+	for _, tag := range allTags {
+		tagName := *tag.Name
+		if strings.Contains(tagName, k8sVersion+"-rc") && strings.Contains(tagName, projectSuffix) {
+			rcs = append(rcs, tag)
 		}
 	}
 
-	return latestRelease(rcs), nil
+	return latestTag(rcs), nil
 }
 
 func LatestPreRelease(ctx context.Context, client *github.Client, owner, repo, version, preReleaseSuffix string) (*string, error) {
@@ -922,15 +923,41 @@ func Stats(ctx context.Context, client *github.Client, startDate, endDate time.T
 }
 
 func latestRelease(versions []*github.RepositoryRelease) *string {
+
 	sort.Slice(versions, func(i, j int) bool {
+
 		return versions[i].PublishedAt.Before(versions[j].PublishedAt.Time)
+
 	})
 
+	if len(versions) == 0 {
+
+		return nil
+
+	}
+
+	return versions[len(versions)-1].TagName
+
+}
+
+func latestTag(versions []*github.RepositoryTag) *string {
 	if len(versions) == 0 {
 		return nil
 	}
 
-	return versions[len(versions)-1].TagName
+	sort.Slice(versions, func(i, j int) bool {
+		nameI := *versions[i].Name
+		nameJ := *versions[j].Name
+
+		cmp := semver.Compare(nameI, nameJ)
+		if cmp == 0 {
+			return nameI < nameJ
+		}
+
+		return cmp < 0
+	})
+
+	return versions[len(versions)-1].Name
 }
 
 // rke2ChartVersion will return the version of the rke2 chart from the chart versions file

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -103,7 +103,7 @@ func CreateRef(ctx context.Context, client *github.Client, r *ecmConfig.RKE2Rele
 	if rc {
 		latestRCNumber := 1
 		if latestRC != nil {
-			trimmedRCNumber, _, found := strings.Cut(strings.TrimPrefix(*latestRC, r.NewK8sVersion+"-rc"), "+k3s")
+			trimmedRCNumber, _, found := strings.Cut(strings.TrimPrefix(*latestRC, r.NewK8sVersion+"-rc"), "+rke2r")
 			if !found {
 				return errors.New("failed to parse rc number from " + *latestRC)
 			}

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v84/github"
+	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
 	"github.com/rancher/ecm-distro-tools/docker"
 	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
+	"github.com/rancher/ecm-distro-tools/release"
+	"github.com/rancher/ecm-distro-tools/repository"
 	"github.com/sirupsen/logrus"
 )
 
@@ -76,6 +81,55 @@ func ImageBuildBaseRelease(ctx context.Context, ghClient *github.Client, dryRun 
 		}
 		logrus.Info("created release for version: " + imageBuildBaseTag)
 	}
+	return nil
+}
+
+func CreateRef(ctx context.Context, client *github.Client, r *ecmConfig.RKE2Release, opts *repository.CreateRefOpts, rc bool) error {
+	fmt.Println("validating tag")
+	_, err := semver.NewVersion(opts.Tag)
+	if err != nil {
+		return errors.New("tag isn't a valid semver: " + opts.Tag)
+	}
+
+	name := r.NewK8sVersion + "+" + r.NewSuffix
+
+	latestRC, err := release.LatestRC(ctx, opts.Owner, opts.Repo, r.NewK8sVersion, r.NewSuffix, client)
+	if err != nil {
+		return err
+	}
+	if latestRC == nil && !rc {
+		return errors.New("couldn't find the latest RC")
+	}
+	if rc {
+		latestRCNumber := 1
+		if latestRC != nil {
+			trimmedRCNumber, _, found := strings.Cut(strings.TrimPrefix(*latestRC, r.NewK8sVersion+"-rc"), "+k3s")
+			if !found {
+				return errors.New("failed to parse rc number from " + *latestRC)
+			}
+			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
+			if err != nil {
+				return err
+			}
+			latestRCNumber = currentRCNumber + 1
+		}
+		name = r.NewK8sVersion + "-rc" + strconv.Itoa(latestRCNumber) + "+" + r.NewSuffix
+	}
+
+	opts.Tag = name
+
+	fmt.Printf("create ref options: %+v\n", *opts)
+
+	if r.DryRun {
+		fmt.Println("dry run, skipping creating tag")
+		return nil
+	}
+	createdRef, err := repository.CreateRef(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("ref created: " + *createdRef.URL)
 	return nil
 }
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -81,6 +81,13 @@ type CreateReleaseOpts struct {
 	Draft        bool   `json:"draft"`
 }
 
+type CreateRefOpts struct {
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	Tag    string `json:"tag"`
+	Branch string `json:"branch"`
+}
+
 func ListReleases(ctx context.Context, client *github.Client, owner, repo string) ([]*github.RepositoryRelease, error) {
 	releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
 	if err != nil {
@@ -136,6 +143,32 @@ func CreateRelease(ctx context.Context, client *github.Client, cro *CreateReleas
 	}
 
 	return release, nil
+}
+
+func CreateRef(ctx context.Context, client *github.Client, cro *CreateRefOpts) (*github.Reference, error) {
+	if cro == nil {
+		return nil, errors.New("CreateReleaseOpts cannot be nil")
+	}
+
+	branchRefStr := "heads/" + cro.Branch
+	branchRef, _, err := client.Git.GetRef(ctx, cro.Owner, cro.Repo, branchRefStr)
+	if err != nil {
+		return nil, err
+	}
+
+	commitSHA := branchRef.Object.GetSHA()
+	tagRefStr := "refs/tags/" + cro.Tag
+	newRef := github.CreateRef{
+		Ref: tagRefStr,
+		SHA: commitSHA,
+	}
+
+	createdRef, _, err := client.Git.CreateRef(ctx, cro.Owner, cro.Repo, newRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdRef, nil
 }
 
 func RefCommitSHA(ctx context.Context, ghClient *github.Client, owner, repo, ref string) (string, error) {


### PR DESCRIPTION
This PR:
- Updates both `release tag rke2` and `release tag k3s` commands, to create a tag instead of a release.
- Updates the `Config.RKE2` struct to support a map of RKE2 release configs.

