### PR TITLE
create a tag and not a release for dashboard and only optionally create the ui tag

### DIFF
--- a/cmd/release/cmd/tag.go
+++ b/cmd/release/cmd/tag.go
@@ -22,7 +22,10 @@ type tagRKE2CmdFlags struct {
 	RPMVersion     *int
 }
 
-var tagRKE2Flags tagRKE2CmdFlags
+var (
+	tagRKE2Flags    tagRKE2CmdFlags
+	createUITagFlag *bool
+)
 
 // tagCmd represents the tag command.
 var tagCmd = &cobra.Command{
@@ -304,36 +307,21 @@ var dashboardTagSubCmd = &cobra.Command{
 
 		releaseBranch = config.ValueOrDefault(dashboardRelease.ReleaseBranch, releaseBranch)
 
-		previousTag := dashboardRelease.PreviousTag
-
-		if previousTag == "" {
-			previousTag, err = previousPatch(tag)
+		if createUITagFlag != nil && *createUITagFlag {
+			tag, sha, err := dashboard.CreateTag(ctx, ghClient, repoOwner, uiRepo, tag, "", releaseBranch, releaseType, preRelease, dryRun)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create ui tag: %v", err)
 			}
+
+			fmt.Println("created tag: " + tag + " - " + sha)
 		}
 
-		uiOpts := &repository.CreateReleaseOpts{
-			Tag:    tag,
-			Repo:   uiRepo,
-			Owner:  repoOwner,
-			Branch: releaseBranch,
-			Draft:  false,
+		tag, sha, err := dashboard.CreateTag(ctx, ghClient, repoOwner, dashboardRepo, tag, "", releaseBranch, releaseType, preRelease, dryRun)
+		if err != nil {
+			return fmt.Errorf("failed to create dashboard tag: %v", err)
 		}
-
-		if err := dashboard.CreateUIRelease(ctx, ghClient, uiOpts, preRelease, dryRun, releaseType, previousTag, releaseNotesAlert); err != nil {
-			return err
-		}
-
-		dashboardOpts := &repository.CreateReleaseOpts{
-			Tag:    tag,
-			Repo:   dashboardRepo,
-			Owner:  repoOwner,
-			Branch: releaseBranch,
-			Draft:  false,
-		}
-
-		return dashboard.CreateDashboardRelease(ctx, ghClient, dashboardOpts, preRelease, dryRun, releaseType, previousTag, releaseNotesAlert)
+		fmt.Println("created tag: " + tag + " - " + sha)
+		return nil
 	},
 }
 
@@ -457,6 +445,8 @@ func init() {
 	tagRKE2Flags.ReleaseVersion = rke2TagSubCmd.Flags().StringP("release-version", "r", "r1", "Release version")
 	tagRKE2Flags.RCVersion = rke2TagSubCmd.Flags().String("rc", "", "RC version")
 	tagRKE2Flags.RPMVersion = rke2TagSubCmd.Flags().Int("rpm-version", 0, "RPM version")
+
+	createUITagFlag = dashboardTagSubCmd.Flags().BoolP("create-ui-tag", "t", false, "Also create a rancher/ui tag and not just the dashboard tag")
 }
 
 func releaseTypePreRelease(releaseType string) (bool, error) {

--- a/release/cli/cli.go
+++ b/release/cli/cli.go
@@ -21,7 +21,7 @@ func CreateRelease(ctx context.Context, client *github.Client, opts *repository.
 		return errors.New("tag isn't a valid semver: " + opts.Tag)
 	}
 
-	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
+	latestPreRelease, err := repository.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
 	if err != nil {
 		return err
 	}

--- a/release/dashboard/dashboard.go
+++ b/release/dashboard/dashboard.go
@@ -5,71 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/google/go-github/v90/github"
-	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"golang.org/x/mod/semver"
 )
-
-// CreateDashboardRelease will create a new tag and a new release with given params.
-func CreateDashboardRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, rc, dryRun bool, releaseType, previousTag, releaseAlert string) error {
-	if !semver.IsValid(opts.Tag) {
-		return errors.New("tag isn't a valid semver: " + opts.Tag)
-	}
-
-	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
-	if err != nil {
-		return err
-	}
-
-	if rc {
-		latestRCNumber := 1
-		if latestPreRelease != nil {
-			// v2.9.0-rcN / -alphaN
-			_, trimmedRCNumber, found := strings.Cut(*latestPreRelease, "-"+releaseType)
-			if !found {
-				return errors.New("failed to parse rc number from " + *latestPreRelease)
-			}
-			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
-			if err != nil {
-				return err
-			}
-			latestRCNumber = currentRCNumber + 1
-		}
-		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
-	}
-
-	opts.Name = opts.Tag
-	opts.Prerelease = true
-	opts.ReleaseNotes = ""
-
-	if !rc {
-		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, previousTag)
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, releaseAlert, client)
-		if err != nil {
-			return err
-		}
-		opts.ReleaseNotes = buff.String()
-	}
-
-	fmt.Printf("create release options: %+v\n", *opts)
-
-	if dryRun {
-		fmt.Println("dry run, skipping creating release")
-		return nil
-	}
-
-	createdRelease, err := repository.CreateRelease(ctx, client, opts)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("release created: " + createdRelease.HTMLURL)
-	return nil
-}
 
 // ReleaseBranchFromTag generates the ui release branch for a release line with the format of 'release-{major}.{minor}'. The generated release branch might not be valid depending on multiple factors that cannot be treated on this function such as it being 'master'.
 // Please make sure that this is the expected format before using the generated release branch.
@@ -88,59 +29,31 @@ func ReleaseBranchFromTag(tag string) (string, error) {
 	return releaseBranch, nil
 }
 
-// CreateUIRelease will create a new tag and a new release with given params.
-func CreateUIRelease(ctx context.Context, client *github.Client, opts *repository.CreateReleaseOpts, preRelease, dryRun bool, releaseType, previousTag, releaseNotesAlert string) error {
-	if !semver.IsValid(opts.Tag) {
-		return errors.New("tag isn't a valid semver: " + opts.Tag)
+func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTag, sha, branch, releaseType string, preRelease, dryRun bool) (string, string, error) {
+	if !semver.IsValid(baseTag) {
+		return "", "", errors.New("the base tag is invalid: " + baseTag)
 	}
 
-	latestPreRelease, err := release.LatestPreRelease(ctx, client, opts.Owner, opts.Repo, opts.Tag, releaseType)
-	if err != nil {
-		return err
-	}
-
-	if preRelease {
-		latestRCNumber := 1
-		if latestPreRelease != nil {
-			// v2.9.0-rcN / -alphaN
-			_, trimmedRCNumber, found := strings.Cut(*latestPreRelease, "-"+releaseType)
-			if !found {
-				return errors.New("failed to parse rc number from " + *latestPreRelease)
-			}
-			currentRCNumber, err := strconv.Atoi(trimmedRCNumber)
-			if err != nil {
-				return err
-			}
-			latestRCNumber = currentRCNumber + 1
-		}
-		opts.Tag = fmt.Sprintf("%s-%s%d", opts.Tag, releaseType, latestRCNumber)
-	}
-
-	opts.Name = opts.Tag
-	opts.Prerelease = true
-	opts.ReleaseNotes = ""
-
-	if !preRelease {
-		fmt.Printf("release.GenReleaseNotes(ctx, %s, %s, %s, %s, client)", opts.Owner, opts.Repo, opts.Branch, previousTag)
-		buff, err := release.GenReleaseNotes(ctx, opts.Owner, opts.Repo, opts.Branch, previousTag, releaseNotesAlert, client)
+	if sha == "" {
+		latestCommit, err := repository.BranchLatestCommitSHA(ctx, ghClient, owner, repo, branch)
 		if err != nil {
-			return err
+			return "", "", err
 		}
-		opts.ReleaseNotes = buff.String()
+		sha = latestCommit
 	}
 
-	fmt.Printf("create release options: %+v\n", *opts)
+	tag := baseTag
+	if preRelease {
+		preReleaseTag, err := repository.LatestPreReleaseTag(ctx, ghClient, owner, repo, releaseType, baseTag)
+		if err != nil {
+			return "", "", err
+		}
+		tag = preReleaseTag
+	}
 
 	if dryRun {
-		fmt.Println("dry run, skipping creating release")
-		return nil
+		fmt.Println("dry run, skipping creating tag")
+		return tag, sha, nil
 	}
-
-	createdRelease, err := repository.CreateRelease(ctx, client, opts)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("release created: " + createdRelease.HTMLURL)
-	return nil
+	return repository.CreateTag(ctx, ghClient, owner, repo, tag, sha)
 }

--- a/release/rancher/rancher.go
+++ b/release/rancher/rancher.go
@@ -24,7 +24,6 @@ import (
 	ecmConfig "github.com/rancher/ecm-distro-tools/cmd/release/config"
 	ecmExec "github.com/rancher/ecm-distro-tools/exec"
 	ecmHTTP "github.com/rancher/ecm-distro-tools/http"
-	"github.com/rancher/ecm-distro-tools/release"
 	"github.com/rancher/ecm-distro-tools/release/cli"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"golang.org/x/mod/semver"
@@ -257,58 +256,6 @@ func ReleaseBranchFromTag(tag string) (string, error) {
 	releaseBranch := "release/" + majorMinor
 
 	return releaseBranch, nil
-}
-
-// CreateTag creates a new tag ref on GitHub based on the provided commit SHA or the latest commit on the provided branch.
-// If the tag to be created is a pre-release (rc or alpha) it will automatically find the latest tag and add one to it. E.g: v2.14.0 (pre-release) -> v2.14.0-alpha2
-// Returns tag, commit sha, error
-func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTag, sha, branch, releaseType string, preRelease, dryRun bool) (string, string, error) {
-	if !semver.IsValid(baseTag) {
-		return "", "", errors.New("the base tag is invalid: " + baseTag)
-	}
-
-	if sha == "" {
-		commitSHA, err := repository.RefCommitSHA(ctx, ghClient, owner, repo, "heads/"+branch)
-		if err != nil {
-			return "", "", err
-		}
-		sha = commitSHA
-	}
-
-	tag := baseTag
-
-	if preRelease {
-		latestVersionNumber := 1
-		latestVersion, err := release.LatestPreRelease(ctx, ghClient, owner, repo, baseTag, releaseType)
-		if err != nil {
-			return "", "", err
-		}
-
-		if latestVersion != nil {
-			trimmedVersionNumber := strings.TrimPrefix(*latestVersion, baseTag+"-"+releaseType)
-			currentVersionNumber, err := strconv.Atoi(trimmedVersionNumber)
-			if err != nil {
-				return "", "", errors.New("failed to parse trimmed latest version number: " + err.Error())
-			}
-			latestVersionNumber = currentVersionNumber + 1
-		}
-		tag = baseTag + "-" + releaseType + strconv.Itoa(latestVersionNumber)
-	}
-
-	if !semver.IsValid(tag) {
-		return "", "", errors.New("the tag is invalid: " + tag)
-	}
-
-	if dryRun {
-		fmt.Println("dry run, skipping creating tag")
-		return tag, sha, nil
-	}
-
-	_, _, err := ghClient.Git.CreateRef(ctx, owner, repo, github.CreateRef{Ref: "refs/tags/" + tag, SHA: sha})
-	if err != nil {
-		return "", "", err
-	}
-	return tag, sha, nil
 }
 
 func CheckRancherRCDeps(ctx context.Context, org, gitRef string) (*RancherRCDeps, error) {
@@ -551,6 +498,38 @@ func GenerateImagesSyncConfig(images []string, sourceRegistry, targetRegistry, o
 	}
 
 	return os.WriteFile(outputPath, b, 0o644)
+}
+
+// CreateTag is a wrapper for the repository.CreateTag function, it takes more information and automatically finds what are the
+// references it needs to create, such as the latest prerelease version (e.g: alpha1, alpha2) and what is the latest commit in
+// a branch to create the tag based on that.
+func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, baseTag, sha, branch, releaseType string, preRelease, dryRun bool) (string, string, error) {
+	if !semver.IsValid(baseTag) {
+		return "", "", errors.New("the base tag is invalid: " + baseTag)
+	}
+
+	if sha == "" {
+		latestCommit, err := repository.BranchLatestCommitSHA(ctx, ghClient, owner, repo, branch)
+		if err != nil {
+			return "", "", err
+		}
+		sha = latestCommit
+	}
+
+	tag := baseTag
+	if preRelease {
+		preReleaseTag, err := repository.LatestPreReleaseTag(ctx, ghClient, owner, repo, releaseType, baseTag)
+		if err != nil {
+			return "", "", err
+		}
+		tag = preReleaseTag
+	}
+
+	if dryRun {
+		fmt.Println("dry run, skipping creating tag")
+		return tag, sha, nil
+	}
+	return repository.CreateTag(ctx, ghClient, owner, repo, tag, sha)
 }
 
 func generateRegsyncConfig(images []string, sourceRegistry, targetRegistry string) (*regsyncConfig, error) {

--- a/release/release.go
+++ b/release/release.go
@@ -1,3 +1,4 @@
+// Package release provides general tools to verify, create and manage github releases
 package release
 
 import (
@@ -808,30 +809,6 @@ func LatestRC(ctx context.Context, owner, repo, k8sVersion, projectSuffix string
 	}
 
 	return latestFoundRC, nil
-}
-
-func LatestPreRelease(ctx context.Context, client *github.Client, owner, repo, version, preReleaseSuffix string) (*string, error) {
-	var latestFoundPreRelease *string
-	preReleaseNumber := 1
-
-	for {
-		tagName := fmt.Sprintf("%s-%s%d", version, preReleaseSuffix, preReleaseNumber)
-
-		ref := "tags/" + tagName
-
-		_, resp, err := client.Git.GetRef(ctx, owner, repo, ref)
-		if err != nil {
-			if resp != nil && resp.StatusCode == http.StatusNotFound {
-				break
-			}
-			return nil, err
-		}
-		found := tagName
-		latestFoundPreRelease = &found
-		preReleaseNumber++
-	}
-
-	return latestFoundPreRelease, nil
 }
 
 // StatsMonthly

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -6,18 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v90/github"
 	"github.com/rancher/ecm-distro-tools/exec"
 	"github.com/rancher/ecm-distro-tools/types"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -109,6 +112,72 @@ func LatestTag(ctx context.Context, client *github.Client, owner, repo string) (
 	}
 
 	return tags[0], nil
+}
+
+func LatestPreRelease(ctx context.Context, client *github.Client, owner, repo, version, preReleaseSuffix string) (*string, error) {
+	var latestFoundPreRelease *string
+	preReleaseNumber := 1
+
+	for {
+		tagName := fmt.Sprintf("%s-%s%d", version, preReleaseSuffix, preReleaseNumber)
+
+		ref := "tags/" + tagName
+
+		_, resp, err := client.Git.GetRef(ctx, owner, repo, ref)
+		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				break
+			}
+			return nil, err
+		}
+		found := tagName
+		latestFoundPreRelease = &found
+		preReleaseNumber++
+	}
+
+	return latestFoundPreRelease, nil
+}
+
+func LatestPreReleaseTag(ctx context.Context, ghClient *github.Client, owner, repo, releaseType, baseTag string) (string, error) {
+	latestVersionNumber := 1
+	latestVersion, err := LatestPreRelease(ctx, ghClient, owner, repo, baseTag, releaseType)
+	if err != nil {
+		return "", err
+	}
+
+	if latestVersion != nil {
+		trimmedVersionNumber := strings.TrimPrefix(*latestVersion, baseTag+"-"+releaseType)
+		currentVersionNumber, err := strconv.Atoi(trimmedVersionNumber)
+		if err != nil {
+			return "", errors.New("failed to parse trimmed latest version number: " + err.Error())
+		}
+		latestVersionNumber = currentVersionNumber + 1
+	}
+	tag := baseTag + "-" + releaseType + strconv.Itoa(latestVersionNumber)
+	return tag, nil
+}
+
+func BranchLatestCommitSHA(ctx context.Context, ghClient *github.Client, owner, repo, branch string) (string, error) {
+	commitSHA, err := RefCommitSHA(ctx, ghClient, owner, repo, "heads/"+branch)
+	if err != nil {
+		return "", err
+	}
+	return commitSHA, nil
+}
+
+// CreateTag creates a new tag ref on GitHub based on the provided commit SHA or the latest commit on the provided branch.
+// If the tag to be created is a pre-release (rc or alpha) it will automatically find the latest tag and add one to it. E.g: v2.14.0 (pre-release) -> v2.14.0-alpha2
+// Returns tag, commit sha, error
+func CreateTag(ctx context.Context, ghClient *github.Client, owner, repo, tag, sha string) (string, string, error) {
+	if !semver.IsValid(tag) {
+		return "", "", errors.New("the tag is invalid: " + tag)
+	}
+
+	_, _, err := ghClient.Git.CreateRef(ctx, owner, repo, github.CreateRef{Ref: "refs/tags/" + tag, SHA: sha})
+	if err != nil {
+		return "", "", err
+	}
+	return tag, sha, nil
 }
 
 func CreateRelease(ctx context.Context, client *github.Client, cro *CreateReleaseOpts) (*github.RepositoryRelease, error) {
@@ -581,7 +650,7 @@ func PushRemoteBranch(r *git.Repository, remote, user, token string, debug bool)
 
 	branchRef := h.Name().String()
 
-	auth := &http.BasicAuth{
+	auth := &githttp.BasicAuth{
 		Username: user,
 		Password: token,
 	}


### PR DESCRIPTION
- **move create tag and latest pre release to the repository package**
- **use the new createtag function and add an option to create the ui tag**

With immutable releases, we're now creating tags and not releases.
rancher/ui is not used for all versions anymore, so, it's only optionally also created using a flag, this is a breaking change.
