### PR TITLE
fix ecm distro tools install path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,19 @@ runs:
       TAG: ${{ inputs.version }}
     run: |
       INSTALL_SCRIPT_PATH="${RUNNER_TEMP}/install.sh"
-      INSTALL_DIR="$HOME/.local/bin/ecm-distro-tools"
 
       wget -O "${INSTALL_SCRIPT_PATH}" "https://raw.githubusercontent.com/rancher/ecm-distro-tools/${INSTALL_SCRIPT_TAG}/install.sh"
-      chmod +x "${INSTALL_SCRIPT_PATH}" 
+      chmod +x "${INSTALL_SCRIPT_PATH}"
+
+      # Use /usr/local/bin with sudo if available (already in PATH on GitHub runners)
+      if command -v sudo >/dev/null 2>&1; then
+        export INSTALL_DIR="/usr/local/bin"
+        export USE_SUDO=true
+        echo "Installing to ${INSTALL_DIR} using sudo"
+      else
+        export INSTALL_DIR="$HOME/.local/bin/ecm-distro-tools"
+        export USE_SUDO=false
+        echo "Installing to ${INSTALL_DIR}"
+      fi
+
       ${INSTALL_SCRIPT_PATH} ${TAG}
-      echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
-      ls -al "${INSTALL_DIR}"

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,11 @@ TMP_DIR=""
 REPO_NAME="ecm-distro-tools"
 REPO_URL="https://github.com/rancher/${REPO_NAME}"
 REPO_RELEASE_URL="${REPO_URL}/releases"
-INSTALL_DIR="$HOME/.local/bin/ecm-distro-tools"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin/ecm-distro-tools}"
 SUFFIX=""
 DOWNLOADER=""
+USE_SUDO="${USE_SUDO:-false}"
+SUDO=""
 
 
 # setup_arch set arch and suffix fatal if architecture not supported.
@@ -86,14 +88,27 @@ install_binaries() {
     cd "${TMP_DIR}"
     tar -xf "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
     rm "${TMP_DIR}/ecm-distro-tools.${SUFFIX}.tar.gz"
-    mkdir -p "${INSTALL_DIR}"
+
+    if [ "${USE_SUDO}" = "true" ]; then
+        SUDO="sudo"
+    fi
+
+    # Check if install directory exists, create it if USE_SUDO is false
+    if [ ! -d "${INSTALL_DIR}" ]; then
+        if [ "${USE_SUDO}" = "true" ]; then
+            echo "Error: Install directory ${INSTALL_DIR} does not exist"
+            exit 1
+        else
+            mkdir -p "${INSTALL_DIR}"
+        fi
+    fi
 
     for f in * ; do
       file_name="${f}"
       if echo "${f}" | grep -q "${SUFFIX}"; then
         file_name=${file_name%"-${SUFFIX}"}
       fi
-      cp "${TMP_DIR}/${f}" "${INSTALL_DIR}/${file_name}"
+      ${SUDO} cp "${TMP_DIR}/${f}" "${INSTALL_DIR}/${file_name}"
     done
 }
 


### PR DESCRIPTION
Writing to GITHUB_PATH can be a security risk, as it allows for arbitrary code execution.

The install script only tries to create the directory if sudo is not being used to avoid any user input being used there.

- **add custom install dir with default and optionally use sudo**
- **remove github_path write and install to /usr/local/bin**
