### PR TITLE
fix sha256sum files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,11 @@ package-binaries: $(BINARIES)
 			rm -f dist/ecm-distro-tools.$${SUFFIX}.tar; \
 		done; \
 	done
+
+	rm -f dist/sha256sum.txt
+	cd dist && \
+	for file in *; do \
+		case "$${file}" in sha256sum*.txt) continue;; esac; \
+		[ -f "$${file}" ] || continue; \
+		$(SHA256SUM) "$${file}" >> sha256sum.txt; \
+	done

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -5,7 +5,9 @@ GO_COMPILE = GOOS=$${os} GOARCH=$${arch} CGO_ENABLED=1 $(GO) build -tags $(TAGS)
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)
-GEN_HASH = shasum -a 256 $@-$${os}-$${arch} >> $(BINDIR)/sha256sums-$(BINARY).txt
+SHA256SUM = shasum -a 256
 else
-GEN_HASH = sha256sum $@-$${os}-$${arch} >> $(BINDIR)/sha256sums-$(BINARY).txt
+SHA256SUM = sha256sum
 endif
+
+GEN_HASH = (cd $(BINDIR) && $(SHA256SUM) $(notdir $@)-$${os}-$${arch} >> sha256sums-$(BINARY).txt)


### PR DESCRIPTION
* Fix the sha256sums-release.txt and sha256sums-backport.txt files by removing the `bin/` prefix
* Add a sha256sum.txt file with checksums for all files
