### PR TITLE
feat. Adding option for skipping sign images

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -153,6 +153,12 @@ inputs:
     type: string
     default: ""
 
+  sign-image:
+    description: |
+      Indicates whether the image should be signed and attested using Cosign and slsactl.
+    default: true
+    type: boolean
+
 runs:
   using: composite
 
@@ -248,11 +254,15 @@ runs:
       IDENTITY_REGISTRY=${IDENTITY_REGISTRY:-"$REGISTRY"}
       IDENTITY="$IDENTITY_REGISTRY/${PRIME_REPO}/${DOCKER_IMAGE}"
 
-      cosign sign \
-        --oidc-provider=github-actions \
-        --yes \
-        --sign-container-identity="$IDENTITY" \
-        "${IMG_NAME}"
+      if [[ "${SIGN_IMAGE}" == "true" ]]; then
+        cosign sign \
+          --oidc-provider=github-actions \
+          --yes \
+          --sign-container-identity="$IDENTITY" \
+          "${IMG_NAME}"
+      else
+        echo "Skipping signing of image ${IMG_NAME} as sign-image is set to false"
+      fi
 
       echo "IMG_NAME=${IMG_NAME}" >> "${GITHUB_OUTPUT}"
     env:
@@ -265,6 +275,7 @@ runs:
       PRIME_REPO: ${{ inputs.prime-repo }}
       PRIME_MAKE_TARGET: ${{ steps.make-targets.outputs.PRIME_MAKE_TARGET }}
       DOCKER_IMAGE: ${{ inputs.image }}
+      SIGN_IMAGE: ${{ inputs.sign-image }}
 
   - name: Build and push image [Public]
     shell: bash
@@ -290,7 +301,7 @@ runs:
 
   - name: Attest provenance
     shell: bash
-    if: ${{ inputs.push-to-prime == true || inputs.push-to-prime == 'true' }}
+    if: ${{ (inputs.push-to-prime == true || inputs.push-to-prime == 'true') && (inputs.sign-image == true || inputs.sign-image == 'true') }}
     run: |
       max_retries=3
       retry_delay=5


### PR DESCRIPTION
I want add a new feature: skip signing the images.

For some cases, we need to publish images to `prime-stg` but we do not need signing the images.
In this particular case, we are publishing images for `rancher-ai-agent` and `rancher-ai-mcp` on `stg prime` with the head code from main In order to check with `image-scanning` the products and know the CVEs as soon as they could arise.

background:
- https://github.com/rancher/rancher-ai-agent/actions/runs/28931529634/job/85831560739
- https://github.com/rancher/security-team/issues/1744