### PR TITLE
chore: bump slsactl to v0.1.33

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -218,7 +218,7 @@ runs:
     uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
   - name: Install Cosign
     uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-  - uses: rancherlabs/slsactl/actions/install-slsactl@d70524abe2bec09b488ab946abcb4bef9c1331bf # v0.1.31
+  - uses: rancherlabs/slsactl/actions/install-slsactl@132f4c15b16537cf031aae50c788fdad1a8fe723 # v0.1.33
 
   - name: Build and push image [Prime]
     id: push-prime


### PR DESCRIPTION
https://github.com/rancherlabs/slsactl/releases/tag/v0.1.33 is released which includes a fix for a problem described in https://github.com/rancherlabs/slsactl/pull/313. To be able to consume it from https://github.com/rancher/cluster-api-provider-rke2/pull/897 we need to use new version of publish image action which uses latest slsactl version