### PR TITLE
Update Go version retrieval logic

### DIFF
--- a/release/k3s/k3s.go
+++ b/release/k3s/k3s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -225,7 +224,7 @@ func rebaseAndTag(ctx context.Context, ghClient *github.Client, r *ecmConfig.K3s
 		return nil, err
 	}
 	fmt.Println(rebaseOut)
-	wrapperImageTag, err := buildGoWrapper(r)
+	wrapperImageTag, err := buildGoWrapper(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -325,35 +324,9 @@ func previousK3sReleaseTag(ctx context.Context, ghClient *github.Client, r *ecmC
 	return "", errors.New("no Git ref found with k8s version: " + r.OldK8sVersion)
 }
 
-func goVersion(r *ecmConfig.K3sRelease) (string, error) {
-	url := "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/" + r.NewK8sVersion + "/.go-version"
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch '.go-version', unexpected status code: %d %s (URL: %s)", resp.StatusCode, resp.Status, url)
-	}
-
-	dat, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	verStr := strings.TrimSpace(string(dat))
-	ver, err := semver.NewVersion(verStr)
-	if err != nil {
-		return "", errors.New("invalid '.go-version' content: " + verStr)
-	}
-
-	return ver.String(), nil
-}
-
-func buildGoWrapper(r *ecmConfig.K3sRelease) (string, error) {
+func buildGoWrapper(ctx context.Context, r *ecmConfig.K3sRelease) (string, error) {
 	fmt.Println("getting go version for k8s")
-	goVersion, err := goVersion(r)
+	goVersion, err := release.GoLatestPatchVersion(r.NewK8sVersion)
 	if err != nil {
 		return "", err
 	}
@@ -563,7 +536,7 @@ func PushTags(ghClient *github.Client, r *ecmConfig.K3sRelease, u *ecmConfig.Use
 }
 
 func UpdateK3sReferences(ctx context.Context, ghClient *github.Client, r *ecmConfig.K3sRelease, u *ecmConfig.User) error {
-	if err := updateK3sReferencesAndPush(r, u); err != nil {
+	if err := updateK3sReferencesAndPush(ctx, r, u); err != nil {
 		return err
 	}
 
@@ -575,14 +548,14 @@ func UpdateK3sReferences(ctx context.Context, ghClient *github.Client, r *ecmCon
 	return createK3sReferencesPR(ctx, ghClient, r, u)
 }
 
-func updateK3sReferencesAndPush(r *ecmConfig.K3sRelease, u *ecmConfig.User) error {
+func updateK3sReferencesAndPush(ctx context.Context, r *ecmConfig.K3sRelease, u *ecmConfig.User) error {
 	if err := release.SetWorkspace(r.Workspace); err != nil {
 		return err
 	}
 
 	fmt.Println("getting k8s go version")
 
-	goVersion, err := goVersion(r)
+	goVersion, err := release.GoLatestPatchVersion(r.NewK8sVersion)
 	if err != nil {
 		return err
 	}

--- a/release/release.go
+++ b/release/release.go
@@ -18,12 +18,13 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v90/github"
 	httpecm "github.com/rancher/ecm-distro-tools/http"
 	"github.com/rancher/ecm-distro-tools/repository"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/semver"
+	gosemver "golang.org/x/mod/semver"
 	"sigs.k8s.io/yaml"
 )
 
@@ -183,7 +184,7 @@ func (rd *k3sReleaseNoteData) Fill(milestone string) error {
 	var runcVersion string
 	var containerdVersion string
 
-	if semver.Compare(rd.K8sVersion, "v1.24.0") == 1 && semver.Compare(rd.K8sVersion, "v1.26.5") == -1 {
+	if gosemver.Compare(rd.K8sVersion, "v1.24.0") == 1 && gosemver.Compare(rd.K8sVersion, "v1.26.5") == -1 {
 		containerdVersion = buildScriptVersion("VERSION_CONTAINERD", k3sRepo, milestone)
 	} else {
 		containerdVersion = goModLibVersion(containerdV2ModLib, k3sRepo, milestone)
@@ -242,7 +243,7 @@ func (_ *cliReleaseNoteData) Template() string {
 func (_ *cliReleaseNoteData) Repo() string { return cliRepo }
 
 func majMin(v string) (string, error) {
-	majMin := semver.MajorMinor(v)
+	majMin := gosemver.MajorMinor(v)
 	if majMin == "" {
 		return "", errors.New("version is not valid")
 	}
@@ -453,6 +454,67 @@ func KubernetesGoVersion(ctx context.Context, client *github.Client, version str
 	}
 
 	return strings.Trim(goVersion, "\n"), nil
+}
+
+func GoLatestPatchVersion(k8sVersion string) (string, error) {
+	httpClient := httpecm.NewClient(time.Second * 30)
+	k8sGoVersionURL := "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/" + k8sVersion + "/.go-version"
+
+	req, err := http.NewRequest(http.MethodGet, k8sGoVersionURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch .go-version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch '.go-version', unexpected status code: %d %s (URL: %s)", resp.StatusCode, resp.Status, k8sGoVersionURL)
+	}
+
+	dat, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read .go-version content: %w", err)
+	}
+
+	verStr := strings.TrimSpace(string(dat))
+	ver, err := semver.NewVersion(verStr)
+	if err != nil {
+		return "", errors.New("invalid '.go-version' content: " + verStr)
+	}
+
+	currentVer := *ver
+	for {
+		nextVer := currentVer.IncPatch()
+
+		tagURL := "https://github.com/golang/go/releases/tag/go" + nextVer.String()
+
+		tagReq, err := http.NewRequest(http.MethodGet, tagURL, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to create tag check request: %w", err)
+		}
+
+		tagResp, err := httpClient.Do(tagReq)
+		if err != nil {
+			return "", fmt.Errorf("error getting tag %s: %w", nextVer.String(), err)
+		}
+
+		tagResp.Body.Close()
+
+		if tagResp.StatusCode == http.StatusNotFound {
+			// If tag is not found, return the last existing version
+			return currentVer.String(), nil
+		}
+
+		if tagResp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("unexpected status %d checking tag %s", tagResp.StatusCode, nextVer.String())
+		}
+
+		currentVer = nextVer
+	}
 }
 
 // VerifyAssets checks the number of assets for the

--- a/release/rke2/rke2.go
+++ b/release/rke2/rke2.go
@@ -141,7 +141,7 @@ func updateRKE2ReferencesAndPush(ctx context.Context, ghClient *github.Client, r
 	}
 
 	fmt.Println("getting k8s go version")
-	goVersion, err := release.KubernetesGoVersion(ctx, ghClient, r.NewK8sVersion)
+	goVersion, err := release.GoLatestPatchVersion(r.NewK8sVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add `GoLatestPatchVersion(...)` function that now retrieves the latest Go patch following K8s upstream's Go `major.minor` version.

This change will affect the behavior of these commands:
- > release update rke2 references
- > release update k3s references