### PR TITLE
Add conditional to check if PR is merged

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -492,6 +492,10 @@ func RetrieveChangeLogContents(ctx context.Context, client *github.Client, owner
 			return nil, err
 		}
 		for _, pr := range prs {
+			if pr.GetMergedAt().IsZero() {
+				// skip PRs that are not merged
+				continue
+			}
 			if exists := addedPRs[pr.GetNumber()]; exists {
 				continue
 			}


### PR DESCRIPTION
`ListPullRequestsWithCommit` returns all pull requests associated with a commit SHA, even if the PRs are open, in draft, etc. So adding the `GetMergedAt().IsZero()` condition check will skip any PR that hasn't been merged yet.