### PR TITLE
Add Tools section in Prime Ribs page

### DIFF
--- a/release/prime/artifacts.go
+++ b/release/prime/artifacts.go
@@ -18,6 +18,7 @@ const (
 	rancherArtifactsPrefix  = "rancher/v"
 	rke2ArtifactsPrefix     = "rke2/v"
 	k3sArtifactsPrefix      = "k3s/v"
+	toolsArtifactsPrefix    = "tools/v"
 	rancherArtifactsBaseURL = "https://prime.ribs.rancher.io"
 )
 
@@ -35,11 +36,12 @@ type ArtifactsIndexContentGroup struct {
 	Rancher ArtifactsIndexVersions
 	RKE2    ArtifactsIndexVersions
 	K3s     ArtifactsIndexVersions
+	Tools   ArtifactsIndexVersions
 	BaseURL string
 }
 
 type ArtifactLister interface {
-	List(ctx context.Context) (rancherKeys []string, rke2Keys []string, k3sKeys []string, err error)
+	List(ctx context.Context) (rancherKeys []string, rke2Keys []string, k3sKeys []string, toolsKeys []string, err error)
 }
 
 type ArtifactBucket struct {
@@ -54,20 +56,25 @@ func NewArtifactBucket(client *s3.Client) ArtifactBucket {
 	}
 }
 
-func (a ArtifactBucket) List(ctx context.Context) ([]string, []string, []string, error) {
+func (a ArtifactBucket) List(ctx context.Context) ([]string, []string, []string, []string, error) {
 	rancherKeys, err := listS3Objects(ctx, a.client, a.bucket, rancherArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	rke2Keys, err := listS3Objects(ctx, a.client, a.bucket, rke2ArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	k3sKeys, err := listS3Objects(ctx, a.client, a.bucket, k3sArtifactsPrefix)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return rancherKeys, rke2Keys, k3sKeys, nil
+
+	toolsKeys, err := listS3Objects(ctx, a.client, a.bucket, toolsArtifactsPrefix)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return rancherKeys, rke2Keys, k3sKeys, toolsKeys, nil
 }
 
 type ArtifactDir struct {
@@ -78,8 +85,8 @@ func NewArtifactDir(dir string) ArtifactDir {
 	return ArtifactDir{dir}
 }
 
-func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, error) {
-	var rancherKeys, rke2Keys, k3sKeys []string
+func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, []string, error) {
+	var rancherKeys, rke2Keys, k3sKeys, toolsKeys []string
 	err := filepath.WalkDir(a.dir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -92,19 +99,22 @@ func (a ArtifactDir) List(ctx context.Context) ([]string, []string, []string, er
 			return err
 		}
 		rel = filepath.ToSlash(rel)
-		if strings.HasPrefix(rel, "rancher/v") {
+		switch {
+		case strings.HasPrefix(rel, rancherArtifactsPrefix):
 			rancherKeys = append(rancherKeys, rel)
-		} else if strings.HasPrefix(rel, "rke2/v") {
+		case strings.HasPrefix(rel, rke2ArtifactsPrefix):
 			rke2Keys = append(rke2Keys, rel)
-		} else if strings.HasPrefix(rel, "k3s/v") {
+		case strings.HasPrefix(rel, k3sArtifactsPrefix):
 			k3sKeys = append(k3sKeys, rel)
+		case strings.HasPrefix(rel, toolsArtifactsPrefix):
+			toolsKeys = append(toolsKeys, rel)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return rancherKeys, rke2Keys, k3sKeys, nil
+	return rancherKeys, rke2Keys, k3sKeys, toolsKeys, nil
 }
 
 // GenerateArtifactsIndex lists artifacts and writes index.html and index-prerelease.html
@@ -113,11 +123,11 @@ func GenerateArtifactsIndex(ctx context.Context, outPath string, ignoreVersions 
 	for _, v := range ignoreVersions {
 		ignore[v] = true
 	}
-	rancherKeys, rke2Keys, k3sKeys, err := lister.List(ctx)
+	rancherKeys, rke2Keys, k3sKeys, toolsKeys, err := lister.List(ctx)
 	if err != nil {
 		return err
 	}
-	content := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, ignore)
+	content := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys, ignore)
 	gaIndex, err := generateArtifactsHTML(content.GA)
 	if err != nil {
 		return err
@@ -132,7 +142,7 @@ func GenerateArtifactsIndex(ctx context.Context, outPath string, ignoreVersions 
 	return os.WriteFile(filepath.Join(outPath, "index-prerelease.html"), preReleaseIndex, 0o644)
 }
 
-func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, ignoreVersions map[string]bool) ArtifactsIndexContent {
+func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys []string, ignoreVersions map[string]bool) ArtifactsIndexContent {
 	indexContent := ArtifactsIndexContent{
 		GA: ArtifactsIndexContentGroup{
 			Rancher: ArtifactsIndexVersions{
@@ -144,6 +154,10 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 				VersionsFiles: map[string][]string{},
 			},
 			K3s: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
+			Tools: ArtifactsIndexVersions{
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
@@ -162,6 +176,10 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
+			Tools: ArtifactsIndexVersions{
+				Versions:      []string{},
+				VersionsFiles: map[string][]string{},
+			},
 			BaseURL: rancherArtifactsBaseURL,
 		},
 	}
@@ -169,6 +187,7 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys []string, igno
 	indexContent.GA.Rancher, indexContent.PreRelease.Rancher = parseVersionsFromKeys(rancherKeys, "rancher/", ignoreVersions)
 	indexContent.GA.RKE2, indexContent.PreRelease.RKE2 = parseVersionsFromKeys(rke2Keys, "rke2/", ignoreVersions)
 	indexContent.GA.K3s, indexContent.PreRelease.K3s = parseVersionsFromKeys(k3sKeys, "k3s/", ignoreVersions)
+	indexContent.GA.Tools, indexContent.PreRelease.Tools = parseVersionsFromKeys(toolsKeys, "tools/", ignoreVersions)
 
 	return indexContent
 }
@@ -361,6 +380,30 @@ const artifactsIndexTemplate = `{{ define "release-artifacts-index" }}
 							<ul>
 							{{ range index $.K3s.VersionsFiles $version }}
 							<li><a href="{{ $.BaseURL }}/k3s/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/k3s/{{ $version }}/{{ . }}</a></li>
+							{{ end }}
+							</ul>
+						</div>
+					</div>
+					{{ end }}
+				</div>
+			</div>
+			<div class="project-tools project">
+				<div class="flex-row">
+					<h2 id="tools" class="project-title"><a class="anchor" href="#tools">#</a>tools</h2>
+					<button onclick="toggleProject('tools')" id="project-tools-expand" class="release-title-expand expand-active">hide</button>
+				</div>
+				<div id="project-tools-releases">
+					{{ range $i, $version := .Tools.Versions }}
+					<div id="tools-{{ $version }}" class="release-{{ $version }} release">
+						<div class="flex-row">
+							<a class="anchor" href="#tools-{{ $version }}">#</a>
+							<b class="release-title-tag">{{ $version }}</b>
+							<button onclick="toggleFiles('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">show</button>
+						</div>
+						<div class="files" id="release-{{ $version }}-files">
+							<ul>
+							{{ range index $.Tools.VersionsFiles $version }}
+							<li><a href="{{ $.BaseURL }}/tools/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/tools/{{ $version }}/{{ . }}</a></li>
 							{{ end }}
 							</ul>
 						</div>

--- a/release/prime/artifacts.go
+++ b/release/prime/artifacts.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -18,7 +19,7 @@ const (
 	rancherArtifactsPrefix  = "rancher/v"
 	rke2ArtifactsPrefix     = "rke2/v"
 	k3sArtifactsPrefix      = "k3s/v"
-	toolsArtifactsPrefix    = "tools/v"
+	toolsArtifactsPrefix    = "tools/"
 	rancherArtifactsBaseURL = "https://prime.ribs.rancher.io"
 )
 
@@ -32,11 +33,18 @@ type ArtifactsIndexVersions struct {
 	VersionsFiles map[string][]string
 }
 
+// ToolsIndex supports the Tool sectionÇ
+// tools/<program>/<version>/<files>
+type ToolsIndex struct {
+	Programs        []string
+	ProgramVersions map[string]ArtifactsIndexVersions
+}
+
 type ArtifactsIndexContentGroup struct {
 	Rancher ArtifactsIndexVersions
 	RKE2    ArtifactsIndexVersions
 	K3s     ArtifactsIndexVersions
-	Tools   ArtifactsIndexVersions
+	Tools   ToolsIndex
 	BaseURL string
 }
 
@@ -157,9 +165,9 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys []s
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
-			Tools: ArtifactsIndexVersions{
-				Versions:      []string{},
-				VersionsFiles: map[string][]string{},
+			Tools: ToolsIndex{
+				Programs:        []string{},
+				ProgramVersions: map[string]ArtifactsIndexVersions{},
 			},
 			BaseURL: rancherArtifactsBaseURL,
 		},
@@ -176,9 +184,9 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys []s
 				Versions:      []string{},
 				VersionsFiles: map[string][]string{},
 			},
-			Tools: ArtifactsIndexVersions{
-				Versions:      []string{},
-				VersionsFiles: map[string][]string{},
+			Tools: ToolsIndex{
+				Programs:        []string{},
+				ProgramVersions: map[string]ArtifactsIndexVersions{},
 			},
 			BaseURL: rancherArtifactsBaseURL,
 		},
@@ -187,7 +195,7 @@ func generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys []s
 	indexContent.GA.Rancher, indexContent.PreRelease.Rancher = parseVersionsFromKeys(rancherKeys, "rancher/", ignoreVersions)
 	indexContent.GA.RKE2, indexContent.PreRelease.RKE2 = parseVersionsFromKeys(rke2Keys, "rke2/", ignoreVersions)
 	indexContent.GA.K3s, indexContent.PreRelease.K3s = parseVersionsFromKeys(k3sKeys, "k3s/", ignoreVersions)
-	indexContent.GA.Tools, indexContent.PreRelease.Tools = parseVersionsFromKeys(toolsKeys, "tools/", ignoreVersions)
+	indexContent.GA.Tools, indexContent.PreRelease.Tools = parseToolsFromKeys(toolsKeys, "tools/", ignoreVersions)
 
 	return indexContent
 }
@@ -244,6 +252,77 @@ func parseVersionsFromKeys(keys []string, prefix string, ignoreVersions map[stri
 	}
 
 	return gaVersions, preReleaseVersions
+}
+
+// parseToolsFromKeys parses tools following the <program>/<version>/<file> structure
+func parseToolsFromKeys(keys []string, prefix string, ignoreVersions map[string]bool) (ToolsIndex, ToolsIndex) {
+	gaTemp := make(map[string]map[string][]string)
+	preTemp := make(map[string]map[string][]string)
+
+	for _, key := range keys {
+		if !strings.Contains(key, prefix) {
+			continue
+		}
+		keyParts := strings.Split(strings.TrimPrefix(key, prefix), "/")
+		// Expecting at least <program>/<version>/<file>
+		if len(keyParts) < 3 || keyParts[1] == "" {
+			continue
+		}
+		program := keyParts[0]
+		version := keyParts[1]
+		file := strings.Join(keyParts[2:], "/")
+
+		if _, ok := ignoreVersions[version]; ok {
+			continue
+		}
+
+		if strings.Contains(version, "-") {
+			if preTemp[program] == nil {
+				preTemp[program] = make(map[string][]string)
+			}
+			preTemp[program][version] = append(preTemp[program][version], file)
+		} else {
+			if gaTemp[program] == nil {
+				gaTemp[program] = make(map[string][]string)
+			}
+			gaTemp[program][version] = append(gaTemp[program][version], file)
+		}
+	}
+
+	return buildToolsIndex(gaTemp), buildToolsIndex(preTemp)
+}
+
+func buildToolsIndex(temp map[string]map[string][]string) ToolsIndex {
+	var programs []string
+	for p := range temp {
+		programs = append(programs, p)
+	}
+	sort.Strings(programs)
+
+	ti := ToolsIndex{
+		Programs:        programs,
+		ProgramVersions: make(map[string]ArtifactsIndexVersions),
+	}
+
+	for _, prog := range programs {
+		versionsMap := temp[prog]
+		var versions []string
+		for v := range versionsMap {
+			versions = append(versions, v)
+		}
+		semver.Sort(versions)
+
+		var sortedVersions []string
+		for i := len(versions) - 1; i >= 0; i-- {
+			sortedVersions = append(sortedVersions, versions[i])
+		}
+
+		ti.ProgramVersions[prog] = ArtifactsIndexVersions{
+			Versions:      sortedVersions,
+			VersionsFiles: versionsMap,
+		}
+	}
+	return ti
 }
 
 func generateArtifactsHTML(content ArtifactsIndexContentGroup) ([]byte, error) {
@@ -393,19 +472,30 @@ const artifactsIndexTemplate = `{{ define "release-artifacts-index" }}
 					<button onclick="toggleProject('tools')" id="project-tools-expand" class="release-title-expand expand-active">hide</button>
 				</div>
 				<div id="project-tools-releases">
-					{{ range $i, $version := .Tools.Versions }}
-					<div id="tools-{{ $version }}" class="release-{{ $version }} release">
+					{{ range $p_i, $program := .Tools.Programs }}
+					<div class="project-{{ $program }} project" style="margin-left: 20px;">
 						<div class="flex-row">
-							<a class="anchor" href="#tools-{{ $version }}">#</a>
-							<b class="release-title-tag">{{ $version }}</b>
-							<button onclick="toggleFiles('{{ $version }}')" id="release-{{ $version }}-expand" class="release-title-expand">show</button>
+							<h3 id="tools-{{ $program }}" class="project-title"><a class="anchor" href="#tools-{{ $program }}">#</a>{{ $program }}</h3>
+							<button onclick="toggleProject('tools-{{ $program }}')" id="project-tools-{{ $program }}-expand" class="release-title-expand expand-active">hide</button>
 						</div>
-						<div class="files" id="release-{{ $version }}-files">
-							<ul>
-							{{ range index $.Tools.VersionsFiles $version }}
-							<li><a href="{{ $.BaseURL }}/tools/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/tools/{{ $version }}/{{ . }}</a></li>
+						<div id="project-tools-{{ $program }}-releases">
+							{{ $progData := index $.Tools.ProgramVersions $program }}
+							{{ range $i, $version := $progData.Versions }}
+							<div id="tools-{{ $program }}-{{ $version }}" class="release-{{ $version }} release">
+								<div class="flex-row">
+									<a class="anchor" href="#tools-{{ $program }}-{{ $version }}">#</a>
+									<b class="release-title-tag">{{ $version }}</b>
+									<button onclick="toggleFiles('tools-{{ $program }}-{{ $version }}')" id="release-tools-{{ $program }}-{{ $version }}-expand" class="release-title-expand">show</button>
+								</div>
+								<div class="files" id="release-tools-{{ $program }}-{{ $version }}-files">
+									<ul>
+									{{ range index $progData.VersionsFiles $version }}
+									<li><a href="{{ $.BaseURL }}/tools/{{ $program }}/{{ $version | urlquery }}/{{ . }}">{{ $.BaseURL }}/tools/{{ $program }}/{{ $version }}/{{ . }}</a></li>
+									{{ end }}
+									</ul>
+								</div>
+							</div>
 							{{ end }}
-							</ul>
 						</div>
 					</div>
 					{{ end }}

--- a/release/prime/artifacts_test.go
+++ b/release/prime/artifacts_test.go
@@ -9,7 +9,7 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	rancherKeys := []string{"rancher/v2.10.0/images.txt"}
 	rke2Keys := []string{"rke2/v1.30.1+rke2r1/images.txt"}
 	k3sKeys := []string{"k3s/v1.30.1+k3s1/images.txt"}
-	toolsKeys := []string{"tools/v1.30.1/tools.txt"}
+	toolsKeys := []string{"tools/rke2-patcher/v1.0.0/tools.txt"}
 	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys, nil)
 	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.10.0"}) {
 		t.Fatalf("unexpected GA rancher versions: %v", got.GA.Rancher.Versions)
@@ -29,11 +29,11 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	if len(got.PreRelease.K3s.Versions) != 0 {
 		t.Fatalf("expected no prerelease k3s versions, got %v", got.PreRelease.K3s.Versions)
 	}
-	if !slices.Equal(got.GA.Tools.Versions, []string{"v1.30.1"}) {
-		t.Fatalf("unexpected GA tools versions: %v", got.GA.Tools.Versions)
+	if !slices.Equal(got.GA.Tools.ProgramVersions["rke2-patcher"].Versions, []string{"v1.0.0"}) {
+		t.Fatalf("unexpected GA tools versions: %v", got.GA.Tools.ProgramVersions["rke2-patcher"].Versions)
 	}
-	if len(got.PreRelease.Tools.Versions) != 0 {
-		t.Fatalf("expected no prerelease tools versions, got %v", got.PreRelease.Tools.Versions)
+	if len(got.GA.Tools.ProgramVersions["rke2-patcher"].Versions) == 0 {
+		t.Fatalf("expected one prerelease tools versions, got %v", got.GA.Tools.ProgramVersions["rke2-patcher"].Versions)
 	}
 }
 

--- a/release/prime/artifacts_test.go
+++ b/release/prime/artifacts_test.go
@@ -9,7 +9,8 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	rancherKeys := []string{"rancher/v2.10.0/images.txt"}
 	rke2Keys := []string{"rke2/v1.30.1+rke2r1/images.txt"}
 	k3sKeys := []string{"k3s/v1.30.1+k3s1/images.txt"}
-	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, nil)
+	toolsKeys := []string{"tools/v1.30.1/tools.txt"}
+	got := generateArtifactsIndexContent(rancherKeys, rke2Keys, k3sKeys, toolsKeys, nil)
 	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.10.0"}) {
 		t.Fatalf("unexpected GA rancher versions: %v", got.GA.Rancher.Versions)
 	}
@@ -28,6 +29,12 @@ func TestGenerateArtifactsIndexContentGA(t *testing.T) {
 	if len(got.PreRelease.K3s.Versions) != 0 {
 		t.Fatalf("expected no prerelease k3s versions, got %v", got.PreRelease.K3s.Versions)
 	}
+	if !slices.Equal(got.GA.Tools.Versions, []string{"v1.30.1"}) {
+		t.Fatalf("unexpected GA tools versions: %v", got.GA.Tools.Versions)
+	}
+	if len(got.PreRelease.Tools.Versions) != 0 {
+		t.Fatalf("expected no prerelease tools versions, got %v", got.PreRelease.Tools.Versions)
+	}
 }
 
 func TestGenerateArtifactsIndexContentPreRelease(t *testing.T) {
@@ -36,7 +43,7 @@ func TestGenerateArtifactsIndexContentPreRelease(t *testing.T) {
 		"rancher/v2.9.0-rc1/foo.txt",
 		"rancher/v2.9.0-hotfix-1/images.txt",
 	}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, nil)
 	wantPre := []string{"v2.9.0-rc1", "v2.9.0-hotfix-1"}
 	if !slices.Equal(got.PreRelease.Rancher.Versions, wantPre) {
 		t.Fatalf("unexpected prerelease versions: %v", got.PreRelease.Rancher.Versions)
@@ -56,7 +63,7 @@ func TestGenerateArtifactsIndexContentIgnoredVersions(t *testing.T) {
 		"rancher/v2.8.2/images.txt",
 	}
 	ignore := map[string]bool{"v2.8.1": true}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, ignore)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, ignore)
 	if len(got.GA.Rancher.Versions) != 1 || got.GA.Rancher.Versions[0] != "v2.8.2" {
 		t.Fatalf("expected only v2.8.2, got %v", got.GA.Rancher.Versions)
 	}
@@ -71,7 +78,7 @@ func TestGenerateArtifactsIndexContentSkipUnexpectedKeys(t *testing.T) {
 		"rancher/v2.11.0/",
 		"rancher/v2.11.0/file.txt",
 	}
-	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil)
+	got := generateArtifactsIndexContent(rancherKeys, nil, nil, nil, nil)
 	if !slices.Equal(got.GA.Rancher.Versions, []string{"v2.11.0"}) {
 		t.Fatalf("expected only valid version captured, got %v", got.GA.Rancher.Versions)
 	}


### PR DESCRIPTION
This pull request adds support for indexing and displaying "tools" artifacts alongside Rancher, RKE2, and K3s artifacts in the release artifacts index. The changes introduce a new structure for handling tools, update artifact listing logic, extend the HTML template to show tools.

https://github.com/user-attachments/assets/6f07821a-78d5-4a67-a9f4-3a00cd807718

Added some mock data to generate this HTML page, basically the tools will be uploaded in the following structure:
```
tools/<program>/<version>/<files>
```