### PR TITLE
Add `release stats cve` command

### DIFF
--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -22,6 +22,7 @@ var (
 	endDate    *string
 	format     *string
 	webhookURL *string
+	severity   *string
 )
 
 var repoToOwner = map[string]string{
@@ -104,7 +105,7 @@ var cveStatsSubCmd = &cobra.Command{
 			return err
 		}
 
-		return reports.CVEsBySeverity("critical", *webhookURL)
+		return reports.CVEsBySeverity(*severity, *webhookURL)
 	},
 }
 
@@ -119,6 +120,7 @@ func init() {
 	endDate = releasesStatsCmd.Flags().StringP("end", "e", "", "end date")
 	format = releasesStatsCmd.Flags().StringP("format", "f", "json", "format (json|yaml)")
 	webhookURL = cveStatsSubCmd.Flags().StringP("webhook-url", "u", "", "Slack webhook URL for sending messages")
+	severity = cveStatsSubCmd.Flags().StringP("severity", "s", "critical", "severity (critical|high|medium|low)")
 
 	if err := releasesStatsCmd.MarkFlagRequired("repo"); err != nil {
 		fmt.Println(err.Error())

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -83,6 +83,16 @@ var statsCmd = &cobra.Command{
 	},
 }
 
+var cveStatsSubCmd = &cobra.Command{
+	Use:   "cve",
+	Short: "CVE statistics command",
+	Long:  `Retrieve CVE statistics from current releases.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(statsCmd)
 

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/rancher/ecm-distro-tools/release"
+	"github.com/rancher/ecm-distro-tools/release/metrics"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -28,9 +29,16 @@ var repoToOwner = map[string]string{
 	"k3s":     "k3s-io",
 }
 
-// statsCmd represents the stats command
+// statsCmd represents the base stats parent command
 var statsCmd = &cobra.Command{
 	Use:   "stats",
+	Short: "Statistics commands",
+	Long:  `Retrieve various statistics including releases and CVEs.`,
+}
+
+// releasesStatsCmd represents the release statistics command
+var releasesStatsCmd = &cobra.Command{
+	Use:   "releases",
 	Short: "Release statistics",
 	Long:  `Retrieve release statistics for a time period.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,28 +96,32 @@ var cveStatsSubCmd = &cobra.Command{
 	Short: "CVE statistics command",
 	Long:  `Retrieve CVE statistics from current releases.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		return nil
+		ctx := context.Background()
+		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
+		return metrics.CVEsMetrics(ctx, ghClient)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(statsCmd)
 
-	repo = statsCmd.Flags().StringP("repo", "r", "", "repository")
-	startDate = statsCmd.Flags().StringP("start", "s", "", "start date")
-	endDate = statsCmd.Flags().StringP("end", "e", "", "end date")
-	format = statsCmd.Flags().StringP("format", "f", "json", "format (json|yaml)")
+	statsCmd.AddCommand(releasesStatsCmd)
+	statsCmd.AddCommand(cveStatsSubCmd)
 
-	if err := statsCmd.MarkFlagRequired("repo"); err != nil {
+	repo = releasesStatsCmd.Flags().StringP("repo", "r", "", "repository")
+	startDate = releasesStatsCmd.Flags().StringP("start", "s", "", "start date")
+	endDate = releasesStatsCmd.Flags().StringP("end", "e", "", "end date")
+	format = releasesStatsCmd.Flags().StringP("format", "f", "json", "format (json|yaml)")
+
+	if err := releasesStatsCmd.MarkFlagRequired("repo"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	if err := statsCmd.MarkFlagRequired("start"); err != nil {
+	if err := releasesStatsCmd.MarkFlagRequired("start"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	if err := statsCmd.MarkFlagRequired("end"); err != nil {
+	if err := releasesStatsCmd.MarkFlagRequired("end"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -17,12 +17,13 @@ import (
 )
 
 var (
-	repo       *string
-	startDate  *string
-	endDate    *string
-	format     *string
-	webhookURL *string
-	severity   *string
+	repo         *string
+	startDate    *string
+	endDate      *string
+	format       *string
+	webhookURL   *string
+	severity     *string
+	skipMirrored *bool
 )
 
 var repoToOwner = map[string]string{
@@ -105,7 +106,7 @@ var cveStatsSubCmd = &cobra.Command{
 			return err
 		}
 
-		return reports.CVEsBySeverity(*severity, *webhookURL)
+		return reports.CVEsBySeverity(*severity, *webhookURL, *skipMirrored)
 	},
 }
 
@@ -121,6 +122,7 @@ func init() {
 	format = releasesStatsCmd.Flags().StringP("format", "f", "json", "format (json|yaml)")
 	webhookURL = cveStatsSubCmd.Flags().StringP("webhook-url", "u", "", "Slack webhook URL for sending messages")
 	severity = cveStatsSubCmd.Flags().StringP("severity", "s", "critical", "severity (critical|high|medium|low)")
+	skipMirrored = cveStatsSubCmd.Flags().BoolP("skip-mirrored", "m", false, "skip mirrored images when calculating CVE statistics")
 
 	if err := releasesStatsCmd.MarkFlagRequired("repo"); err != nil {
 		fmt.Println(err.Error())

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	repo      *string
-	startDate *string
-	endDate   *string
-	format    *string
+	repo       *string
+	startDate  *string
+	endDate    *string
+	format     *string
+	webhookURL *string
 )
 
 var repoToOwner = map[string]string{
@@ -103,7 +104,7 @@ var cveStatsSubCmd = &cobra.Command{
 			return err
 		}
 
-		return reports.CVEsBySeverity("critical")
+		return reports.CVEsBySeverity("critical", *webhookURL)
 	},
 }
 
@@ -117,6 +118,7 @@ func init() {
 	startDate = releasesStatsCmd.Flags().StringP("start", "s", "", "start date")
 	endDate = releasesStatsCmd.Flags().StringP("end", "e", "", "end date")
 	format = releasesStatsCmd.Flags().StringP("format", "f", "json", "format (json|yaml)")
+	webhookURL = cveStatsSubCmd.Flags().StringP("webhook-url", "u", "", "Slack webhook URL for sending messages")
 
 	if err := releasesStatsCmd.MarkFlagRequired("repo"); err != nil {
 		fmt.Println(err.Error())
@@ -127,6 +129,11 @@ func init() {
 		os.Exit(1)
 	}
 	if err := releasesStatsCmd.MarkFlagRequired("end"); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	if err := cveStatsSubCmd.MarkFlagRequired("webhook-url"); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -103,7 +103,7 @@ var cveStatsSubCmd = &cobra.Command{
 			return err
 		}
 
-		return reports.PrintCVEsBySeverity("critical")
+		return reports.CVEsBySeverity("critical")
 	},
 }
 

--- a/cmd/release/cmd/stats.go
+++ b/cmd/release/cmd/stats.go
@@ -98,7 +98,12 @@ var cveStatsSubCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		ghClient := repository.NewGithub(ctx, rootConfig.Auth.GithubToken)
-		return metrics.CVEsMetrics(ctx, ghClient)
+		reports, err := metrics.CVEsMetrics(ctx, ghClient)
+		if err != nil {
+			return err
+		}
+
+		return reports.PrintCVEsBySeverity("critical")
 	},
 }
 

--- a/cmd/release/config/config.go
+++ b/cmd/release/config/config.go
@@ -10,15 +10,16 @@ import (
 )
 
 const (
-	RancherGithubOrganization  = "rancher"
-	RancherRepositoryName      = "rancher"
-	RancherPrimeRepositoryName = "rancher-prime"
-	UIRepositoryName           = "ui"
-	DashboardRepositoryName    = "dashboard"
-	CLIRepositoryName          = "cli"
-	K3sGithubOrganization      = "k3s-io"
-	K3sRepositoryName          = "k3s"
-	K3sK8sRepositoryName       = "kubernetes"
+	RancherGithubOrganization   = "rancher"
+	RancherRepositoryName       = "rancher"
+	RancherPrimeRepositoryName  = "rancher-prime"
+	UIRepositoryName            = "ui"
+	DashboardRepositoryName     = "dashboard"
+	CLIRepositoryName           = "cli"
+	K3sGithubOrganization       = "k3s-io"
+	K3sRepositoryName           = "k3s"
+	K3sK8sRepositoryName        = "kubernetes"
+	ImageScanningRepositoryName = "image-scanning"
 )
 
 const (

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -1,0 +1,1 @@
+package metrics

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -49,98 +49,114 @@ func (s SeverityCounts) Total() int {
 	return s.Critical + s.High + s.Medium + s.Low + s.Other
 }
 
-type ProjectReport struct {
-	Name   string
-	CVEs   []CVE
-	Counts SeverityCounts
+// ReleaseReport holds all filtered CVEs for a single project+release pair.
+type ReleaseReport struct {
+	ProjectName string
+	Release     string
+	CVEs        []CVE
+	Counts      SeverityCounts
 }
 
 type ReportData struct {
 	MinSeverity string
-	Projects    []ProjectReport
+	Releases    []ReleaseReport
 	Totals      SeverityCounts
 }
 
-// CVEsBySeverity filters and renders a CVE report, sending one Slack message per project.
+// CVEsBySeverity filters and renders a CVE report, sending one Slack message per release.
 func (r *Reports) CVEsBySeverity(minSeverity, webhookURL string) error {
 	data := r.buildReportData(minSeverity)
 
-	for i, project := range data.Projects {
-		if err := notifySlackProject(project, data.MinSeverity, webhookURL); err != nil {
-			return fmt.Errorf("failed to send message for project %s: %w", project.Name, err)
+	for i, release := range data.Releases {
+		if err := notifySlackRelease(release, data.MinSeverity, webhookURL); err != nil {
+			return fmt.Errorf("failed to send message for %s · %s: %w", release.ProjectName, release.Release, err)
 		}
 
 		// Slack has a rate limit for Incoming Webhooks, of 1 req / sec.
-		if i < len(data.Projects)-1 {
+		if i < len(data.Releases)-1 {
 			time.Sleep(2 * time.Second)
 		}
 	}
 
-	fmt.Println("Successfully sent all project reports to Slack!")
+	fmt.Println("Successfully sent all release reports to Slack!")
 	return nil
 }
 
-// buildReportData filters, sorts, and counts CVEs.
+// buildReportData filters, sorts, and groups CVEs by project and release.
 func (r *Reports) buildReportData(minSeverity string) ReportData {
 	minScore := severityScore(minSeverity)
 	minSeverityDisplay := strings.ToUpper(minSeverity[:1]) + strings.ToLower(minSeverity[1:])
 
-	allProjects := []ProjectReport{
-		{Name: "Harvester", CVEs: r.Harvester},
-		{Name: "K3s", CVEs: r.K3s},
-		{Name: "Longhorn", CVEs: r.Longhorn},
-		{Name: "Observability", CVEs: r.Observability},
-		{Name: "Observability Agent", CVEs: r.ObservabilityAgent},
-		{Name: "Rancher", CVEs: r.Rancher},
-		{Name: "RKE2", CVEs: r.RKE2},
+	allProjects := []struct {
+		name string
+		cves []CVE
+	}{
+		{"Harvester", r.Harvester},
+		{"K3s", r.K3s},
+		{"Longhorn", r.Longhorn},
+		{"Observability", r.Observability},
+		{"Observability Agent", r.ObservabilityAgent},
+		{"Rancher", r.Rancher},
+		{"RKE2", r.RKE2},
 	}
 
 	data := ReportData{MinSeverity: minSeverityDisplay}
 
 	for _, p := range allProjects {
-		var matched []CVE
-		for _, cve := range p.CVEs {
-			// skip any CVE that does not affect the current project
-			if cve.Status == "not_affected" || cve.Status == "under_investigation" {
+		releaseMap := make(map[string][]CVE)
+		var releaseOrder []string
+
+		for _, cve := range p.cves {
+			if cve.Status != "affected" && cve.Status != "under_investigation" {
 				continue
 			}
-			if severityScore(cve.Severity) >= minScore {
-				matched = append(matched, cve)
+			if severityScore(cve.Severity) < minScore {
+				continue
 			}
+			if _, seen := releaseMap[cve.Release]; !seen {
+				releaseOrder = append(releaseOrder, cve.Release)
+			}
+			releaseMap[cve.Release] = append(releaseMap[cve.Release], cve)
 		}
 
-		sort.Slice(matched, func(i, j int) bool {
-			si, sj := severityScore(matched[i].Severity), severityScore(matched[j].Severity)
-			if si != sj {
-				return si > sj
-			}
-			return matched[i].VulnerabilityID < matched[j].VulnerabilityID
-		})
+		for _, release := range releaseOrder {
+			cves := releaseMap[release]
 
-		counts := countSeverities(matched)
+			sort.Slice(cves, func(i, j int) bool {
+				si, sj := severityScore(cves[i].Severity), severityScore(cves[j].Severity)
+				if si != sj {
+					return si > sj
+				}
+				return cves[i].VulnerabilityID < cves[j].VulnerabilityID
+			})
 
-		data.Projects = append(data.Projects, ProjectReport{
-			Name:   p.Name,
-			CVEs:   matched,
-			Counts: counts,
-		})
+			counts := countSeverities(cves)
+			data.Releases = append(data.Releases, ReleaseReport{
+				ProjectName: p.name,
+				Release:     release,
+				CVEs:        cves,
+				Counts:      counts,
+			})
 
-		data.Totals.Critical += counts.Critical
-		data.Totals.High += counts.High
-		data.Totals.Medium += counts.Medium
-		data.Totals.Low += counts.Low
-		data.Totals.Other += counts.Other
+			data.Totals.Critical += counts.Critical
+			data.Totals.High += counts.High
+			data.Totals.Medium += counts.Medium
+			data.Totals.Low += counts.Low
+			data.Totals.Other += counts.Other
+		}
 	}
 
 	return data
 }
 
-func notifySlackProject(project ProjectReport, minSeverity, webhookURL string) error {
-	if len(project.CVEs) == 0 {
-		fmt.Printf("Skipping notification for '%s', no CVE of severity '%s' or higher found\n", project.Name, minSeverity)
+func notifySlackRelease(release ReleaseReport, minSeverity, webhookURL string) error {
+	if len(release.CVEs) == 0 {
+		fmt.Printf("Skipping notification for '%s · %s', no CVE of severity '%s' or higher found\n",
+			release.ProjectName, release.Release, minSeverity)
 		return nil
 	}
-	payload := buildProjectSlackPayload(project, minSeverity)
+
+	payload := buildReleaseSlackPayload(release, minSeverity)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -187,69 +203,117 @@ type slackText struct {
 	Emoji bool   `json:"emoji,omitempty"`
 }
 
-func buildProjectSlackPayload(project ProjectReport, minSeverity string) slackPayload {
+// buildReleaseSlackPayload builds a Slack message for a single project release.
+//
+// Block budget: Slack enforces a hard limit of 50 blocks per payload. With releases
+// that have hundreds of images and thousands of CVEs, emitting one block per image
+// header and per status label would easily blow past that limit.
+//
+// To stay well under 50 blocks we stream all content (image headers, status labels,
+// and CVE lines) into a single text builder and flush it into section blocks only
+// when the 2900-char mrkdwn limit is approached. The result is:
+//
+//	3 fixed blocks (header + summary + divider)
+//	+ ceil(total_content_chars / 2900) content blocks
+//
+// For a release with 1000 CVEs (~60 chars/line ≈ 60 KB), that yields ~24 blocks total.
+func buildReleaseSlackPayload(release ReleaseReport, minSeverity string) slackPayload {
 	var blocks []slackBlock
 
 	blocks = append(blocks,
-		headerBlock(fmt.Sprintf("🔍 %s Vulnerabilities · Min: %s", project.Name, minSeverity)),
+		headerBlock(fmt.Sprintf("🔍 %s · %s  |  Min: %s", release.ProjectName, release.Release, minSeverity)),
 	)
 
-	if project.Counts.Total() == 0 {
+	if release.Counts.Total() == 0 {
 		blocks = append(blocks, sectionBlock("✅  No findings at or above this severity"))
 		return slackPayload{Blocks: blocks}
 	}
 
 	plural := "s"
-	if project.Counts.Total() == 1 {
+	if release.Counts.Total() == 1 {
 		plural = ""
 	}
 
-	summaryLine := fmt.Sprintf("*%d CVE%s* |  🔴 %d CRIT  |  🟠 %d HIGH  |  🟡 %d MED  |  🔵 %d LOW",
-		project.Counts.Total(), plural,
-		project.Counts.Critical, project.Counts.High, project.Counts.Medium, project.Counts.Low)
+	summaryLine := fmt.Sprintf("*%d CVE%s*  |  🔴 %d CRIT  |  🟠 %d HIGH  |  🟡 %d MED  |  🔵 %d LOW",
+		release.Counts.Total(), plural,
+		release.Counts.Critical, release.Counts.High, release.Counts.Medium, release.Counts.Low)
 
 	blocks = append(blocks,
 		sectionBlock(summaryLine),
 		dividerBlock(),
 	)
 
-	// Append chunked CVE blocks to avoid Slack's 3000 character limit
-	blocks = append(blocks, buildCVEBlocks(project.CVEs)...)
+	// Group CVEs by image, sorted alphabetically for deterministic output.
+	imageMap := make(map[string][]CVE)
+	var imageOrder []string
+	for _, cve := range release.CVEs {
+		if _, seen := imageMap[cve.Image]; !seen {
+			imageOrder = append(imageOrder, cve.Image)
+		}
+		imageMap[cve.Image] = append(imageMap[cve.Image], cve)
+	}
+	sort.Strings(imageOrder)
+
+	statusLabel := map[string]string{
+		"affected":            "⚠️ *Affected*",
+		"under_investigation": "🔎 *Under Investigation*",
+	}
+
+	// stream accumulates all CVE content into a single rolling text buffer.
+	// writeLine flushes it into a new section block whenever the mrkdwn limit
+	// is approached, keeping structural labels and CVE lines in the same flow.
+	var stream strings.Builder
+
+	flush := func() {
+		if stream.Len() > 0 {
+			blocks = append(blocks, sectionBlock(stream.String()))
+			stream.Reset()
+		}
+	}
+
+	writeLine := func(line string) {
+		if stream.Len()+len(line) > 2900 {
+			flush()
+		}
+		stream.WriteString(line)
+	}
+
+	for i, image := range imageOrder {
+		writeLine(fmt.Sprintf("*📦 %s*\n", image))
+
+		// Always render affected before under_investigation.
+		for _, status := range []string{"affected", "under_investigation"} {
+			var group []CVE
+			for _, cve := range imageMap[image] {
+				if cve.Status == status {
+					group = append(group, cve)
+				}
+			}
+			if len(group) == 0 {
+				continue
+			}
+
+			writeLine(statusLabel[status] + "\n")
+			for _, cve := range group {
+				writeLine(fmt.Sprintf("%s `%s` %s %s _%s_\n",
+					severityEmoji(cve.Severity),
+					cve.VulnerabilityID,
+					cve.PackageName,
+					cve.PackageVersion,
+					cve.Type,
+				))
+			}
+		}
+
+		// Blank line between images for visual separation, except after the last one.
+		if i < len(imageOrder)-1 {
+			writeLine("\n")
+		}
+	}
+
+	flush()
 
 	return slackPayload{Blocks: blocks}
-}
-
-func buildCVEBlocks(cves []CVE) []slackBlock {
-	var blocks []slackBlock
-	var currentChunk strings.Builder
-
-	for _, cve := range cves {
-		line := fmt.Sprintf("%s  `%s`  %s %s  _%s_",
-			severityEmoji(cve.Severity),
-			cve.VulnerabilityID,
-			cve.PackageName,
-			cve.PackageVersion,
-			cve.Release,
-		)
-		if cve.Status != "" {
-			line += "  ·  " + cve.Status
-		}
-		line += "\n"
-
-		// Slack mrkdwn limit is 3000 chars. We chunk at 2900 to be perfectly safe.
-		if currentChunk.Len()+len(line) > 2900 {
-			blocks = append(blocks, sectionBlock(currentChunk.String()))
-			currentChunk.Reset()
-		}
-		currentChunk.WriteString(line)
-	}
-
-	// Flush the remaining text as the final block
-	if currentChunk.Len() > 0 {
-		blocks = append(blocks, sectionBlock(currentChunk.String()))
-	}
-
-	return blocks
 }
 
 func headerBlock(text string) slackBlock {
@@ -388,7 +452,6 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 }
 
 func downloadAndParseCSV(client *http.Client, downloadURL string) ([]CVE, error) {
-
 	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -282,7 +282,10 @@ func buildReleaseSlackPayload(release ReleaseReport, minSeverity string) slackPa
 	}
 
 	for i, image := range imageOrder {
-		writeLine(fmt.Sprintf("*📦 %s*\n", image))
+		// this is a workaround to prevent Slack from auto-linking image names as URLs, which breaks the formatting.
+		// inserting a zero-width space after each dot allows the image name to render correctly.
+		safeImage := strings.ReplaceAll(image, ".", ".\u200B")
+		writeLine(fmt.Sprintf("*📦 %s*\n", safeImage))
 
 		// Always render affected before under_investigation.
 		for _, status := range []string{"affected", "under_investigation"} {

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -1,1 +1,62 @@
 package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v85/github"
+	"github.com/rancher/ecm-distro-tools/cmd/release/config"
+)
+
+const (
+	reportsFolder = "reports"
+)
+
+type Reports struct {
+	Harvester          []CVE
+	K3s                []CVE
+	Longhorn           []CVE
+	Observability      []CVE
+	ObservabilityAgent []CVE
+	Rancher            []CVE
+	RKE2               []CVE
+}
+
+type CVE struct {
+	Image           string
+	Release         string
+	PackageName     string
+	PackageVersion  string
+	Type            string
+	VulnerabilityID string
+	Severity        string
+	URL             string
+	Target          string
+	PatchedVersion  string
+	Mirrored        bool
+	Status          string
+	Justification   string
+}
+
+func CVEsMetrics(ctx context.Context, client *github.Client) error {
+	opts := &github.RepositoryContentGetOptions{
+		Ref: "main",
+	}
+
+	// GetContents returns (fileContent, directoryContent, response, error).
+	// But since we are querying a directory(reports), fileContent will be nil, and directoryContent will be populated.
+	_, directoryContent, _, err := client.Repositories.GetContents(ctx, config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, opts)
+	if err != nil {
+		return fmt.Errorf("failed to get contents for %s/%s at path %s: %w", config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, err)
+	}
+
+	for _, item := range directoryContent {
+		switch item.GetType() {
+		case "file":
+			fmt.Printf("File: %s\n", item.GetName())
+			//fmt.Printf("\tURL: %s\n", item.GetDownloadURL())
+		}
+	}
+
+	return nil
+}

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -67,8 +67,8 @@ type ReportData struct {
 }
 
 // CVEsBySeverity filters and renders a CVE report, sending one Slack message per release.
-func (r *Reports) CVEsBySeverity(minSeverity, webhookURL string) error {
-	data := r.buildReportData(minSeverity)
+func (r *Reports) CVEsBySeverity(minSeverity, webhookURL string, skipMirrored bool) error {
+	data := r.buildReportData(minSeverity, skipMirrored)
 
 	for i, release := range data.Releases {
 		if err := notifySlackRelease(release, data.MinSeverity, webhookURL); err != nil {
@@ -86,7 +86,7 @@ func (r *Reports) CVEsBySeverity(minSeverity, webhookURL string) error {
 }
 
 // buildReportData filters, sorts, and groups CVEs by project and release.
-func (r *Reports) buildReportData(minSeverity string) ReportData {
+func (r *Reports) buildReportData(minSeverity string, skipMirrored bool) ReportData {
 	minScore := severityScore(minSeverity)
 	minSeverityDisplay := strings.ToUpper(minSeverity[:1]) + strings.ToLower(minSeverity[1:])
 
@@ -110,6 +110,10 @@ func (r *Reports) buildReportData(minSeverity string) ReportData {
 		var releaseOrder []string
 
 		for _, cve := range p.cves {
+			// Skip mirrored images if the 'skipMirrored' flag is set to true.
+			if skipMirrored && (cve.Mirrored || strings.Contains(strings.ToLower(cve.Image), "mirrored")) {
+				continue
+			}
 			if cve.Status != "affected" && cve.Status != "under_investigation" {
 				continue
 			}

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -2,7 +2,14 @@ package metrics
 
 import (
 	"context"
+	"encoding/csv"
 	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
@@ -22,6 +29,70 @@ type Reports struct {
 	RKE2               []CVE
 }
 
+type ProjectReport struct {
+	Name string
+	CVEs []CVE
+}
+
+type ReportData struct {
+	MinSeverity string
+	Projects    []ProjectReport
+}
+
+// PrintCVEsBySeverity prints a formatted report of all CVEs that meet or exceed the given severity using a template.
+func (r *Reports) PrintCVEsBySeverity(minSeverity string) error {
+	minScore := severityScore(minSeverity)
+	minSeverityDisplay := strings.ToUpper(minSeverity[:1]) + strings.ToLower(minSeverity[1:])
+
+	// Group the projects for easy iteration in the template
+	allProjects := []ProjectReport{
+		{"Harvester", r.Harvester},
+		{"K3s", r.K3s},
+		{"Longhorn", r.Longhorn},
+		{"Observability", r.Observability},
+		{"Observability Agent", r.ObservabilityAgent},
+		{"Rancher", r.Rancher},
+		{"RKE2", r.RKE2},
+	}
+
+	data := ReportData{
+		MinSeverity: minSeverityDisplay,
+	}
+
+	// Filter CVEs based on severity
+	for _, p := range allProjects {
+		var matched []CVE
+		for _, cve := range p.CVEs {
+			if severityScore(cve.Severity) >= minScore {
+				matched = append(matched, cve)
+			}
+		}
+		data.Projects = append(data.Projects, ProjectReport{
+			Name: p.Name,
+			CVEs: matched,
+		})
+	}
+
+	// Register a custom function to format the severity block
+	funcMap := template.FuncMap{
+		"formatSeverity": func(s string) string {
+			return fmt.Sprintf("%-8s", strings.ToUpper(s))
+		},
+	}
+
+	tmpl, err := template.New("cve-report").Funcs(funcMap).Parse(reportTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse report template: %w", err)
+	}
+
+	// Execute the template directly to standard output
+	if err := tmpl.Execute(os.Stdout, data); err != nil {
+		return fmt.Errorf("failed to execute report template: %w", err)
+	}
+
+	return nil
+}
+
 type CVE struct {
 	Image           string
 	Release         string
@@ -38,25 +109,151 @@ type CVE struct {
 	Justification   string
 }
 
-func CVEsMetrics(ctx context.Context, client *github.Client) error {
+// CVEsMetrics fetches and unmarshals CSV reports into the Reports struct.
+func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 	opts := &github.RepositoryContentGetOptions{
 		Ref: "main",
 	}
 
-	// GetContents returns (fileContent, directoryContent, response, error).
-	// But since we are querying a directory(reports), fileContent will be nil, and directoryContent will be populated.
-	_, directoryContent, _, err := client.Repositories.GetContents(ctx, config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, opts)
+	_, directoryContent, _, err := client.Repositories.GetContents(
+		ctx,
+		config.RancherGithubOrganization,
+		config.ImageScanningRepositoryName,
+		reportsFolder,
+		opts,
+	)
 	if err != nil {
-		return fmt.Errorf("failed to get contents for %s/%s at path %s: %w", config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, err)
+		return nil, fmt.Errorf("failed to get contents for %s/%s at path %s: %w",
+			config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, err)
 	}
 
+	// Regex to match the project name and ensure we only process -cves.csv files.
+	// the observability-agent should be before observability so the match doesn't clip the name.
+	cveFileRegex := regexp.MustCompile(`^report-(harvester|k3s|longhorn|observability-agent|observability|rancher|rke2)-.*-cves\.csv$`)
+
+	reports := &Reports{}
+
 	for _, item := range directoryContent {
-		switch item.GetType() {
-		case "file":
-			fmt.Printf("File: %s\n", item.GetName())
-			//fmt.Printf("\tURL: %s\n", item.GetDownloadURL())
+		if item.GetType() != "file" {
+			continue
+		}
+
+		matches := cveFileRegex.FindStringSubmatch(item.GetName())
+		// Skip files that don't match our CVE reports pattern (like stats.csv)
+		if len(matches) < 2 {
+			continue
+		}
+
+		projectName := matches[1]
+
+		cves, err := downloadAndParseCSV(item.GetDownloadURL())
+		if err != nil {
+			return nil, fmt.Errorf("failed to process %s: %w", item.GetName(), err)
+		}
+
+		// Route the parsed CVEs to the correct project slice
+		switch projectName {
+		case "harvester":
+			reports.Harvester = append(reports.Harvester, cves...)
+		case "k3s":
+			reports.K3s = append(reports.K3s, cves...)
+		case "longhorn":
+			reports.Longhorn = append(reports.Longhorn, cves...)
+		case "observability-agent":
+			reports.ObservabilityAgent = append(reports.ObservabilityAgent, cves...)
+		case "observability":
+			reports.Observability = append(reports.Observability, cves...)
+		case "rancher":
+			reports.Rancher = append(reports.Rancher, cves...)
+		case "rke2":
+			reports.RKE2 = append(reports.RKE2, cves...)
 		}
 	}
 
-	return nil
+	return reports, nil
+}
+
+// downloadAndParseCSV handles fetching the file and unmarshaling the rows into CVE structs.
+func downloadAndParseCSV(downloadURL string) ([]CVE, error) {
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download csv: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d when downloading csv", resp.StatusCode)
+	}
+
+	reader := csv.NewReader(resp.Body)
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read csv records: %w", err)
+	}
+
+	var cves []CVE
+	for i, row := range records {
+		// Skip the header row
+		if i == 0 {
+			continue
+		}
+
+		// padding the row to avoid "index out of bounds" panics
+		for len(row) < 13 {
+			row = append(row, "")
+		}
+
+		mirrored, _ := strconv.ParseBool(row[10])
+
+		cve := CVE{
+			Image:           row[0],
+			Release:         row[1],
+			PackageName:     row[2],
+			PackageVersion:  row[3],
+			Type:            row[4],
+			VulnerabilityID: row[5],
+			Severity:        row[6],
+			URL:             row[7],
+			Target:          row[8],
+			PatchedVersion:  row[9],
+			Mirrored:        mirrored,
+			Status:          row[11],
+			Justification:   row[12],
+		}
+		cves = append(cves, cve)
+	}
+
+	return cves, nil
+}
+
+const reportTemplate = `=== Vulnerability Report (Severity: {{ .MinSeverity }} or higher) ===
+{{ range .Projects }}
+--------------------------------------------------
+Project: {{ .Name }}
+--------------------------------------------------
+{{- if not .CVEs }}
+No CVEs found matching or exceeding severity '{{ $.MinSeverity }}'.
+{{- else }}
+{{- range .CVEs }}
+- [{{ formatSeverity .Severity }}] {{ printf "%-15s" .VulnerabilityID }} | Package: {{ .PackageName }} ({{ .PackageVersion }}) | Release: {{ .Release }}
+{{- end }}
+{{- end }}
+{{ end }}
+`
+
+// severityScore assigns a numerical value to severities for easy comparison.
+func severityScore(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
 }

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -346,8 +346,12 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 	}
 
 	cveFileRegex := regexp.MustCompile(`^report-(harvester|k3s|longhorn|observability-agent|observability|rancher|rke2)-.*-cves\.csv$`)
-	reports := &Reports{}
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	reports := &Reports{}
 	for _, item := range directoryContent {
 		if item.GetType() != "file" {
 			continue
@@ -358,7 +362,7 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 			continue
 		}
 
-		cves, err := downloadAndParseCSV(item.GetDownloadURL())
+		cves, err := downloadAndParseCSV(httpClient, item.GetDownloadURL())
 		if err != nil {
 			return nil, fmt.Errorf("failed to process %s: %w", item.GetName(), err)
 		}
@@ -384,8 +388,14 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 	return reports, nil
 }
 
-func downloadAndParseCSV(downloadURL string) ([]CVE, error) {
-	resp, err := http.Get(downloadURL)
+func downloadAndParseCSV(client *http.Client, downloadURL string) ([]CVE, error) {
+
+	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download csv: %w", err)
 	}

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
+	"github.com/sirupsen/logrus"
 )
 
 const reportsFolder = "reports"
@@ -136,6 +137,10 @@ func (r *Reports) buildReportData(minSeverity string) ReportData {
 }
 
 func notifySlackProject(project ProjectReport, minSeverity, webhookURL string) error {
+	if len(project.CVEs) == 0 {
+		logrus.Infof("Skipping notification for '%s', no CVE of severity '%s' or higher found", project.Name, minSeverity)
+		return nil
+	}
 	payload := buildProjectSlackPayload(project, minSeverity)
 
 	body, err := json.Marshal(payload)

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -28,6 +28,8 @@ const (
 	emojiLow      = "🔵"
 )
 
+const csvHeaderCount = 13
+
 type Reports struct {
 	Harvester          []CVE
 	K3s                []CVE
@@ -430,7 +432,7 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 		Timeout: 30 * time.Second,
 	}
 
-	reports := &Reports{}
+	var reports Reports
 	for _, item := range directoryContent {
 		if item.GetType() != "file" {
 			continue
@@ -464,7 +466,7 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 		}
 	}
 
-	return reports, nil
+	return &reports, nil
 }
 
 func downloadAndParseCSV(client *http.Client, downloadURL string) ([]CVE, error) {
@@ -493,7 +495,7 @@ func downloadAndParseCSV(client *http.Client, downloadURL string) ([]CVE, error)
 		if i == 0 {
 			continue
 		}
-		for len(row) < 13 {
+		for len(row) < csvHeaderCount {
 			row = append(row, "")
 		}
 		mirrored, _ := strconv.ParseBool(row[10])

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -3,20 +3,27 @@ package metrics
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
 )
 
+const reportsFolder = "reports"
+
+// Slack severity emojis.
 const (
-	reportsFolder = "reports"
+	emojiCritical = "🔴"
+	emojiHigh     = "🟠"
+	emojiMedium   = "🟡"
+	emojiLow      = "🔵"
 )
 
 type Reports struct {
@@ -29,69 +36,207 @@ type Reports struct {
 	RKE2               []CVE
 }
 
+type SeverityCounts struct {
+	Critical int
+	High     int
+	Medium   int
+	Low      int
+	Other    int
+}
+
+func (s SeverityCounts) Total() int {
+	return s.Critical + s.High + s.Medium + s.Low + s.Other
+}
+
 type ProjectReport struct {
-	Name string
-	CVEs []CVE
+	Name   string
+	CVEs   []CVE
+	Counts SeverityCounts
 }
 
 type ReportData struct {
 	MinSeverity string
 	Projects    []ProjectReport
+	Totals      SeverityCounts
 }
 
-// PrintCVEsBySeverity prints a formatted report of all CVEs that meet or exceed the given severity using a template.
-func (r *Reports) PrintCVEsBySeverity(minSeverity string) error {
+// PrintCVEsBySeverity filters and renders a CVE report as a Slack payload.
+func (r *Reports) CVEsBySeverity(minSeverity string) error {
+	data := r.buildReportData(minSeverity)
+	return renderSlack(data)
+}
+
+// buildReportData filters, sorts, and counts CVEs.
+func (r *Reports) buildReportData(minSeverity string) ReportData {
 	minScore := severityScore(minSeverity)
 	minSeverityDisplay := strings.ToUpper(minSeverity[:1]) + strings.ToLower(minSeverity[1:])
 
-	// Group the projects for easy iteration in the template
 	allProjects := []ProjectReport{
-		{"Harvester", r.Harvester},
-		{"K3s", r.K3s},
-		{"Longhorn", r.Longhorn},
-		{"Observability", r.Observability},
-		{"Observability Agent", r.ObservabilityAgent},
-		{"Rancher", r.Rancher},
-		{"RKE2", r.RKE2},
+		{Name: "Harvester", CVEs: r.Harvester},
+		{Name: "K3s", CVEs: r.K3s},
+		{Name: "Longhorn", CVEs: r.Longhorn},
+		{Name: "Observability", CVEs: r.Observability},
+		{Name: "Observability Agent", CVEs: r.ObservabilityAgent},
+		{Name: "Rancher", CVEs: r.Rancher},
+		{Name: "RKE2", CVEs: r.RKE2},
 	}
 
-	data := ReportData{
-		MinSeverity: minSeverityDisplay,
-	}
+	data := ReportData{MinSeverity: minSeverityDisplay}
 
-	// Filter CVEs based on severity
 	for _, p := range allProjects {
 		var matched []CVE
 		for _, cve := range p.CVEs {
+			// skip any CVE that does not affect the current project
+			if cve.Status == "not_affected" {
+				continue
+			}
 			if severityScore(cve.Severity) >= minScore {
 				matched = append(matched, cve)
 			}
 		}
-		data.Projects = append(data.Projects, ProjectReport{
-			Name: p.Name,
-			CVEs: matched,
+
+		sort.Slice(matched, func(i, j int) bool {
+			si, sj := severityScore(matched[i].Severity), severityScore(matched[j].Severity)
+			if si != sj {
+				return si > sj
+			}
+			return matched[i].VulnerabilityID < matched[j].VulnerabilityID
 		})
+
+		counts := countSeverities(matched)
+
+		data.Projects = append(data.Projects, ProjectReport{
+			Name:   p.Name,
+			CVEs:   matched,
+			Counts: counts,
+		})
+
+		data.Totals.Critical += counts.Critical
+		data.Totals.High += counts.High
+		data.Totals.Medium += counts.Medium
+		data.Totals.Low += counts.Low
+		data.Totals.Other += counts.Other
 	}
 
-	// Register a custom function to format the severity block
-	funcMap := template.FuncMap{
-		"formatSeverity": func(s string) string {
-			return fmt.Sprintf("%-8s", strings.ToUpper(s))
-		},
-	}
-
-	tmpl, err := template.New("cve-report").Funcs(funcMap).Parse(reportTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to parse report template: %w", err)
-	}
-
-	// Execute the template directly to standard output
-	if err := tmpl.Execute(os.Stdout, data); err != nil {
-		return fmt.Errorf("failed to execute report template: %w", err)
-	}
-
-	return nil
+	return data
 }
+
+// ── Slack renderer ───────────────────────────────────────────────────────────
+
+func renderSlack(data ReportData) error {
+	payload := buildSlackPayload(data)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+type slackPayload struct {
+	Blocks []slackBlock `json:"blocks"`
+}
+
+type slackBlock struct {
+	Type string     `json:"type"`
+	Text *slackText `json:"text,omitempty"`
+}
+
+type slackText struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Emoji bool   `json:"emoji,omitempty"`
+}
+
+func buildSlackPayload(data ReportData) slackPayload {
+	var blocks []slackBlock
+
+	blocks = append(blocks,
+		headerBlock(fmt.Sprintf("🔍 Vulnerability Report · Min Severity: %s", data.MinSeverity)),
+		sectionBlock(fmt.Sprintf("*SUMMARY*\n%s", buildSummaryTable(data))),
+		dividerBlock(),
+		sectionBlock("*DETAILS*"),
+	)
+
+	for _, p := range data.Projects {
+		if p.Counts.Total() == 0 {
+			blocks = append(blocks, sectionBlock(
+				fmt.Sprintf("✅  *%s* — No findings at or above this severity", p.Name),
+			))
+			continue
+		}
+
+		plural := "s"
+		if p.Counts.Total() == 1 {
+			plural = ""
+		}
+		blocks = append(blocks,
+			sectionBlock(fmt.Sprintf("*%s* — %d CVE%s", p.Name, p.Counts.Total(), plural)),
+			sectionBlock(buildCVELines(p.CVEs)),
+			dividerBlock(),
+		)
+	}
+
+	return slackPayload{Blocks: blocks}
+}
+
+func buildSummaryTable(data ReportData) string {
+	const header = "Project                  CRIT   HIGH    MED    LOW   TOTAL"
+	sep := strings.Repeat("─", len(header))
+
+	var sb strings.Builder
+	sb.WriteString("```\n")
+	sb.WriteString(header + "\n")
+	sb.WriteString(sep + "\n")
+
+	for _, p := range data.Projects {
+		fmt.Fprintf(&sb, "%-24s %5d  %5d  %5d  %5d  %6d\n",
+			p.Name,
+			p.Counts.Critical, p.Counts.High, p.Counts.Medium, p.Counts.Low,
+			p.Counts.Total(),
+		)
+	}
+
+	sb.WriteString(sep + "\n")
+	fmt.Fprintf(&sb, "%-24s %5d  %5d  %5d  %5d  %6d\n",
+		"Total",
+		data.Totals.Critical, data.Totals.High, data.Totals.Medium, data.Totals.Low,
+		data.Totals.Total(),
+	)
+	sb.WriteString("```")
+
+	return sb.String()
+}
+
+func buildCVELines(cves []CVE) string {
+	var lines []string
+	for _, cve := range cves {
+		line := fmt.Sprintf("%s  `%s`  %s %s  _%s_",
+			severityEmoji(cve.Severity),
+			cve.VulnerabilityID,
+			cve.PackageName,
+			cve.PackageVersion,
+			cve.Release,
+		)
+		if cve.Status != "" {
+			line += "  ·  " + cve.Status
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func headerBlock(text string) slackBlock {
+	return slackBlock{Type: "header", Text: &slackText{Type: "plain_text", Text: text, Emoji: true}}
+}
+
+func sectionBlock(text string) slackBlock {
+	return slackBlock{Type: "section", Text: &slackText{Type: "mrkdwn", Text: text}}
+}
+
+func dividerBlock() slackBlock {
+	return slackBlock{Type: "divider"}
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
 
 type CVE struct {
 	Image           string
@@ -109,11 +254,59 @@ type CVE struct {
 	Justification   string
 }
 
-// CVEsMetrics fetches and unmarshals CSV reports into the Reports struct.
-func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
-	opts := &github.RepositoryContentGetOptions{
-		Ref: "main",
+func countSeverities(cves []CVE) SeverityCounts {
+	var c SeverityCounts
+	for _, cve := range cves {
+		switch strings.ToLower(strings.TrimSpace(cve.Severity)) {
+		case "critical":
+			c.Critical++
+		case "high":
+			c.High++
+		case "medium":
+			c.Medium++
+		case "low":
+			c.Low++
+		default:
+			c.Other++
+		}
 	}
+	return c
+}
+
+func severityEmoji(severity string) string {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return emojiCritical
+	case "high":
+		return emojiHigh
+	case "medium":
+		return emojiMedium
+	case "low":
+		return emojiLow
+	default:
+		return "⚪"
+	}
+}
+
+func severityScore(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// ── Data fetching ────────────────────────────────────────────────────────────
+
+func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
+	opts := &github.RepositoryContentGetOptions{Ref: "main"}
 
 	_, directoryContent, _, err := client.Repositories.GetContents(
 		ctx,
@@ -127,10 +320,7 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 			config.RancherGithubOrganization, config.ImageScanningRepositoryName, reportsFolder, err)
 	}
 
-	// Regex to match the project name and ensure we only process -cves.csv files.
-	// the observability-agent should be before observability so the match doesn't clip the name.
 	cveFileRegex := regexp.MustCompile(`^report-(harvester|k3s|longhorn|observability-agent|observability|rancher|rke2)-.*-cves\.csv$`)
-
 	reports := &Reports{}
 
 	for _, item := range directoryContent {
@@ -139,20 +329,16 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 		}
 
 		matches := cveFileRegex.FindStringSubmatch(item.GetName())
-		// Skip files that don't match our CVE reports pattern (like stats.csv)
 		if len(matches) < 2 {
 			continue
 		}
-
-		projectName := matches[1]
 
 		cves, err := downloadAndParseCSV(item.GetDownloadURL())
 		if err != nil {
 			return nil, fmt.Errorf("failed to process %s: %w", item.GetName(), err)
 		}
 
-		// Route the parsed CVEs to the correct project slice
-		switch projectName {
+		switch matches[1] {
 		case "harvester":
 			reports.Harvester = append(reports.Harvester, cves...)
 		case "k3s":
@@ -173,7 +359,6 @@ func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 	return reports, nil
 }
 
-// downloadAndParseCSV handles fetching the file and unmarshaling the rows into CVE structs.
 func downloadAndParseCSV(downloadURL string) ([]CVE, error) {
 	resp, err := http.Get(downloadURL)
 	if err != nil {
@@ -185,28 +370,21 @@ func downloadAndParseCSV(downloadURL string) ([]CVE, error) {
 		return nil, fmt.Errorf("unexpected status code %d when downloading csv", resp.StatusCode)
 	}
 
-	reader := csv.NewReader(resp.Body)
-
-	records, err := reader.ReadAll()
+	records, err := csv.NewReader(resp.Body).ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read csv records: %w", err)
 	}
 
 	var cves []CVE
 	for i, row := range records {
-		// Skip the header row
 		if i == 0 {
 			continue
 		}
-
-		// padding the row to avoid "index out of bounds" panics
 		for len(row) < 13 {
 			row = append(row, "")
 		}
-
 		mirrored, _ := strconv.ParseBool(row[10])
-
-		cve := CVE{
+		cves = append(cves, CVE{
 			Image:           row[0],
 			Release:         row[1],
 			PackageName:     row[2],
@@ -220,40 +398,8 @@ func downloadAndParseCSV(downloadURL string) ([]CVE, error) {
 			Mirrored:        mirrored,
 			Status:          row[11],
 			Justification:   row[12],
-		}
-		cves = append(cves, cve)
+		})
 	}
 
 	return cves, nil
-}
-
-const reportTemplate = `=== Vulnerability Report (Severity: {{ .MinSeverity }} or higher) ===
-{{ range .Projects }}
---------------------------------------------------
-Project: {{ .Name }}
---------------------------------------------------
-{{- if not .CVEs }}
-No CVEs found matching or exceeding severity '{{ $.MinSeverity }}'.
-{{- else }}
-{{- range .CVEs }}
-- [{{ formatSeverity .Severity }}] {{ printf "%-15s" .VulnerabilityID }} | Package: {{ .PackageName }} ({{ .PackageVersion }}) | Release: {{ .Release }}
-{{- end }}
-{{- end }}
-{{ end }}
-`
-
-// severityScore assigns a numerical value to severities for easy comparison.
-func severityScore(severity string) int {
-	switch strings.ToLower(strings.TrimSpace(severity)) {
-	case "critical":
-		return 4
-	case "high":
-		return 3
-	case "medium":
-		return 2
-	case "low":
-		return 1
-	default:
-		return 0
-	}
 }

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
-	"github.com/sirupsen/logrus"
 )
 
 const reportsFolder = "reports"
@@ -138,7 +137,7 @@ func (r *Reports) buildReportData(minSeverity string) ReportData {
 
 func notifySlackProject(project ProjectReport, minSeverity, webhookURL string) error {
 	if len(project.CVEs) == 0 {
-		logrus.Infof("Skipping notification for '%s', no CVE of severity '%s' or higher found", project.Name, minSeverity)
+		fmt.Printf("Skipping notification for '%s', no CVE of severity '%s' or higher found\n", project.Name, minSeverity)
 		return nil
 	}
 	payload := buildProjectSlackPayload(project, minSeverity)

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
+	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
 )
 
 const reportsFolder = "reports"
@@ -169,7 +170,7 @@ func notifySlackRelease(release ReleaseReport, minSeverity, webhookURL string) e
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := ecmHTTP.NewClient(time.Second * 30)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request to slack: %w", err)

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -1,16 +1,18 @@
 package metrics
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v85/github"
 	"github.com/rancher/ecm-distro-tools/cmd/release/config"
@@ -18,7 +20,6 @@ import (
 
 const reportsFolder = "reports"
 
-// Slack severity emojis.
 const (
 	emojiCritical = "🔴"
 	emojiHigh     = "🟠"
@@ -60,10 +61,23 @@ type ReportData struct {
 	Totals      SeverityCounts
 }
 
-// PrintCVEsBySeverity filters and renders a CVE report as a Slack payload.
-func (r *Reports) CVEsBySeverity(minSeverity string) error {
+// CVEsBySeverity filters and renders a CVE report, sending one Slack message per project.
+func (r *Reports) CVEsBySeverity(minSeverity, webhookURL string) error {
 	data := r.buildReportData(minSeverity)
-	return renderSlack(data)
+
+	for i, project := range data.Projects {
+		if err := notifySlackProject(project, data.MinSeverity, webhookURL); err != nil {
+			return fmt.Errorf("failed to send message for project %s: %w", project.Name, err)
+		}
+
+		// Slack has a rate limit for Incoming Webhooks, of 1 req / sec.
+		if i < len(data.Projects)-1 {
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	fmt.Println("Successfully sent all project reports to Slack!")
+	return nil
 }
 
 // buildReportData filters, sorts, and counts CVEs.
@@ -87,7 +101,7 @@ func (r *Reports) buildReportData(minSeverity string) ReportData {
 		var matched []CVE
 		for _, cve := range p.CVEs {
 			// skip any CVE that does not affect the current project
-			if cve.Status == "not_affected" {
+			if cve.Status == "not_affected" || cve.Status == "under_investigation" {
 				continue
 			}
 			if severityScore(cve.Severity) >= minScore {
@@ -121,14 +135,37 @@ func (r *Reports) buildReportData(minSeverity string) ReportData {
 	return data
 }
 
-// ── Slack renderer ───────────────────────────────────────────────────────────
+func notifySlackProject(project ProjectReport, minSeverity, webhookURL string) error {
+	payload := buildProjectSlackPayload(project, minSeverity)
 
-func renderSlack(data ReportData) error {
-	payload := buildSlackPayload(data)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal slack payload: %w", err)
+	}
 
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(payload)
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to create http request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request to slack: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respB, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response's body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("slack API rejected the request with status %d: %s", resp.StatusCode, string(respB))
+	}
+
+	return nil
 }
 
 type slackPayload struct {
@@ -146,68 +183,42 @@ type slackText struct {
 	Emoji bool   `json:"emoji,omitempty"`
 }
 
-func buildSlackPayload(data ReportData) slackPayload {
+func buildProjectSlackPayload(project ProjectReport, minSeverity string) slackPayload {
 	var blocks []slackBlock
 
 	blocks = append(blocks,
-		headerBlock(fmt.Sprintf("🔍 Vulnerability Report · Min Severity: %s", data.MinSeverity)),
-		sectionBlock(fmt.Sprintf("*SUMMARY*\n%s", buildSummaryTable(data))),
-		dividerBlock(),
-		sectionBlock("*DETAILS*"),
+		headerBlock(fmt.Sprintf("🔍 %s Vulnerabilities · Min: %s", project.Name, minSeverity)),
 	)
 
-	for _, p := range data.Projects {
-		if p.Counts.Total() == 0 {
-			blocks = append(blocks, sectionBlock(
-				fmt.Sprintf("✅  *%s* — No findings at or above this severity", p.Name),
-			))
-			continue
-		}
-
-		plural := "s"
-		if p.Counts.Total() == 1 {
-			plural = ""
-		}
-		blocks = append(blocks,
-			sectionBlock(fmt.Sprintf("*%s* — %d CVE%s", p.Name, p.Counts.Total(), plural)),
-			sectionBlock(buildCVELines(p.CVEs)),
-			dividerBlock(),
-		)
+	if project.Counts.Total() == 0 {
+		blocks = append(blocks, sectionBlock("✅  No findings at or above this severity"))
+		return slackPayload{Blocks: blocks}
 	}
+
+	plural := "s"
+	if project.Counts.Total() == 1 {
+		plural = ""
+	}
+
+	summaryLine := fmt.Sprintf("*%d CVE%s* |  🔴 %d CRIT  |  🟠 %d HIGH  |  🟡 %d MED  |  🔵 %d LOW",
+		project.Counts.Total(), plural,
+		project.Counts.Critical, project.Counts.High, project.Counts.Medium, project.Counts.Low)
+
+	blocks = append(blocks,
+		sectionBlock(summaryLine),
+		dividerBlock(),
+	)
+
+	// Append chunked CVE blocks to avoid Slack's 3000 character limit
+	blocks = append(blocks, buildCVEBlocks(project.CVEs)...)
 
 	return slackPayload{Blocks: blocks}
 }
 
-func buildSummaryTable(data ReportData) string {
-	const header = "Project                  CRIT   HIGH    MED    LOW   TOTAL"
-	sep := strings.Repeat("─", len(header))
+func buildCVEBlocks(cves []CVE) []slackBlock {
+	var blocks []slackBlock
+	var currentChunk strings.Builder
 
-	var sb strings.Builder
-	sb.WriteString("```\n")
-	sb.WriteString(header + "\n")
-	sb.WriteString(sep + "\n")
-
-	for _, p := range data.Projects {
-		fmt.Fprintf(&sb, "%-24s %5d  %5d  %5d  %5d  %6d\n",
-			p.Name,
-			p.Counts.Critical, p.Counts.High, p.Counts.Medium, p.Counts.Low,
-			p.Counts.Total(),
-		)
-	}
-
-	sb.WriteString(sep + "\n")
-	fmt.Fprintf(&sb, "%-24s %5d  %5d  %5d  %5d  %6d\n",
-		"Total",
-		data.Totals.Critical, data.Totals.High, data.Totals.Medium, data.Totals.Low,
-		data.Totals.Total(),
-	)
-	sb.WriteString("```")
-
-	return sb.String()
-}
-
-func buildCVELines(cves []CVE) string {
-	var lines []string
 	for _, cve := range cves {
 		line := fmt.Sprintf("%s  `%s`  %s %s  _%s_",
 			severityEmoji(cve.Severity),
@@ -219,9 +230,22 @@ func buildCVELines(cves []CVE) string {
 		if cve.Status != "" {
 			line += "  ·  " + cve.Status
 		}
-		lines = append(lines, line)
+		line += "\n"
+
+		// Slack mrkdwn limit is 3000 chars. We chunk at 2900 to be perfectly safe.
+		if currentChunk.Len()+len(line) > 2900 {
+			blocks = append(blocks, sectionBlock(currentChunk.String()))
+			currentChunk.Reset()
+		}
+		currentChunk.WriteString(line)
 	}
-	return strings.Join(lines, "\n")
+
+	// Flush the remaining text as the final block
+	if currentChunk.Len() > 0 {
+		blocks = append(blocks, sectionBlock(currentChunk.String()))
+	}
+
+	return blocks
 }
 
 func headerBlock(text string) slackBlock {
@@ -235,8 +259,6 @@ func sectionBlock(text string) slackBlock {
 func dividerBlock() slackBlock {
 	return slackBlock{Type: "divider"}
 }
-
-// ── Shared helpers ───────────────────────────────────────────────────────────
 
 type CVE struct {
 	Image           string
@@ -302,8 +324,6 @@ func severityScore(severity string) int {
 		return 0
 	}
 }
-
-// ── Data fetching ────────────────────────────────────────────────────────────
 
 func CVEsMetrics(ctx context.Context, client *github.Client) (*Reports, error) {
 	opts := &github.RepositoryContentGetOptions{Ref: "main"}

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -355,9 +355,9 @@ type CVE struct {
 	URL             string
 	Target          string
 	PatchedVersion  string
-	Mirrored        bool
 	Status          string
 	Justification   string
+	Mirrored        bool
 }
 
 func countSeverities(cves []CVE) SeverityCounts {

--- a/release/metrics/cve.go
+++ b/release/metrics/cve.go
@@ -318,15 +318,30 @@ func buildReleaseSlackPayload(release ReleaseReport, minSeverity string) slackPa
 }
 
 func headerBlock(text string) slackBlock {
-	return slackBlock{Type: "header", Text: &slackText{Type: "plain_text", Text: text, Emoji: true}}
+	return slackBlock{
+		Type: "header",
+		Text: &slackText{
+			Type:  "plain_text",
+			Text:  text,
+			Emoji: true,
+		},
+	}
 }
 
 func sectionBlock(text string) slackBlock {
-	return slackBlock{Type: "section", Text: &slackText{Type: "mrkdwn", Text: text}}
+	return slackBlock{
+		Type: "section",
+		Text: &slackText{
+			Type: "mrkdwn",
+			Text: text,
+		},
+	}
 }
 
 func dividerBlock() slackBlock {
-	return slackBlock{Type: "divider"}
+	return slackBlock{
+		Type: "divider",
+	}
 }
 
 type CVE struct {


### PR DESCRIPTION
This pull request add a new statistics command, `release stats cve` that retrieves the CVE reports from `rancher/image-scanning`, and sends a notification via Slack.



**Command structure and functionality improvements:**

* Refactored the `stats` command to serve as a parent command with dedicated subcommands for releases and CVE statistics, improving clarity and extensibility (`cmd/release/cmd/stats.go`).
* Added a new `cve` subcommand under `stats` that retrieves CVE statistics from current releases and requires a Slack webhook URL for sending messages (`cmd/release/cmd/stats.go`).
* Updated flag handling so that release-related flags are now specific to the `releases` subcommand, and a new `webhook-url` flag is required for the `cve` subcommand (`cmd/release/cmd/stats.go`).

**Dependency and configuration updates:**

* Imported the `metrics` package to support CVE metrics functionality (`cmd/release/cmd/stats.go`).
* Added a new constant `ImageScanningRepositoryName` to the configuration for future use or clarity (`cmd/release/config/config.go`).

**Screenshots of the messages:**

An empty (no CVEs) report:
<img width="445" height="522" alt="image" src="https://github.com/user-attachments/assets/496286d1-c9a2-4b73-a9be-64547aa78c86" />

With CVEs:
<img width="977" height="421" alt="image" src="https://github.com/user-attachments/assets/d79db900-f409-4d8c-b0b7-1d2ac5d90a31" />
