### PR TITLE
Add TrimSpace version

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -350,9 +350,10 @@ func goVersion(r *ecmConfig.K3sRelease) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ver, err := semver.NewVersion(string(dat))
+	verStr := strings.TrimSpace(string(dat))
+	ver, err := semver.NewVersion(verStr)
 	if err != nil {
-		return "", errors.New("invalid '.go-version' content: " + string(dat))
+		return "", errors.New("invalid '.go-version' content: " + verStr)
 	}
 
 	return ver.String(), nil


### PR DESCRIPTION
Fixing this odd error:
```
removing unwanted files
git checkout .
git  [rebase --onto v1.33.12 v1.33.11 v1.33.11-k3s1~1]

getting go version for k8s
error:  failed to rebase and tag: invalid '.go-version' content: 1.25.9
```

When parsing `.go-version` from upstream.