### PR TITLE
Specify slsactl version to be able to consume desired version

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -218,7 +218,10 @@ runs:
     uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
   - name: Install Cosign
     uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-  - uses: rancherlabs/slsactl/actions/install-slsactl@132f4c15b16537cf031aae50c788fdad1a8fe723 # v0.1.33
+  - name: Install slsactl
+    uses: rancherlabs/slsactl/actions/install-slsactl@132f4c15b16537cf031aae50c788fdad1a8fe723 # v0.1.33
+    with:
+      version: v0.1.33
 
   - name: Build and push image [Prime]
     id: push-prime


### PR DESCRIPTION
When using the publish-image action, slsactl is pinned by commit hash but always installs v0.1.30 by default unless a version is explicitly set. This is due to hardcoded [logic](https://github.com/rancherlabs/slsactl/blob/main/actions/install-slsactl/action.yml#L32) in the install-slsactl action. As a temporary workaround, this PR sets the desired slsactl version explicitly. The long-term fix should be to improve the defaulting logic in the slsactl action itself.