### PR TITLE
Bump slsactl to v0.1.37 in publish-image action

### DIFF
--- a/actions/publish-image/action.yaml
+++ b/actions/publish-image/action.yaml
@@ -226,9 +226,9 @@ runs:
   - name: Install Cosign
     uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
   - name: Install slsactl
-    uses: rancherlabs/slsactl/actions/install-slsactl@ddd4735b474ca57fac67c5a0a0d36d0a4624ac87 # v0.1.35
+    uses: rancherlabs/slsactl/actions/install-slsactl@22b4f4bf17657fc9275fb914c4179257f20c898a # v0.1.37
     with:
-      version: v0.1.35
+      version: v0.1.37
 
   - name: Build and push image [Prime]
     id: push-prime


### PR DESCRIPTION
Update the action and executable.

We have a [repo](https://github.com/harvester/harvester-mcp-server) that uses the push-image action and need newer slsactl to attest its provenance.
(Harvester image/repo mappings are added in https://github.com/rancherlabs/slsactl/pull/345)