### PR TITLE
Bump slsactl to v0.1.35

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -219,7 +219,7 @@ runs:
   - name: Install Cosign
     uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
   - name: Install slsactl
-    uses: rancherlabs/slsactl/actions/install-slsactl@132f4c15b16537cf031aae50c788fdad1a8fe723 # v0.1.33
+    uses: rancherlabs/slsactl/actions/install-slsactl@ddd4735b474ca57fac67c5a0a0d36d0a4624ac87 # v0.1.35
     with:
       version: v0.1.33
 

--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -221,7 +221,7 @@ runs:
   - name: Install slsactl
     uses: rancherlabs/slsactl/actions/install-slsactl@ddd4735b474ca57fac67c5a0a0d36d0a4624ac87 # v0.1.35
     with:
-      version: v0.1.33
+      version: v0.1.35
 
   - name: Build and push image [Prime]
     id: push-prime


### PR DESCRIPTION
New version includes commit to support hardened vpshere repos 
https://github.com/rancherlabs/slsactl/commit/ddd4735b474ca57fac67c5a0a0d36d0a4624ac87
Signed-off-by: Derek Nola <derek.nola@suse.com>