### PR TITLE
Add `--alert` flag for release notes generation cmd

### DIFF
--- a/cmd/release/cmd/generate.go
+++ b/cmd/release/cmd/generate.go
@@ -35,6 +35,8 @@ var (
 	cliPrevMilestone string
 	cliMilestone     string
 
+	releaseNotesAlert string
+
 	concurrencyLimit                      int
 	imagesListURL                         string
 	registry                              string
@@ -81,7 +83,7 @@ var k3sGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "k3s-io", "k3s", k3sMilestone, k3sPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "k3s-io", "k3s", k3sMilestone, k3sPrevMilestone, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}
@@ -122,7 +124,7 @@ var rke2GenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "rke2", rke2Milestone, rke2PrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "rke2", rke2Milestone, rke2PrevMilestone, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}
@@ -320,7 +322,7 @@ var uiGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "ui", dashboardMilestone, dashboardPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "ui", dashboardMilestone, dashboardPrevMilestone, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}
@@ -343,7 +345,7 @@ var dashboardGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "dashboard", dashboardMilestone, dashboardPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "dashboard", dashboardMilestone, dashboardPrevMilestone, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}
@@ -366,7 +368,7 @@ var cliGenerateReleaseNotesSubCmd = &cobra.Command{
 		ctx := context.Background()
 		client := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		notes, err := release.GenReleaseNotes(ctx, "rancher", "cli", cliMilestone, cliPrevMilestone, client)
+		notes, err := release.GenReleaseNotes(ctx, "rancher", "cli", cliMilestone, cliPrevMilestone, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}
@@ -451,6 +453,7 @@ func init() {
 	generateCmd.AddCommand(kdmGenerateSubCmd)
 
 	// k3s release notes
+	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&releaseNotesAlert, "alert", "a", "", "Appends the specified alert type in the release notes. Valid values are: 'note', 'tip', 'important', 'warning' and 'caution'")
 	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sPrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
 	k3sGenerateReleaseNotesSubCmd.Flags().StringVarP(&k3sMilestone, "milestone", "m", "", "Milestone")
 	if err := k3sGenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {
@@ -463,6 +466,7 @@ func init() {
 	}
 
 	// rke2 release notes
+	rke2GenerateReleaseNotesSubCmd.Flags().StringVarP(&releaseNotesAlert, "alert", "a", "", "Appends the specified alert type in the release notes. Valid values are: 'note', 'tip', 'important', 'warning' and 'caution'")
 	rke2GenerateReleaseNotesSubCmd.Flags().StringVarP(&rke2PrevMilestone, "prev-milestone", "p", "", "Previous Milestone")
 	rke2GenerateReleaseNotesSubCmd.Flags().StringVarP(&rke2Milestone, "milestone", "m", "", "Milestone")
 	if err := rke2GenerateReleaseNotesSubCmd.MarkFlagRequired("prev-milestone"); err != nil {

--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -182,7 +182,7 @@ var systemAgentInstallerK3sTagSubCmd = &cobra.Command{
 			Branch: "main",
 		}
 
-		return k3s.CreateRelease(ctx, ghClient, &k3sRelease, opts, rc)
+		return k3s.CreateRelease(ctx, ghClient, &k3sRelease, opts, releaseNotesAlert, rc)
 	},
 }
 
@@ -314,7 +314,7 @@ var dashboardTagSubCmd = &cobra.Command{
 			Draft:  false,
 		}
 
-		if err := ui.CreateRelease(ctx, ghClient, uiOpts, preRelease, dryRun, releaseType, previousTag); err != nil {
+		if err := ui.CreateRelease(ctx, ghClient, uiOpts, preRelease, dryRun, releaseType, previousTag, releaseNotesAlert); err != nil {
 			return err
 		}
 
@@ -326,7 +326,7 @@ var dashboardTagSubCmd = &cobra.Command{
 			Draft:  false,
 		}
 
-		return dashboard.CreateRelease(ctx, ghClient, dashboardOpts, preRelease, dryRun, releaseType, previousTag)
+		return dashboard.CreateRelease(ctx, ghClient, dashboardOpts, preRelease, dryRun, releaseType, previousTag, releaseNotesAlert)
 	},
 }
 
@@ -399,7 +399,7 @@ var cliTagSubCmd = &cobra.Command{
 			Draft:  false,
 		}
 
-		return cli.CreateRelease(ctx, ghClient, cliOpts, rc, releaseType, previousTag, dryRun)
+		return cli.CreateRelease(ctx, ghClient, cliOpts, rc, releaseType, previousTag, releaseNotesAlert, dryRun)
 	},
 }
 

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -118,11 +118,11 @@ func updateRancherReferencesAndPush(tag, releaseBranch, rancherCommitSHA string,
 
 func createCLIReferencesPR(ctx context.Context, ghClient *github.Client, tag, tagSHA, releaseBranch, cliRepoName, rancherRepoOwner, githubUsername string) error {
 	pull := &github.NewPullRequest{
-		Title:               new("Bump Rancher version to " + tag),
-		Base:                new(releaseBranch),
-		Head:                new(githubUsername + ":" + UpdateCLIRefsBranchName(tag)),
-		Body:                new("```" + tag + ": " + tagSHA + "```"),
-		MaintainerCanModify: new(true),
+		Title:               github.Ptr("Bump Rancher version to " + tag),
+		Base:                github.Ptr(releaseBranch),
+		Head:                github.Ptr(githubUsername + ":" + UpdateCLIRefsBranchName(tag)),
+		Body:                github.Ptr("```" + tag + ": " + tagSHA + "```"),
+		MaintainerCanModify: github.Ptr(true),
 	}
 
 	// creating a pr from your fork branch

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CreateRelease will create a new tag and a new release with given params.
-func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, rc bool, releaseType, previousTag string, dryRun bool) error {
+func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, rc bool, releaseType, previousTag, releaseNotesAlert string, dryRun bool) error {
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
@@ -47,7 +47,7 @@ func CreateRelease(ctx context.Context, client *github.Client, opts *repository.
 		opts.Tag = fmt.Sprintf("%s-%s.%d", opts.Tag, releaseType, latestRCNumber)
 	} else {
 		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, previousTag)
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, client)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -22,7 +22,7 @@ const (
 )
 
 // CreateRelease will create a new tag and a new release with given params.
-func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, rc, dryRun bool, releaseType, previousTag string) error {
+func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, rc, dryRun bool, releaseType, previousTag, releaseAlert string) error {
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
@@ -55,7 +55,7 @@ func CreateRelease(ctx context.Context, client *github.Client, opts *repository.
 
 	if !rc {
 		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, previousTag)
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, client)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, releaseAlert, client)
 		if err != nil {
 			return err
 		}

--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -731,7 +731,7 @@ func cleanGitRepo(dir string) error {
 	return nil
 }
 
-func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sRelease, opts *repository.CreateReleaseOpts, rc bool) error {
+func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sRelease, opts *repository.CreateReleaseOpts, releaseNotesAlert string, rc bool) error {
 	fmt.Println("validating tag")
 	_, err := semver.NewVersion(opts.Tag)
 	if err != nil {
@@ -773,7 +773,7 @@ func CreateRelease(ctx context.Context, client *github.Client, r *ecmConfig.K3sR
 	fmt.Printf("create release options: %+v\n", *opts)
 
 	if !rc && opts.Repo == "k3s" {
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, *latestRC, oldName, client)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, *latestRC, oldName, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -181,10 +181,10 @@ func updateDashboardReferencesAndPush(tag, rancherReleaseBranch, rancherUpstream
 
 func createDashboardReferencesPR(ctx context.Context, ghClient *github.Client, u *ecmConfig.User, tag, rancherReleaseBranch, rancherRepoName, rancherRepoOwner string) error {
 	pull := &github.NewPullRequest{
-		Title:               new("Bump Dashboard to " + tag),
-		Base:                new(rancherReleaseBranch),
-		Head:                new(u.GithubUsername + ":" + UpdateDashboardRefsBranchName(tag)),
-		MaintainerCanModify: new(true),
+		Title:               github.Ptr("Bump Dashboard to " + tag),
+		Base:                github.Ptr(rancherReleaseBranch),
+		Head:                github.Ptr(u.GithubUsername + ":" + UpdateDashboardRefsBranchName(tag)),
+		MaintainerCanModify: github.Ptr(true),
 	}
 
 	// creating a pr from your fork branch
@@ -228,10 +228,10 @@ func updateCLIReferencesAndPush(tag, rancherUpstreamURL, rancherReleaseBranch st
 
 func createCLIReferencesPR(ctx context.Context, ghClient *github.Client, tag, rancherReleaseBranch, githubUsername, rancherRepoName, rancherRepoOwner string) error {
 	pull := &github.NewPullRequest{
-		Title:               new("Bump Rancher CLI version to " + tag),
-		Base:                new(rancherReleaseBranch),
-		Head:                new(githubUsername + ":" + cli.UpdateCLIRefsBranchName(tag)),
-		MaintainerCanModify: new(true),
+		Title:               github.Ptr("Bump Rancher CLI version to " + tag),
+		Base:                github.Ptr(rancherReleaseBranch),
+		Head:                github.Ptr(githubUsername + ":" + cli.UpdateCLIRefsBranchName(tag)),
+		MaintainerCanModify: github.Ptr(true),
 	}
 
 	// creating a pr from your fork branch

--- a/release/release.go
+++ b/release/release.go
@@ -55,6 +55,7 @@ type releaseNoteData struct {
 	Milestone        string
 	MajorMinor       string
 	ChangeLogVersion string
+	Alert            string
 	ChangeLogData    changeLogData
 }
 
@@ -264,9 +265,25 @@ func capitalize(s string) string {
 	return s
 }
 
+const (
+	AlertNote      = "note"
+	AlertTip       = "tip"
+	AlertImportant = "important"
+	AlertWarning   = "warning"
+	AlertCaution   = "caution"
+)
+
+var AlertMap = map[string]struct{}{
+	AlertNote:      {},
+	AlertTip:       {},
+	AlertImportant: {},
+	AlertWarning:   {},
+	AlertCaution:   {},
+}
+
 // GenReleaseNotes genereates release notes based on the given milestone,
 // previous milestone, and repository.
-func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone string, client *github.Client) (*bytes.Buffer, error) {
+func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone, alert string, client *github.Client) (*bytes.Buffer, error) {
 	funcMap := template.FuncMap{
 		"majMin":      majMin,
 		"trimPeriods": trimPeriods,
@@ -318,6 +335,14 @@ func GenReleaseNotes(ctx context.Context, owner, repo, milestone, prevMilestone 
 		MajorMinor:       majorMinor,
 		ChangeLogVersion: markdownVersion,
 		ChangeLogData:    cgData,
+	}
+
+	if _, ok := AlertMap[alert]; !ok && alert != "" {
+		return nil, errors.New("invalid alert type: it must be note, tip, important, warning or caution, received " + alert)
+	}
+
+	if alert != "" {
+		commonRD.Alert = fmt.Sprintf(alertTemplate, strings.ToUpper(alert))
 	}
 
 	switch repo {
@@ -1013,7 +1038,7 @@ var changelogTemplate = `
 const rke2ReleaseNoteTemplate = `
 {{- define "rke2" -}}
 <!-- {{.Milestone}} -->
-
+{{ if .Alert }}{{.Alert}}{{ end }}
 This release updates Kubernetes to {{.K8sVersion}}.
 
 **Important Note**
@@ -1081,7 +1106,7 @@ As always, we welcome and appreciate feedback from our community of users. Pleas
 const k3sReleaseNoteTemplate = `
 {{- define "k3s" -}}
 <!-- {{.Milestone}} -->
-
+{{ if .Alert }}{{.Alert}}{{ end }}
 This release updates Kubernetes to {{.K8sVersion}}, and fixes a number of issues.
 
 For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{.MajorMinor}}.md#changelog-since-{{.ChangeLogSince}}).
@@ -1121,3 +1146,8 @@ const defaultReleaseNoteTemplate = `
 
 {{ template "changelog" . }}
 {{ end }}`
+
+const alertTemplate = `> [!%s]
+> Fill this section with important information for users to know about this release, such as breaking changes, deprecations, or critical bug fixes. 
+> This will be highlighted in the release notes to ensure users see it.
+`

--- a/release/ui/ui.go
+++ b/release/ui/ui.go
@@ -20,7 +20,7 @@ const (
 )
 
 // CreateRelease will create a new tag and a new release with given params.
-func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, preRelease, dryRun bool, releaseType, previousTag string) error {
+func CreateRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, preRelease, dryRun bool, releaseType, previousTag, releaseNotesAlert string) error {
 	if !semver.IsValid(opts.Tag) {
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
@@ -53,7 +53,7 @@ func CreateRelease(ctx context.Context, client *github.Client, opts *repository.
 
 	if !preRelease {
 		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, previousTag)
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, client)
+		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, releaseNotesAlert, client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
With the `--alert` flag, release notes will be generated with alert boxes at the beginning of the document, can be one of the following:

For `--alert=note`:
> [!NOTE]
> Lorem ipsum dolor sit amet

For `--alert=tip`:
> [!TIP]
> Lorem ipsum dolor sit amet

For `--alert=important`:
> [!IMPORTANT]
> Lorem ipsum dolor sit amet

For `--alert=warning`:
> [!WARNING]
> Lorem ipsum dolor sit amet

For `--alert=caution`:
> [!CAUTION]
> Lorem ipsum dolor sit amet

If the value is not supported it will error-out. 