### PR TITLE
Add skip-buildx-setup input to publish-image action

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -77,6 +77,11 @@ inputs:
     type: string
     default: linux/amd64,linux/arm64
 
+  skip-buildx-setup:
+    description: skip buildx setup when making sequential calls to this action
+    default: false
+    type: boolean
+
   push-to-public:
     description: |
       Indicates whether the image should be pushed to the Public container
@@ -210,11 +215,13 @@ runs:
       password: ${{ inputs.prime-password }}
 
   - name: Setup QEMU
+    if: ${{ inputs.skip-buildx-setup != true && inputs.skip-buildx-setup != 'true' }}
     uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     with:
       image: tonistiigi/binfmt:qemu-v10.0.4
       cache-image: false
   - name: Setup Docker Buildx
+    if: ${{ inputs.skip-buildx-setup != true && inputs.skip-buildx-setup != 'true' }}
     uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
   - name: Install Cosign
     uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
Sequential calls to publish-image do not allow efficent cache reuse, as the setup-docker-buildx wipes any cache for a new buildx instance. This is harmful for many of the image-build-XXX repos as we first build and push to PRIME_STAGING and then call the same action again for pushing to PRIME

See https://github.com/rancher/image-build-etcd/actions/runs/32392790681/job/96502596980 as an example, we are doing twice as much work as no intermediate layers can be reused between the builds. 

Signed-off-by: Derek Nola <derek.nola@suse.com>