### PR TITLE
install action:  use /usr/local/bin by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,15 +22,10 @@ runs:
       wget -O "${INSTALL_SCRIPT_PATH}" "https://raw.githubusercontent.com/rancher/ecm-distro-tools/${INSTALL_SCRIPT_TAG}/install.sh"
       chmod +x "${INSTALL_SCRIPT_PATH}"
 
-      # Use /usr/local/bin with sudo if available (already in PATH on GitHub runners)
+      export INSTALL_DIR="/usr/local/bin"
+      export USE_SUDO=false
       if command -v sudo >/dev/null 2>&1; then
-        export INSTALL_DIR="/usr/local/bin"
         export USE_SUDO=true
-        echo "Installing to ${INSTALL_DIR} using sudo"
-      else
-        export INSTALL_DIR="$HOME/.local/bin/ecm-distro-tools"
-        export USE_SUDO=false
-        echo "Installing to ${INSTALL_DIR}"
       fi
 
       ${INSTALL_SCRIPT_PATH} ${TAG}

--- a/install.sh
+++ b/install.sh
@@ -93,14 +93,10 @@ install_binaries() {
         SUDO="sudo"
     fi
 
-    # Check if install directory exists, create it if USE_SUDO is false
+    # Check if install directory exists
     if [ ! -d "${INSTALL_DIR}" ]; then
-        if [ "${USE_SUDO}" = "true" ]; then
-            echo "Error: Install directory ${INSTALL_DIR} does not exist"
-            exit 1
-        else
-            mkdir -p "${INSTALL_DIR}"
-        fi
+      echo "Error: Install directory ${INSTALL_DIR} does not exist"
+      exit 1
     fi
 
     for f in * ; do


### PR DESCRIPTION
- **install to usr local bin by default**
- **don't try to create directory**

Install to usr/local/bin by default instead of only when sudo is available
