### PR TITLE
use tags for latest pre release check

### DIFF
--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -138,12 +138,7 @@ var rancherTagSubCmd = &cobra.Command{
 
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
-
-		if dryRun {
-			fmt.Println("dry run, skipping creating release")
-			return nil
-		}
-		createdTag, tagCommit, err := rancher.CreateTag(ctx, ghClient, owner, repo, tag, "", releaseBranch, releaseType, preRelease)
+		createdTag, tagCommit, err := rancher.CreateTag(ctx, ghClient, owner, repo, tag, "", releaseBranch, releaseType, preRelease, dryRun)
 		if err != nil {
 			return err
 		}
@@ -230,12 +225,7 @@ var rancherPrimeTagSubCmd = &cobra.Command{
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
 
-		if dryRun {
-			fmt.Println("dry run, skipping creating release")
-			return nil
-		}
-
-		createdTag, tagCommit, err := rancher.CreateTag(ctx, ghClient, owner, repo, tag, "", releaseBranch, releaseType, preRelease)
+		createdTag, tagCommit, err := rancher.CreateTag(ctx, ghClient, owner, repo, tag, "", releaseBranch, releaseType, preRelease, dryRun)
 		if err != nil {
 			return err
 		}

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -262,7 +262,7 @@ func ReleaseBranchFromTag(tag string) (string, error) {
 // CreateTag creates a new tag ref on GitHub based on the provided commit SHA or the latest commit on the provided branch.
 // If the tag to be created is a pre-release (rc or alpha) it will automatically find the latest tag and add one to it. E.g: v2.14.0 (pre-release) -> v2.14.0-alpha2
 // Returns tag, commit sha, error
-func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTag, sha, branch, releaseType string, preRelease bool) (string, string, error) {
+func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTag, sha, branch, releaseType string, preRelease, dryRun bool) (string, string, error) {
 	if !semver.IsValid(baseTag) {
 		return "", "", errors.New("the base tag is invalid: " + baseTag)
 	}
@@ -297,6 +297,11 @@ func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTa
 
 	if !semver.IsValid(tag) {
 		return "", "", errors.New("the tag is invalid: " + tag)
+	}
+
+	if dryRun {
+		fmt.Println("dry run, skipping creating tag")
+		return tag, sha, nil
 	}
 
 	_, _, err := ghClient.Git.CreateRef(ctx, owner, repo, github.CreateRef{Ref: "refs/tags/" + tag, SHA: sha})

--- a/release/release.go
+++ b/release/release.go
@@ -682,7 +682,7 @@ func imageEnvVersion(envName, repo, branchVersion string) string {
 		imageListURL = "https://raw.githubusercontent.com/" + repoName + "/" + branchVersion + "/scripts/build-images"
 	}
 
-	var regex = fmt.Sprintf(`^(%s)=.+$`, envName)
+	regex := fmt.Sprintf(`^(%s)=.+$`, envName)
 	submatch := findInURL(imageListURL, regex, envName, true)
 	if len(submatch) == 0 {
 		logrus.Debugf("env %s not found in %s", envName, imageListURL)
@@ -808,23 +808,27 @@ func LatestRC(ctx context.Context, owner, repo, k8sVersion, projectSuffix string
 }
 
 func LatestPreRelease(ctx context.Context, client *github.Client, owner, repo, version, preReleaseSuffix string) (*string, error) {
-	var versions []*github.RepositoryRelease
+	var latestFoundPreRelease *string
+	preReleaseNumber := 1
 
-	allReleases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{
-		Page:    0,
-		PerPage: 40,
-	})
-	if err != nil {
-		return nil, err
-	}
+	for {
+		tagName := fmt.Sprintf("%s-%s%d", version, preReleaseSuffix, preReleaseNumber)
 
-	for _, release := range allReleases {
-		if strings.Contains(*release.TagName, version+"-"+preReleaseSuffix) {
-			versions = append(versions, release)
+		ref := "tags/" + tagName
+
+		_, resp, err := client.Git.GetRef(ctx, owner, repo, ref)
+		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				break
+			}
+			return nil, err
 		}
+		found := tagName
+		latestFoundPreRelease = &found
+		preReleaseNumber++
 	}
 
-	return latestRelease(versions), nil
+	return latestFoundPreRelease, nil
 }
 
 // StatsMonthly
@@ -954,21 +958,15 @@ func Stats(ctx context.Context, client *github.Client, startDate, endDate time.T
 }
 
 func latestRelease(versions []*github.RepositoryRelease) *string {
-
 	sort.Slice(versions, func(i, j int) bool {
-
 		return versions[i].PublishedAt.Before(versions[j].PublishedAt.Time)
-
 	})
 
 	if len(versions) == 0 {
-
 		return nil
-
 	}
 
 	return versions[len(versions)-1].TagName
-
 }
 
 func latestTag(versions []*github.RepositoryTag) *string {

--- a/release/release.go
+++ b/release/release.go
@@ -957,38 +957,6 @@ func Stats(ctx context.Context, client *github.Client, startDate, endDate time.T
 	return &sd, nil
 }
 
-func latestRelease(versions []*github.RepositoryRelease) *string {
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[i].PublishedAt.Before(versions[j].PublishedAt.Time)
-	})
-
-	if len(versions) == 0 {
-		return nil
-	}
-
-	return versions[len(versions)-1].TagName
-}
-
-func latestTag(versions []*github.RepositoryTag) *string {
-	if len(versions) == 0 {
-		return nil
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		nameI := *versions[i].Name
-		nameJ := *versions[j].Name
-
-		cmp := semver.Compare(nameI, nameJ)
-		if cmp == 0 {
-			return nameI < nameJ
-		}
-
-		return cmp < 0
-	})
-
-	return versions[len(versions)-1].Name
-}
-
 // rke2ChartVersion will return the version of the rke2 chart from the chart versions file
 func rke2ChartsVersion(branchVersion string) (map[string]chart, error) {
 	chartVersionsURL := "https://raw.githubusercontent.com/rancher/rke2/" + branchVersion + "/charts/" + rke2ChartsVersionsFile


### PR DESCRIPTION
* use tags instead of releases to check what is the latest prerelease, like k3s and rke2
* move the dry run check to inside the function to test the latest tag

A future change can merge both checks, since they are almost the same, but for now, I don't want to break the existing check.
